### PR TITLE
fix(web-ui): 为所有交互元素添加 cursor: pointer 样式

### DIFF
--- a/web-ui/src/pages/ShortLinkCreatePage.vue
+++ b/web-ui/src/pages/ShortLinkCreatePage.vue
@@ -118,7 +118,7 @@ async function handleSubmit() {
             type="button"
             role="switch"
             :aria-checked="isEnable"
-            class="relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors"
+            class="relative inline-flex h-6 w-11 shrink-0 rounded-full border-2 border-transparent transition-colors"
             :class="isEnable ? 'bg-blue-600' : 'bg-gray-200'"
             @click="isEnable = !isEnable"
           >

--- a/web-ui/src/pages/ShortLinkEditPage.vue
+++ b/web-ui/src/pages/ShortLinkEditPage.vue
@@ -167,7 +167,7 @@ onMounted(fetchData)
             type="button"
             role="switch"
             :aria-checked="isEnable"
-            class="relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors"
+            class="relative inline-flex h-6 w-11 shrink-0 rounded-full border-2 border-transparent transition-colors"
             :class="isEnable ? 'bg-blue-600' : 'bg-gray-200'"
             @click="isEnable = !isEnable"
           >

--- a/web-ui/src/style.css
+++ b/web-ui/src/style.css
@@ -16,6 +16,8 @@ button:disabled,
 [type="reset"]:disabled,
 [type="submit"]:disabled,
 [role="button"]:disabled,
+[type="checkbox"]:disabled,
+[type="radio"]:disabled,
 select:disabled {
   cursor: not-allowed;
 }

--- a/web-ui/src/style.css
+++ b/web-ui/src/style.css
@@ -1,1 +1,21 @@
 @import 'tailwindcss';
+
+button,
+[type="button"],
+[type="reset"],
+[type="submit"],
+[role="button"],
+[type="checkbox"],
+[type="radio"],
+select {
+  cursor: pointer;
+}
+
+button:disabled,
+[type="button"]:disabled,
+[type="reset"]:disabled,
+[type="submit"]:disabled,
+[role="button"]:disabled,
+select:disabled {
+  cursor: not-allowed;
+}


### PR DESCRIPTION
## Summary

- 在 `style.css` 中添加全局 CSS 规则，为所有按钮、复选框、单选框、下拉选择框等交互元素设置 `cursor: pointer`
- 禁用状态的元素（包括 checkbox/radio）使用 `cursor: not-allowed`
- 清理了 `ShortLinkCreatePage.vue` 和 `ShortLinkEditPage.vue` 中 toggle 开关上多余的 `cursor-pointer` class（现在由全局规则覆盖）

## Test plan

- [ ] 验证所有页面中的按钮 hover 时显示 pointer 光标
- [ ] 验证复选框 hover 时显示 pointer 光标
- [ ] 验证下拉选择框 hover 时显示 pointer 光标
- [ ] 验证禁用状态的按钮显示 not-allowed 光标
- [ ] 验证 toggle 开关行为不变