### PR TITLE
更新 build_and_deploy

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -1,12 +1,12 @@
-# 构建最新的容器镜像 - 推送到 Docker Hub - 推送到阿里云仓库 - 服务器部署最新版本的镜像
+# 构建最新的容器镜像 - 推送到 Docker Hub - 推送到腾讯云仓库 - 服务器部署最新版本的镜像
 # 参数说明：
-#   - secrets.DOCKER_HUB_USERNAME         Docker Hub 用户名
-#   - secrets.DOCKER_HUB_PASSWORD         Docker Hub 密码
-#   - secrets.ALI_YUN_REGISTRY_USERNAME   阿里云仓库用户名
-#   - secrets.ALI_YUN_REGISTRY_PASSWORD   阿里云仓库用户名
-#   - secrets.SERVER_PRIVATE_KEY          登入服务器密钥
-#   - secrets.SERVER_HOST                 服务器地址
-#   - secrets.SERVER_USERNAME             服务器用户
+#   - secrets.DOCKER_HUB_USERNAME               Docker Hub 用户名
+#   - secrets.DOCKER_HUB_PASSWORD               Docker Hub 密码
+#   - secrets.TENCENT_CLOUD_REGISTRY_USERNAME   腾讯云仓库用户名
+#   - secrets.TENCENT_CLOUD_REGISTRY_PASSWORD   腾讯云仓库用户名
+#   - secrets.SERVER_PRIVATE_KEY                登入服务器密钥
+#   - secrets.SERVER_HOST                       服务器地址
+#   - secrets.SERVER_USERNAME                   服务器用户
 
 name: Build and deploy
 
@@ -17,8 +17,8 @@ on:
 
 env:
   DOCKER_HUB_REPOSITORY: studiomj/jump-jump
-  ALI_YUN_REGISTRY: registry.cn-hongkong.aliyuncs.com
-  ALI_YUN_REPOSITORY: registry.cn-hongkong.aliyuncs.com/anmuji/jump-jump
+  TENCENT_CLOUD_REGISTRY: hkccr.ccs.tencentyun.com
+  TENCENT_CLOUD_REPOSITORY: hkccr.ccs.tencentyun.com/anmuji/jump-jump
 
 jobs:
 
@@ -55,18 +55,18 @@ jobs:
       - name: Build docker image
         run: |
           docker build \
-            -t $ALI_YUN_REPOSITORY:latest \
-            -t $ALI_YUN_REPOSITORY:${{ steps.tag.outputs.tag }} \
+            -t $TENCENT_CLOUD_REPOSITORY:latest \
+            -t $TENCENT_CLOUD_REPOSITORY:${{ steps.tag.outputs.tag }} \
             -f build/package/Dockerfile .
 
-      - name: Push docker image to aliyun registry
+      - name: Push docker image to tencent cloud registry
         run: |
           docker login \
-            --username=${{ secrets.ALI_YUN_REGISTRY_USERNAME }} \
-            --password=${{ secrets.ALI_YUN_REGISTRY_PASSWORD }} \
-            $ALI_YUN_REGISTRY
-          docker push $ALI_YUN_REPOSITORY:latest
-          docker push $ALI_YUN_REPOSITORY:${{ steps.tag.outputs.tag }}
+            --username=${{ secrets.TENCENT_CLOUD_REGISTRY_USERNAME }} \
+            --password=${{ secrets.TENCENT_CLOUD_REGISTRY_PASSWORD }} \
+            $TENCENT_CLOUD_REGISTRY
+          docker push $TENCENT_CLOUD_REPOSITORY:latest
+          docker push $TENCENT_CLOUD_REPOSITORY:${{ steps.tag.outputs.tag }}
           docker logout
 
       - uses: webfactory/ssh-agent@v0.5.3

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -35,7 +35,7 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_PASSWORD }}
-          repository: ${{ DOCKER_HUB_REPOSITORY }}
+          repository: ${{ env.DOCKER_HUB_REPOSITORY }}
           tags: latest
           tag_with_ref: true
           dockerfile: ./build/package/Dockerfile


### PR DESCRIPTION
使用腾讯云仓库替换阿里云仓库，由于当前服务器使用的是腾讯云的，在服务器下载镜像时，使用腾讯云仓库的速度比阿里云的快许多。