### PR TITLE
feat: tenant member management APIs (JWM-51)

### DIFF
--- a/internal/app/handlers/tenant.go
+++ b/internal/app/handlers/tenant.go
@@ -22,11 +22,6 @@ import (
 // @Router /tenant/ [post]
 func CreateTenantAPI() gin.HandlerFunc {
 	return Authenticator(func(c *gin.Context, ctx *AuthContext) {
-		if !ctx.User.IsSuper && ctx.Member.Role != models.RoleAdmin {
-			c.JSON(http.StatusOK, models.NewErrorResponse("你无权创建租户"))
-			return
-		}
-
 		p := &models.CreateTenantRequest{}
 		if err := c.ShouldBindJSON(p); err != nil {
 			c.JSON(http.StatusOK, models.NewErrorResponse("参数错误"))
@@ -39,6 +34,13 @@ func CreateTenantAPI() gin.HandlerFunc {
 			c.JSON(http.StatusOK, models.NewErrorResponse(err.Error()))
 			return
 		}
+
+		memberRepo := repository.GetTenantMemberRepo(db.GetPostgresPool())
+		memberRepo.Save(&models.TenantMember{
+			TenantID: t.ID,
+			UserID:   ctx.User.ID,
+			Role:     models.RoleAdmin,
+		})
 
 		c.JSON(http.StatusOK, models.NewSuccessResponse(t))
 	})

--- a/internal/app/handlers/tenant.go
+++ b/internal/app/handlers/tenant.go
@@ -11,7 +11,7 @@ import (
 
 // CreateTenantAPI godoc
 // @Summary 创建租户
-// @Description 创建租户（仅管理员）
+// @Description 创建租户（已登录用户均可创建，创建者自动成为管理员）
 // @Tags 租户
 // @Accept json
 // @Produce json
@@ -36,11 +36,14 @@ func CreateTenantAPI() gin.HandlerFunc {
 		}
 
 		memberRepo := repository.GetTenantMemberRepo(db.GetPostgresPool())
-		memberRepo.Save(&models.TenantMember{
+		if err := memberRepo.Save(&models.TenantMember{
 			TenantID: t.ID,
 			UserID:   ctx.User.ID,
 			Role:     models.RoleAdmin,
-		})
+		}); err != nil {
+			c.JSON(http.StatusOK, models.NewErrorResponse("创建租户成员关系失败"))
+			return
+		}
 
 		c.JSON(http.StatusOK, models.NewSuccessResponse(t))
 	})

--- a/internal/app/handlers/tenant_member.go
+++ b/internal/app/handlers/tenant_member.go
@@ -112,7 +112,8 @@ func InviteUserAPI() gin.HandlerFunc {
 		}
 
 		memberRepo := repository.GetTenantMemberRepo(db.GetPostgresPool())
-		if memberRepo.IsMember(tenantID, invitee.ID) {
+		isMember, _ := memberRepo.IsMember(tenantID, invitee.ID)
+		if isMember {
 			c.JSON(http.StatusOK, models.NewErrorResponse("该用户已是租户成员"))
 			return
 		}
@@ -123,7 +124,8 @@ func InviteUserAPI() gin.HandlerFunc {
 		}
 
 		invRepo := repository.GetTenantInvitationRepo(db.GetPostgresPool())
-		if invRepo.HasPendingInvitation(tenantID, invitee.ID) {
+		hasPending, _ := invRepo.HasPendingInvitation(tenantID, invitee.ID)
+		if hasPending {
 			c.JSON(http.StatusOK, models.NewErrorResponse("该用户已有待处理的邀请"))
 			return
 		}
@@ -219,11 +221,6 @@ func AcceptInvitationAPI() gin.HandlerFunc {
 			return
 		}
 
-		if err := invRepo.UpdateStatus(inv.ID, models.InvitationStatusAccepted); err != nil {
-			c.JSON(http.StatusOK, models.NewErrorResponse("操作失败"))
-			return
-		}
-
 		memberRepo := repository.GetTenantMemberRepo(db.GetPostgresPool())
 		if err := memberRepo.Save(&models.TenantMember{
 			TenantID: inv.TenantID,
@@ -231,6 +228,11 @@ func AcceptInvitationAPI() gin.HandlerFunc {
 			Role:     models.RoleMember,
 		}); err != nil {
 			c.JSON(http.StatusOK, models.NewErrorResponse("加入租户失败"))
+			return
+		}
+
+		if err := invRepo.UpdateStatus(inv.ID, models.InvitationStatusAccepted); err != nil {
+			c.JSON(http.StatusOK, models.NewErrorResponse("操作失败"))
 			return
 		}
 
@@ -320,7 +322,8 @@ func UpdateMemberRoleAPI() gin.HandlerFunc {
 		}
 
 		memberRepo := repository.GetTenantMemberRepo(db.GetPostgresPool())
-		if !memberRepo.IsMember(tenantID, targetUserID) {
+		isMember, _ := memberRepo.IsMember(tenantID, targetUserID)
+		if !isMember {
 			c.JSON(http.StatusOK, models.NewErrorResponse("该用户不是租户成员"))
 			return
 		}
@@ -363,7 +366,8 @@ func RemoveMemberAPI() gin.HandlerFunc {
 		}
 
 		memberRepo := repository.GetTenantMemberRepo(db.GetPostgresPool())
-		if !memberRepo.IsMember(tenantID, targetUserID) {
+		isMember, _ := memberRepo.IsMember(tenantID, targetUserID)
+		if !isMember {
 			c.JSON(http.StatusOK, models.NewErrorResponse("该用户不是租户成员"))
 			return
 		}

--- a/internal/app/handlers/tenant_member.go
+++ b/internal/app/handlers/tenant_member.go
@@ -1,0 +1,408 @@
+package handlers
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/jwma/jump-jump/internal/app/db"
+	"github.com/jwma/jump-jump/internal/app/models"
+	"github.com/jwma/jump-jump/internal/app/repository"
+)
+
+// helper: check if the current user is admin of the given tenant (or is super admin).
+func isTenantAdmin(user *models.User, tenantID string) (*models.TenantMember, error) {
+	if user.IsSuper {
+		return &models.TenantMember{TenantID: tenantID, UserID: user.ID, Role: models.RoleAdmin}, nil
+	}
+	memberRepo := repository.GetTenantMemberRepo(db.GetPostgresPool())
+	return memberRepo.Get(tenantID, user.ID)
+}
+
+// helper: resolve member for a tenant; returns nil (not a member) rather than error for non-members.
+func getMemberOrNil(user *models.User, tenantID string) *models.TenantMember {
+	if user.IsSuper {
+		return &models.TenantMember{TenantID: tenantID, UserID: user.ID, Role: models.RoleAdmin}
+	}
+	memberRepo := repository.GetTenantMemberRepo(db.GetPostgresPool())
+	m, err := memberRepo.Get(tenantID, user.ID)
+	if err != nil {
+		return nil
+	}
+	return m
+}
+
+// ListTenantMembersAPI godoc
+// @Summary 租户成员列表
+// @Description 查看租户成员列表（租户内所有成员均可查看）
+// @Tags 租户成员
+// @Accept json
+// @Produce json
+// @Security ApiKeyAuth
+// @Param id path string true "租户 ID"
+// @Success 200 {object} models.Response{data=[]models.TenantMemberData}
+// @Failure 401 {object} nil
+// @Router /tenant/{id}/members [get]
+func ListTenantMembersAPI() gin.HandlerFunc {
+	return Authenticator(func(c *gin.Context, ctx *AuthContext) {
+		tenantID := c.Param("id")
+		member := getMemberOrNil(ctx.User, tenantID)
+		if member == nil {
+			c.JSON(http.StatusOK, models.NewErrorResponse("你不是该租户的成员"))
+			return
+		}
+
+		memberRepo := repository.GetTenantMemberRepo(db.GetPostgresPool())
+		members, err := memberRepo.ListByTenant(tenantID)
+		if err != nil {
+			c.JSON(http.StatusOK, models.NewErrorResponse("查询成员列表失败"))
+			return
+		}
+
+		userRepo := repository.GetUserRepo(db.GetPostgresPool())
+		result := make([]*models.TenantMemberData, 0, len(members))
+		for _, m := range members {
+			u, err := userRepo.FindByID(m.UserID)
+			if err != nil {
+				continue
+			}
+			result = append(result, &models.TenantMemberData{
+				UserID:   m.UserID,
+				Username: u.Username,
+				Role:     m.Role,
+				JoinedAt: m.JoinedAt,
+			})
+		}
+
+		c.JSON(http.StatusOK, models.NewSuccessResponse(result))
+	})
+}
+
+// InviteUserAPI godoc
+// @Summary 邀请用户加入租户
+// @Description 邀请用户加入租户（仅 admin）
+// @Tags 租户成员
+// @Accept json
+// @Produce json
+// @Security ApiKeyAuth
+// @Param id path string true "租户 ID"
+// @Param body body models.InviteUserRequest true "邀请请求"
+// @Success 200 {object} models.Response{data=models.TenantInvitation}
+// @Failure 401 {object} nil
+// @Router /tenant/{id}/invitations [post]
+func InviteUserAPI() gin.HandlerFunc {
+	return Authenticator(func(c *gin.Context, ctx *AuthContext) {
+		tenantID := c.Param("id")
+		member, err := isTenantAdmin(ctx.User, tenantID)
+		if err != nil || !member.IsAdmin() {
+			c.JSON(http.StatusOK, models.NewErrorResponse("仅租户管理员可邀请用户"))
+			return
+		}
+
+		req := &models.InviteUserRequest{}
+		if err := c.ShouldBindJSON(req); err != nil {
+			c.JSON(http.StatusOK, models.NewErrorResponse("参数错误"))
+			return
+		}
+
+		userRepo := repository.GetUserRepo(db.GetPostgresPool())
+		invitee, err := userRepo.FindByUsername(req.Username)
+		if err != nil {
+			c.JSON(http.StatusOK, models.NewErrorResponse("用户不存在"))
+			return
+		}
+
+		memberRepo := repository.GetTenantMemberRepo(db.GetPostgresPool())
+		if memberRepo.IsMember(tenantID, invitee.ID) {
+			c.JSON(http.StatusOK, models.NewErrorResponse("该用户已是租户成员"))
+			return
+		}
+
+		if invitee.ID == ctx.User.ID {
+			c.JSON(http.StatusOK, models.NewErrorResponse("不能邀请自己"))
+			return
+		}
+
+		invRepo := repository.GetTenantInvitationRepo(db.GetPostgresPool())
+		if invRepo.HasPendingInvitation(tenantID, invitee.ID) {
+			c.JSON(http.StatusOK, models.NewErrorResponse("该用户已有待处理的邀请"))
+			return
+		}
+
+		inv := &models.TenantInvitation{
+			TenantID:  tenantID,
+			InviterID: ctx.User.ID,
+			InviteeID: invitee.ID,
+		}
+		if err := invRepo.Create(inv); err != nil {
+			c.JSON(http.StatusOK, models.NewErrorResponse("创建邀请失败: "+err.Error()))
+			return
+		}
+
+		c.JSON(http.StatusOK, models.NewSuccessResponse(inv))
+	})
+}
+
+// ListMyInvitationsAPI godoc
+// @Summary 查看我的邀请
+// @Description 查看当前用户收到的所有待处理邀请
+// @Tags 邀请
+// @Accept json
+// @Produce json
+// @Security ApiKeyAuth
+// @Success 200 {object} models.Response{data=[]models.InvitationData}
+// @Failure 401 {object} nil
+// @Router /invitations [get]
+func ListMyInvitationsAPI() gin.HandlerFunc {
+	return Authenticator(func(c *gin.Context, ctx *AuthContext) {
+		invRepo := repository.GetTenantInvitationRepo(db.GetPostgresPool())
+		invs, err := invRepo.FindPendingByInvitee(ctx.User.ID)
+		if err != nil {
+			c.JSON(http.StatusOK, models.NewErrorResponse("查询邀请列表失败"))
+			return
+		}
+
+		userRepo := repository.GetUserRepo(db.GetPostgresPool())
+		tenantRepo := repository.GetTenantRepo(db.GetPostgresPool())
+		result := make([]*models.InvitationData, 0, len(invs))
+		for _, inv := range invs {
+			t, err := tenantRepo.GetByID(inv.TenantID)
+			if err != nil {
+				continue
+			}
+			inviter, err := userRepo.FindByID(inv.InviterID)
+			if err != nil {
+				continue
+			}
+			result = append(result, &models.InvitationData{
+				ID:              inv.ID,
+				TenantID:        inv.TenantID,
+				TenantName:      t.Name,
+				InviterUsername: inviter.Username,
+				Status:          inv.Status,
+				CreatedAt:       inv.CreatedAt,
+			})
+		}
+
+		c.JSON(http.StatusOK, models.NewSuccessResponse(result))
+	})
+}
+
+// AcceptInvitationAPI godoc
+// @Summary 接受邀请
+// @Description 接受租户邀请
+// @Tags 邀请
+// @Accept json
+// @Produce json
+// @Security ApiKeyAuth
+// @Param id path string true "邀请 ID"
+// @Success 200 {object} models.Response
+// @Failure 401 {object} nil
+// @Router /invitations/{id}/accept [post]
+func AcceptInvitationAPI() gin.HandlerFunc {
+	return Authenticator(func(c *gin.Context, ctx *AuthContext) {
+		invID := c.Param("id")
+		invRepo := repository.GetTenantInvitationRepo(db.GetPostgresPool())
+
+		inv, err := invRepo.Get(invID)
+		if err != nil {
+			c.JSON(http.StatusOK, models.NewErrorResponse("邀请不存在"))
+			return
+		}
+
+		if inv.InviteeID != ctx.User.ID {
+			c.JSON(http.StatusOK, models.NewErrorResponse("无权操作此邀请"))
+			return
+		}
+
+		if inv.Status != models.InvitationStatusPending {
+			c.JSON(http.StatusOK, models.NewErrorResponse("邀请已处理"))
+			return
+		}
+
+		if err := invRepo.UpdateStatus(inv.ID, models.InvitationStatusAccepted); err != nil {
+			c.JSON(http.StatusOK, models.NewErrorResponse("操作失败"))
+			return
+		}
+
+		memberRepo := repository.GetTenantMemberRepo(db.GetPostgresPool())
+		if err := memberRepo.Save(&models.TenantMember{
+			TenantID: inv.TenantID,
+			UserID:   ctx.User.ID,
+			Role:     models.RoleMember,
+		}); err != nil {
+			c.JSON(http.StatusOK, models.NewErrorResponse("加入租户失败"))
+			return
+		}
+
+		c.JSON(http.StatusOK, models.NewSuccessResponse(nil))
+	})
+}
+
+// RejectInvitationAPI godoc
+// @Summary 拒绝邀请
+// @Description 拒绝租户邀请
+// @Tags 邀请
+// @Accept json
+// @Produce json
+// @Security ApiKeyAuth
+// @Param id path string true "邀请 ID"
+// @Success 200 {object} models.Response
+// @Failure 401 {object} nil
+// @Router /invitations/{id}/reject [post]
+func RejectInvitationAPI() gin.HandlerFunc {
+	return Authenticator(func(c *gin.Context, ctx *AuthContext) {
+		invID := c.Param("id")
+		invRepo := repository.GetTenantInvitationRepo(db.GetPostgresPool())
+
+		inv, err := invRepo.Get(invID)
+		if err != nil {
+			c.JSON(http.StatusOK, models.NewErrorResponse("邀请不存在"))
+			return
+		}
+
+		if inv.InviteeID != ctx.User.ID {
+			c.JSON(http.StatusOK, models.NewErrorResponse("无权操作此邀请"))
+			return
+		}
+
+		if inv.Status != models.InvitationStatusPending {
+			c.JSON(http.StatusOK, models.NewErrorResponse("邀请已处理"))
+			return
+		}
+
+		if err := invRepo.UpdateStatus(inv.ID, models.InvitationStatusRejected); err != nil {
+			c.JSON(http.StatusOK, models.NewErrorResponse("操作失败"))
+			return
+		}
+
+		c.JSON(http.StatusOK, models.NewSuccessResponse(nil))
+	})
+}
+
+// UpdateMemberRoleAPI godoc
+// @Summary 修改成员角色
+// @Description 修改租户成员角色（仅 admin，不能修改自己的角色）
+// @Tags 租户成员
+// @Accept json
+// @Produce json
+// @Security ApiKeyAuth
+// @Param id path string true "租户 ID"
+// @Param userId path string true "用户 ID"
+// @Param body body models.UpdateRoleRequest true "角色修改请求"
+// @Success 200 {object} models.Response
+// @Failure 401 {object} nil
+// @Router /tenant/{id}/members/{userId}/role [patch]
+func UpdateMemberRoleAPI() gin.HandlerFunc {
+	return Authenticator(func(c *gin.Context, ctx *AuthContext) {
+		tenantID := c.Param("id")
+		targetUserID := c.Param("userId")
+
+		member, err := isTenantAdmin(ctx.User, tenantID)
+		if err != nil || !member.IsAdmin() {
+			c.JSON(http.StatusOK, models.NewErrorResponse("仅租户管理员可修改角色"))
+			return
+		}
+
+		if targetUserID == ctx.User.ID {
+			c.JSON(http.StatusOK, models.NewErrorResponse("不能修改自己的角色"))
+			return
+		}
+
+		req := &models.UpdateRoleRequest{}
+		if err := c.ShouldBindJSON(req); err != nil {
+			c.JSON(http.StatusOK, models.NewErrorResponse("参数错误"))
+			return
+		}
+
+		if req.Role != models.RoleAdmin && req.Role != models.RoleMember {
+			c.JSON(http.StatusOK, models.NewErrorResponse("角色必须为 admin 或 member"))
+			return
+		}
+
+		memberRepo := repository.GetTenantMemberRepo(db.GetPostgresPool())
+		if !memberRepo.IsMember(tenantID, targetUserID) {
+			c.JSON(http.StatusOK, models.NewErrorResponse("该用户不是租户成员"))
+			return
+		}
+
+		if err := memberRepo.UpdateRole(tenantID, targetUserID, req.Role); err != nil {
+			c.JSON(http.StatusOK, models.NewErrorResponse("修改角色失败"))
+			return
+		}
+
+		c.JSON(http.StatusOK, models.NewSuccessResponse(nil))
+	})
+}
+
+// RemoveMemberAPI godoc
+// @Summary 移除成员
+// @Description 移除租户成员（仅 admin，不能移除自己）
+// @Tags 租户成员
+// @Accept json
+// @Produce json
+// @Security ApiKeyAuth
+// @Param id path string true "租户 ID"
+// @Param userId path string true "用户 ID"
+// @Success 200 {object} models.Response
+// @Failure 401 {object} nil
+// @Router /tenant/{id}/members/{userId} [delete]
+func RemoveMemberAPI() gin.HandlerFunc {
+	return Authenticator(func(c *gin.Context, ctx *AuthContext) {
+		tenantID := c.Param("id")
+		targetUserID := c.Param("userId")
+
+		member, err := isTenantAdmin(ctx.User, tenantID)
+		if err != nil || !member.IsAdmin() {
+			c.JSON(http.StatusOK, models.NewErrorResponse("仅租户管理员可移除成员"))
+			return
+		}
+
+		if targetUserID == ctx.User.ID {
+			c.JSON(http.StatusOK, models.NewErrorResponse("不能移除自己，如需离开请使用退出租户功能"))
+			return
+		}
+
+		memberRepo := repository.GetTenantMemberRepo(db.GetPostgresPool())
+		if !memberRepo.IsMember(tenantID, targetUserID) {
+			c.JSON(http.StatusOK, models.NewErrorResponse("该用户不是租户成员"))
+			return
+		}
+
+		if err := memberRepo.Delete(tenantID, targetUserID); err != nil {
+			c.JSON(http.StatusOK, models.NewErrorResponse("移除成员失败"))
+			return
+		}
+
+		c.JSON(http.StatusOK, models.NewSuccessResponse(nil))
+	})
+}
+
+// LeaveTenantAPI godoc
+// @Summary 退出租户
+// @Description 退出租户（任何成员均可操作）
+// @Tags 租户成员
+// @Accept json
+// @Produce json
+// @Security ApiKeyAuth
+// @Param id path string true "租户 ID"
+// @Success 200 {object} models.Response
+// @Failure 401 {object} nil
+// @Router /tenant/{id}/leave [post]
+func LeaveTenantAPI() gin.HandlerFunc {
+	return Authenticator(func(c *gin.Context, ctx *AuthContext) {
+		tenantID := c.Param("id")
+		member := getMemberOrNil(ctx.User, tenantID)
+		if member == nil {
+			c.JSON(http.StatusOK, models.NewErrorResponse("你不是该租户的成员"))
+			return
+		}
+
+		memberRepo := repository.GetTenantMemberRepo(db.GetPostgresPool())
+		if err := memberRepo.Delete(tenantID, ctx.User.ID); err != nil {
+			c.JSON(http.StatusOK, models.NewErrorResponse("退出租户失败"))
+			return
+		}
+
+		c.JSON(http.StatusOK, models.NewSuccessResponse(nil))
+	})
+}

--- a/internal/app/models/models.go
+++ b/internal/app/models/models.go
@@ -57,6 +57,30 @@ type AddDomainRequest struct {
 	IsDefault bool   `json:"isDefault"`
 }
 
+type InviteUserRequest struct {
+	Username string `json:"username" binding:"required"`
+}
+
+type UpdateRoleRequest struct {
+	Role string `json:"role" binding:"required"`
+}
+
+type TenantMemberData struct {
+	UserID    string `json:"userId"`
+	Username  string `json:"username"`
+	Role      string `json:"role"`
+	JoinedAt  time.Time `json:"joinedAt"`
+}
+
+type InvitationData struct {
+	ID              string    `json:"id"`
+	TenantID        string    `json:"tenantId"`
+	TenantName      string    `json:"tenantName"`
+	InviterUsername string    `json:"inviterUsername"`
+	Status          string    `json:"status"`
+	CreatedAt       time.Time `json:"createdAt"`
+}
+
 // --- Auth ---
 
 type LoginAPIRequest struct {

--- a/internal/app/repository/repository.go
+++ b/internal/app/repository/repository.go
@@ -409,18 +409,26 @@ func (r *TenantMemberRepository) ListByTenant(tenantID string) ([]*models.Tenant
 }
 
 func (r *TenantMemberRepository) UpdateRole(tenantID, userID, role string) error {
-	_, err := r.db.Exec(context.Background(),
+	ct, err := r.db.Exec(context.Background(),
 		`UPDATE tenant_members SET role = $1 WHERE tenant_id = $2 AND user_id = $3`,
 		role, tenantID, userID)
-	return err
+	if err != nil {
+		return err
+	}
+	if ct.RowsAffected() == 0 {
+		return fmt.Errorf("成员不存在")
+	}
+	return nil
 }
 
-func (r *TenantMemberRepository) IsMember(tenantID, userID string) bool {
+func (r *TenantMemberRepository) IsMember(tenantID, userID string) (bool, error) {
 	var exists bool
-	r.db.QueryRow(context.Background(),
+	if err := r.db.QueryRow(context.Background(),
 		`SELECT EXISTS(SELECT 1 FROM tenant_members WHERE tenant_id = $1 AND user_id = $2)`,
-		tenantID, userID).Scan(&exists)
-	return exists
+		tenantID, userID).Scan(&exists); err != nil {
+		return false, err
+	}
+	return exists, nil
 }
 
 func (r *TenantMemberRepository) ListByUser(userID string) ([]*models.TenantMember, error) {
@@ -539,18 +547,25 @@ func (r *TenantInvitationRepository) FindPendingByInvitee(inviteeID string) ([]*
 	result := make([]*models.TenantInvitation, 0)
 	for rows.Next() {
 		inv := &models.TenantInvitation{}
-		rows.Scan(&inv.ID, &inv.TenantID, &inv.InviterID, &inv.InviteeID, &inv.Status, &inv.CreatedAt)
+		if err := rows.Scan(&inv.ID, &inv.TenantID, &inv.InviterID, &inv.InviteeID, &inv.Status, &inv.CreatedAt); err != nil {
+			return nil, err
+		}
 		result = append(result, inv)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
 	}
 	return result, nil
 }
 
-func (r *TenantInvitationRepository) HasPendingInvitation(tenantID, inviteeID string) bool {
+func (r *TenantInvitationRepository) HasPendingInvitation(tenantID, inviteeID string) (bool, error) {
 	var exists bool
-	r.db.QueryRow(context.Background(),
+	if err := r.db.QueryRow(context.Background(),
 		`SELECT EXISTS(SELECT 1 FROM tenant_invitations WHERE tenant_id = $1 AND invitee_id = $2 AND status = $3)`,
-		tenantID, inviteeID, models.InvitationStatusPending).Scan(&exists)
-	return exists
+		tenantID, inviteeID, models.InvitationStatusPending).Scan(&exists); err != nil {
+		return false, err
+	}
+	return exists, nil
 }
 // --- Short Link Repository (PG + Redis cache, tenant-scoped) ---
 

--- a/internal/app/repository/repository.go
+++ b/internal/app/repository/repository.go
@@ -408,6 +408,21 @@ func (r *TenantMemberRepository) ListByTenant(tenantID string) ([]*models.Tenant
 	return result, nil
 }
 
+func (r *TenantMemberRepository) UpdateRole(tenantID, userID, role string) error {
+	_, err := r.db.Exec(context.Background(),
+		`UPDATE tenant_members SET role = $1 WHERE tenant_id = $2 AND user_id = $3`,
+		role, tenantID, userID)
+	return err
+}
+
+func (r *TenantMemberRepository) IsMember(tenantID, userID string) bool {
+	var exists bool
+	r.db.QueryRow(context.Background(),
+		`SELECT EXISTS(SELECT 1 FROM tenant_members WHERE tenant_id = $1 AND user_id = $2)`,
+		tenantID, userID).Scan(&exists)
+	return exists
+}
+
 func (r *TenantMemberRepository) ListByUser(userID string) ([]*models.TenantMember, error) {
 	rows, err := r.db.Query(context.Background(),
 		`SELECT tenant_id, user_id, role, joined_at
@@ -510,6 +525,33 @@ func (r *TenantInvitationRepository) ListByInvitee(inviteeID string) ([]*models.
 	return result, nil
 }
 
+
+func (r *TenantInvitationRepository) FindPendingByInvitee(inviteeID string) ([]*models.TenantInvitation, error) {
+	rows, err := r.db.Query(context.Background(),
+		`SELECT id, tenant_id, inviter_id, invitee_id, status, created_at
+		 FROM tenant_invitations WHERE invitee_id = $1 AND status = $2 ORDER BY created_at DESC`,
+		inviteeID, models.InvitationStatusPending)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	result := make([]*models.TenantInvitation, 0)
+	for rows.Next() {
+		inv := &models.TenantInvitation{}
+		rows.Scan(&inv.ID, &inv.TenantID, &inv.InviterID, &inv.InviteeID, &inv.Status, &inv.CreatedAt)
+		result = append(result, inv)
+	}
+	return result, nil
+}
+
+func (r *TenantInvitationRepository) HasPendingInvitation(tenantID, inviteeID string) bool {
+	var exists bool
+	r.db.QueryRow(context.Background(),
+		`SELECT EXISTS(SELECT 1 FROM tenant_invitations WHERE tenant_id = $1 AND invitee_id = $2 AND status = $3)`,
+		tenantID, inviteeID, models.InvitationStatusPending).Scan(&exists)
+	return exists
+}
 // --- Short Link Repository (PG + Redis cache, tenant-scoped) ---
 
 type shortLinkRepository struct {

--- a/internal/app/routers/router.go
+++ b/internal/app/routers/router.go
@@ -139,6 +139,20 @@ func SetupRouter() *gin.Engine {
 		tenantAPI.GET("/:id/domains", handlers.ListDomainsAPI())
 		tenantAPI.POST("/:id/domains", handlers.AddDomainAPI())
 		tenantAPI.DELETE("/:id/domains", handlers.RemoveDomainAPI())
+		tenantAPI.GET("/:id/members", handlers.ListTenantMembersAPI())
+		tenantAPI.POST("/:id/invitations", handlers.InviteUserAPI())
+		tenantAPI.PATCH("/:id/members/:userId/role", handlers.UpdateMemberRoleAPI())
+		tenantAPI.DELETE("/:id/members/:userId", handlers.RemoveMemberAPI())
+		tenantAPI.POST("/:id/leave", handlers.LeaveTenantAPI())
+
+		// Invitation routes (no tenant context in path)
+		invAPI := v1.Group("/invitations")
+		invAPI.Use(handlers.JWTAuthenticatorMiddleware())
+		{
+			invAPI.GET("/", handlers.ListMyInvitationsAPI())
+			invAPI.POST("/:id/accept", handlers.AcceptInvitationAPI())
+			invAPI.POST("/:id/reject", handlers.RejectInvitationAPI())
+		}
 	}
 
 	return r

--- a/internal/app/routers/router.go
+++ b/internal/app/routers/router.go
@@ -144,15 +144,15 @@ func SetupRouter() *gin.Engine {
 		tenantAPI.PATCH("/:id/members/:userId/role", handlers.UpdateMemberRoleAPI())
 		tenantAPI.DELETE("/:id/members/:userId", handlers.RemoveMemberAPI())
 		tenantAPI.POST("/:id/leave", handlers.LeaveTenantAPI())
+	}
 
-		// Invitation routes (no tenant context in path)
-		invAPI := v1.Group("/invitations")
-		invAPI.Use(handlers.JWTAuthenticatorMiddleware())
-		{
-			invAPI.GET("/", handlers.ListMyInvitationsAPI())
-			invAPI.POST("/:id/accept", handlers.AcceptInvitationAPI())
-			invAPI.POST("/:id/reject", handlers.RejectInvitationAPI())
-		}
+	// Invitation routes — no TenantResolverMiddleware (tenant-agnostic)
+	invAPI := r.Group("/v1/invitations")
+	invAPI.Use(handlers.JWTAuthenticatorMiddleware())
+	{
+		invAPI.GET("/", handlers.ListMyInvitationsAPI())
+		invAPI.POST("/:id/accept", handlers.AcceptInvitationAPI())
+		invAPI.POST("/:id/reject", handlers.RejectInvitationAPI())
 	}
 
 	return r


### PR DESCRIPTION
## Summary
- Implement complete tenant member management APIs including invitation flow, role management, member removal, and leave functionality (JWM-51 / BE-4)
- Modify CreateTenantAPI to allow any logged-in user to create tenants with auto-join as admin
- Add 8 new API endpoints for tenant member lifecycle management

## Changes
- internal/app/handlers/tenant_member.go — New handlers for member management
- internal/app/handlers/tenant.go — Updated CreateTenantAPI (remove admin-only restriction, auto-join creator)
- internal/app/models/models.go — New request/response models
- internal/app/repository/repository.go — New repository methods (UpdateRole, IsMember, FindPendingByInvitee, HasPendingInvitation)
- internal/app/routers/router.go — New route registrations

## Test plan
- [ ] Verify go build ./... compiles successfully
- [ ] Test tenant creation with auto-join as admin
- [ ] Test invitation flow (create, list, accept/reject)
- [ ] Test role update (admin only, cannot modify self)
- [ ] Test member removal (admin only, cannot remove self)
- [ ] Test leave tenant
- [ ] Test permission enforcement (non-admin cannot invite/remove/change roles)

Generated with Claude Code