### PR TITLE
fix: center logo icon when sidebar is collapsed

### DIFF
--- a/web-ui/src/components/AppSidebar.vue
+++ b/web-ui/src/components/AppSidebar.vue
@@ -74,7 +74,9 @@ async function handleLogout() {
     <div
       :class="[
         'flex h-14 items-center border-b',
-        layout.sidebarCollapsed ? 'justify-center' : 'justify-between px-3',
+        layout.sidebarCollapsed
+          ? 'justify-between px-3 lg:justify-center lg:px-0'
+          : 'justify-between px-3',
       ]"
     >
       <router-link
@@ -115,7 +117,9 @@ async function handleLogout() {
     <!-- Expand toggle (only when collapsed, desktop) -->
     <button
       v-if="layout.sidebarCollapsed"
-      class="absolute -right-3 top-4 hidden h-6 w-6 items-center justify-center rounded-full border border-gray-200 bg-white shadow-sm text-gray-400 hover:text-gray-600 lg:flex"
+      class="absolute -right-3 top-4 z-10 hidden h-6 w-6 items-center justify-center rounded-full border border-gray-200 bg-white shadow-sm text-gray-400 hover:text-gray-600 lg:flex"
+      aria-label="Expand sidebar"
+      title="Expand sidebar"
       @click="layout.toggleSidebar"
     >
       <ChevronLeft class="h-3 w-3 rotate-180" />

--- a/web-ui/src/components/AppSidebar.vue
+++ b/web-ui/src/components/AppSidebar.vue
@@ -71,7 +71,12 @@ async function handleLogout() {
     ]"
   >
     <!-- Header -->
-    <div class="flex h-14 items-center justify-between border-b px-3">
+    <div
+      :class="[
+        'flex h-14 items-center border-b',
+        layout.sidebarCollapsed ? 'justify-center' : 'justify-between px-3',
+      ]"
+    >
       <router-link
         to="/"
         class="flex items-center gap-2 overflow-hidden"
@@ -97,16 +102,24 @@ async function handleLogout() {
       >
         <X class="h-5 w-5" />
       </button>
-      <!-- Desktop collapse -->
+      <!-- Desktop collapse (only when expanded) -->
       <button
+        v-show="!layout.sidebarCollapsed"
         class="hidden rounded p-1 text-gray-400 hover:text-gray-600 lg:block"
         @click="layout.toggleSidebar"
       >
-        <ChevronLeft
-          :class="['h-4 w-4 transition-transform', layout.sidebarCollapsed && 'rotate-180']"
-        />
+        <ChevronLeft class="h-4 w-4 transition-transform" />
       </button>
     </div>
+
+    <!-- Expand toggle (only when collapsed, desktop) -->
+    <button
+      v-if="layout.sidebarCollapsed"
+      class="absolute -right-3 top-4 hidden h-6 w-6 items-center justify-center rounded-full border border-gray-200 bg-white shadow-sm text-gray-400 hover:text-gray-600 lg:flex"
+      @click="layout.toggleSidebar"
+    >
+      <ChevronLeft class="h-3 w-3 rotate-180" />
+    </button>
 
     <!-- Navigation -->
     <nav class="flex-1 overflow-y-auto px-2 py-3">


### PR DESCRIPTION
## Summary
- Fixed the sidebar header layout so the "JJ" logo icon displays correctly when the sidebar is collapsed
- When collapsed (`w-16`/64px), the header now centers the logo icon instead of trying to fit both the icon and toggle button side-by-side (which caused the icon to be clipped)
- Added a small floating expand button on the sidebar edge (desktop only) so users can re-expand the sidebar

## Test plan
- [ ] Collapse the sidebar on desktop — JJ icon should be fully visible and centered
- [ ] Expand the sidebar — "Jump Jump" text and collapse chevron should display normally
- [ ] Click the floating expand button (right edge of collapsed sidebar) to re-expand
- [ ] Verify mobile sidebar still works (hamburger menu, close button)

🤖 Generated with [Claude Code](https://claude.com/claude-code)