### PR TITLE
feat: adapt short link APIs for many-to-many user-tenant model (BE-6)

### DIFF
--- a/internal/app/db/migrate.go
+++ b/internal/app/db/migrate.go
@@ -73,6 +73,19 @@ var migrationStmts = []string{
     updated_at  TIMESTAMPTZ NOT NULL DEFAULT now()
 )`,
 
+	// Migrate short_links.created_by from VARCHAR to UUID if the table already exists
+	`DO $$ BEGIN
+	    IF EXISTS (
+	        SELECT 1 FROM information_schema.columns
+	        WHERE table_name = 'short_links' AND column_name = 'created_by' AND data_type = 'character varying'
+	    ) THEN
+	        ALTER TABLE short_links DROP CONSTRAINT IF EXISTS short_links_created_by_fkey;
+	        ALTER TABLE short_links ALTER COLUMN created_by TYPE UUID USING created_by::UUID;
+	        ALTER TABLE short_links ADD CONSTRAINT short_links_created_by_fkey
+	            FOREIGN KEY (created_by) REFERENCES users(id);
+	    END IF;
+	END $$`,
+
 	`CREATE INDEX IF NOT EXISTS idx_short_links_tenant ON short_links(tenant_id)`,
 	`CREATE INDEX IF NOT EXISTS idx_short_links_tenant_created ON short_links(tenant_id, created_at DESC)`,
 	`CREATE INDEX IF NOT EXISTS idx_short_links_created_by ON short_links(created_by)`,

--- a/internal/app/db/migrate.go
+++ b/internal/app/db/migrate.go
@@ -68,7 +68,7 @@ var migrationStmts = []string{
     url         TEXT NOT NULL,
     description TEXT NOT NULL DEFAULT '',
     is_enabled  BOOLEAN NOT NULL DEFAULT true,
-    created_by  VARCHAR(50) NOT NULL,
+    created_by  UUID NOT NULL REFERENCES users(id),
     created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
     updated_at  TIMESTAMPTZ NOT NULL DEFAULT now()
 )`,

--- a/internal/app/handlers/preferences.go
+++ b/internal/app/handlers/preferences.go
@@ -47,7 +47,7 @@ type updatePreferencesRequest struct {
 // @Param body body object true "更新偏好设置请求" example({"preferences":[{"key":"theme","value":"dark"}]})
 // @Success 200 {object} models.Response{data=map[string]interface{}} "data.preferences 为 []*models.UserPreference"
 // @Failure 401 {object} nil
-// @Router /user/preferences [put]
+// @Router /user/preferences [patch]
 func UpdateUserPreferencesAPI() gin.HandlerFunc {
 	return Authenticator(func(c *gin.Context, ctx *AuthContext) {
 		req := &updatePreferencesRequest{}

--- a/internal/app/handlers/shortlink.go
+++ b/internal/app/handlers/shortlink.go
@@ -14,6 +14,53 @@ import (
 	"github.com/jwma/jump-jump/internal/app/utils"
 )
 
+// resolveUsernames batch-resolves user IDs to usernames.
+func resolveUsernames(userIDs []string) map[string]string {
+	userRepo := repository.GetUserRepo(db.GetPostgresPool())
+	m, err := userRepo.FindUsernamesByIDs(userIDs)
+	if err != nil {
+		return make(map[string]string)
+	}
+	return m
+}
+
+func collectCreatedByIDs(links []*models.ShortLink) []string {
+	seen := make(map[string]bool)
+	ids := make([]string, 0, len(links))
+	for _, l := range links {
+		if !seen[l.CreatedBy] {
+			seen[l.CreatedBy] = true
+			ids = append(ids, l.CreatedBy)
+		}
+	}
+	return ids
+}
+
+func toShortLinkDataSliceWithUsernames(links []*models.ShortLink) []*models.ShortLinkData {
+	if len(links) == 0 {
+		return make([]*models.ShortLinkData, 0)
+	}
+	usernameMap := resolveUsernames(collectCreatedByIDs(links))
+	result := make([]*models.ShortLinkData, 0, len(links))
+	for _, s := range links {
+		d := models.ToShortLinkData(s)
+		if username, ok := usernameMap[s.CreatedBy]; ok {
+			d.CreatedBy = username
+		}
+		result = append(result, d)
+	}
+	return result
+}
+
+func toShortLinkDataWithUsername(s *models.ShortLink) *models.ShortLinkData {
+	usernameMap := resolveUsernames([]string{s.CreatedBy})
+	d := models.ToShortLinkData(s)
+	if username, ok := usernameMap[s.CreatedBy]; ok {
+		d.CreatedBy = username
+	}
+	return d
+}
+
 // GetShortLinkAPI godoc
 // @Summary 获取指定 ID 短链接
 // @Description 获取指定 ID 短链接详情
@@ -34,13 +81,8 @@ func GetShortLinkAPI() gin.HandlerFunc {
 			return
 		}
 
-		if !ctx.User.IsSuper && !ctx.Member.IsAdmin() && ctx.User.Username != s.CreatedBy {
-			c.JSON(http.StatusOK, models.NewErrorResponse("你无权查看"))
-			return
-		}
-
 		c.JSON(http.StatusOK, models.NewSuccessResponse(&models.GetShortLinkAPIResponseData{
-			ShortLinkData: models.ToShortLinkData(s),
+			ShortLinkData: toShortLinkDataWithUsername(s),
 		}))
 	})
 }
@@ -65,14 +107,10 @@ func CreateShortLinkAPI() gin.HandlerFunc {
 		}
 
 		tenantID := getTenantID(c)
-		s := models.NewShortLink(tenantID, ctx.User.Username, params)
+		s := models.NewShortLink(tenantID, ctx.User.ID, params)
 		repo := repository.GetShortLinkRepo(db.GetPostgresPool(), db.GetRedisClient())
 		idCfg := config.GetIdConfig(tenantID)
 		idLen := idCfg.IdLength
-
-		if !ctx.User.IsSuper && ctx.Member.Role == models.RoleMember {
-			s.Id = ""
-		}
 
 		if s.Id != "" {
 			checkShortLink, _ := repo.Get(s.Id)
@@ -104,7 +142,7 @@ func CreateShortLinkAPI() gin.HandlerFunc {
 		}
 
 		c.JSON(http.StatusOK, models.NewSuccessResponse(models.CreateShortLinkAPIResponseData{
-			ShortLinkData: models.ToShortLinkData(s),
+			ShortLinkData: toShortLinkDataWithUsername(s),
 		}))
 	})
 }
@@ -130,11 +168,6 @@ func UpdateShortLinkAPI() gin.HandlerFunc {
 			return
 		}
 
-		if !ctx.User.IsSuper && !ctx.Member.IsAdmin() && ctx.User.Username != s.CreatedBy {
-			c.JSON(http.StatusOK, models.NewErrorResponse("你无权修改此短链接"))
-			return
-		}
-
 		updateShortLink := &models.UpdateShortLinkAPIRequest{}
 		if err := c.ShouldBindJSON(updateShortLink); err != nil {
 			c.JSON(http.StatusOK, models.NewErrorResponse(err.Error()))
@@ -147,7 +180,7 @@ func UpdateShortLinkAPI() gin.HandlerFunc {
 		}
 
 		c.JSON(http.StatusOK, models.NewSuccessResponse(models.UpdateShortLinkAPIResponseData{
-			ShortLinkData: models.ToShortLinkData(s),
+			ShortLinkData: toShortLinkDataWithUsername(s),
 		}))
 	})
 }
@@ -169,11 +202,6 @@ func DeleteShortLinkAPI() gin.HandlerFunc {
 		s, err := slRepo.Get(c.Param("id"))
 		if err != nil {
 			c.JSON(http.StatusOK, models.NewErrorResponse(err.Error()))
-			return
-		}
-
-		if !ctx.User.IsSuper && !ctx.Member.IsAdmin() && ctx.User.Username != s.CreatedBy {
-			c.JSON(http.StatusOK, models.NewErrorResponse("你无权删除此短链接"))
 			return
 		}
 
@@ -201,14 +229,14 @@ func ListShortLinksAPI() gin.HandlerFunc {
 		start := int64((page - 1) * pageSize)
 
 		slRepo := repository.GetShortLinkRepo(db.GetPostgresPool(), db.GetRedisClient())
-		result, err := slRepo.List(getTenantID(c), ctx.User.Username, ctx.User.IsSuper || ctx.Member.IsAdmin(), start, int64(pageSize))
+		result, err := slRepo.List(getTenantID(c), start, int64(pageSize))
 		if err != nil {
 			c.JSON(http.StatusOK, models.NewErrorResponse(err.Error()))
 			return
 		}
 
 		c.JSON(http.StatusOK, models.NewSuccessResponse(&models.ListShortLinksAPIResponseData{
-			ShortLinks: models.ToShortLinkDataSlice(result.ShortLinks),
+			ShortLinks: toShortLinkDataSliceWithUsernames(result.ShortLinks),
 			Total:      result.Total,
 		}))
 	})
@@ -234,11 +262,6 @@ func ShortLinkActionAPI() gin.HandlerFunc {
 			s, err := slRepo.Get(c.Param("id"))
 			if err != nil {
 				c.JSON(http.StatusOK, models.NewErrorResponse(err.Error()))
-				return
-			}
-
-			if !ctx.User.IsSuper && !ctx.Member.IsAdmin() && ctx.User.Username != s.CreatedBy {
-				c.JSON(http.StatusOK, models.NewErrorResponse("你无权查看"))
 				return
 			}
 

--- a/internal/app/handlers/shortlink.go
+++ b/internal/app/handlers/shortlink.go
@@ -61,6 +61,15 @@ func toShortLinkDataWithUsername(s *models.ShortLink) *models.ShortLinkData {
 	return d
 }
 
+// checkTenantOwnership verifies that a short link belongs to the current tenant.
+func checkTenantOwnership(c *gin.Context, s *models.ShortLink) bool {
+	if s.TenantID != getTenantID(c) {
+		c.JSON(http.StatusOK, models.NewErrorResponse("短链接不存在"))
+		return false
+	}
+	return true
+}
+
 // GetShortLinkAPI godoc
 // @Summary 获取指定 ID 短链接
 // @Description 获取指定 ID 短链接详情
@@ -78,6 +87,10 @@ func GetShortLinkAPI() gin.HandlerFunc {
 		s, err := slRepo.Get(c.Param("id"))
 		if err != nil {
 			c.JSON(http.StatusOK, models.NewErrorResponse(err.Error()))
+			return
+		}
+
+		if !checkTenantOwnership(c, s) {
 			return
 		}
 
@@ -168,6 +181,10 @@ func UpdateShortLinkAPI() gin.HandlerFunc {
 			return
 		}
 
+		if !checkTenantOwnership(c, s) {
+			return
+		}
+
 		updateShortLink := &models.UpdateShortLinkAPIRequest{}
 		if err := c.ShouldBindJSON(updateShortLink); err != nil {
 			c.JSON(http.StatusOK, models.NewErrorResponse(err.Error()))
@@ -202,6 +219,10 @@ func DeleteShortLinkAPI() gin.HandlerFunc {
 		s, err := slRepo.Get(c.Param("id"))
 		if err != nil {
 			c.JSON(http.StatusOK, models.NewErrorResponse(err.Error()))
+			return
+		}
+
+		if !checkTenantOwnership(c, s) {
 			return
 		}
 
@@ -262,6 +283,10 @@ func ShortLinkActionAPI() gin.HandlerFunc {
 			s, err := slRepo.Get(c.Param("id"))
 			if err != nil {
 				c.JSON(http.StatusOK, models.NewErrorResponse(err.Error()))
+				return
+			}
+
+			if !checkTenantOwnership(c, s) {
 				return
 			}
 

--- a/internal/app/handlers/super_admin.go
+++ b/internal/app/handlers/super_admin.go
@@ -260,7 +260,7 @@ func SuperListTenantShortLinksAPI(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, models.NewSuccessResponse(&models.ListShortLinksAPIResponseData{
-		ShortLinks: models.ToShortLinkDataSlice(result.ShortLinks),
+		ShortLinks: toShortLinkDataSliceWithUsernames(result.ShortLinks),
 		Total:      result.Total,
 	}))
 }

--- a/internal/app/handlers/user.go
+++ b/internal/app/handlers/user.go
@@ -133,7 +133,7 @@ func LogoutAPI() gin.HandlerFunc {
 // @Param body body models.ChangePasswordAPIRequest true "修改密码请求"
 // @Success 200 {object} models.Response
 // @Failure 401 {object} nil
-// @Router /user/change-password [post]
+// @Router /auth/change-password [post]
 func ChangePasswordAPI() gin.HandlerFunc {
 	return Authenticator(func(c *gin.Context, ctx *AuthContext) {
 		p := &models.ChangePasswordAPIRequest{}

--- a/internal/app/repository/repository.go
+++ b/internal/app/repository/repository.go
@@ -386,6 +386,37 @@ func (r *userRepository) UpdateStatus(userID string, isActive bool) error {
 	return nil
 }
 
+func (r *userRepository) FindUsernamesByIDs(userIDs []string) (map[string]string, error) {
+	if len(userIDs) == 0 {
+		return make(map[string]string), nil
+	}
+	seen := make(map[string]bool)
+	unique := make([]string, 0, len(userIDs))
+	for _, id := range userIDs {
+		if !seen[id] {
+			seen[id] = true
+			unique = append(unique, id)
+		}
+	}
+
+	rows, err := r.db.Query(context.Background(),
+		`SELECT id, username FROM users WHERE id = ANY($1)`, unique)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	result := make(map[string]string, len(unique))
+	for rows.Next() {
+		var id, username string
+		if err := rows.Scan(&id, &username); err != nil {
+			return nil, err
+		}
+		result[id] = username
+	}
+	return result, rows.Err()
+}
+
 func (r *userRepository) GetUserTenants(u *models.User) ([]*models.UserTenantEntry, error) {
 	if u.IsSuper {
 		rows, err := r.db.Query(context.Background(),
@@ -767,32 +798,19 @@ func makeEmptyShortLinkListResult() *shortLinkListResult {
 	return &shortLinkListResult{ShortLinks: make([]*models.ShortLink, 0), Total: 0}
 }
 
-func (r *shortLinkRepository) List(tenantID, username string, isAdmin bool, start, pageSize int64) (*shortLinkListResult, error) {
+func (r *shortLinkRepository) List(tenantID string, start, pageSize int64) (*shortLinkListResult, error) {
 	result := makeEmptyShortLinkListResult()
 
-	var countQuery, dataQuery string
-	var args []interface{}
-
-	args = append(args, tenantID)
-
-	if isAdmin {
-		countQuery = `SELECT COUNT(*) FROM short_links WHERE tenant_id = $1`
-		dataQuery = `SELECT id, tenant_id, url, description, is_enabled, created_by, created_at, updated_at
-					 FROM short_links WHERE tenant_id = $1 ORDER BY created_at DESC LIMIT $2 OFFSET $3`
-	} else {
-		countQuery = `SELECT COUNT(*) FROM short_links WHERE tenant_id = $1 AND created_by = $2`
-		dataQuery = `SELECT id, tenant_id, url, description, is_enabled, created_by, created_at, updated_at
-					 FROM short_links WHERE tenant_id = $1 AND created_by = $2 ORDER BY created_at DESC LIMIT $3 OFFSET $4`
-		args = append(args, username)
-	}
-
-	err := r.db.QueryRow(context.Background(), countQuery, args...).Scan(&result.Total)
+	err := r.db.QueryRow(context.Background(),
+		`SELECT COUNT(*) FROM short_links WHERE tenant_id = $1`, tenantID).Scan(&result.Total)
 	if err != nil || result.Total == 0 {
 		return result, nil
 	}
 
-	dataArgs := append(args, pageSize, start)
-	rows, err := r.db.Query(context.Background(), dataQuery, dataArgs...)
+	rows, err := r.db.Query(context.Background(),
+		`SELECT id, tenant_id, url, description, is_enabled, created_by, created_at, updated_at
+		 FROM short_links WHERE tenant_id = $1 ORDER BY created_at DESC LIMIT $2 OFFSET $3`,
+		tenantID, pageSize, start)
 	if err != nil {
 		return result, errors.New("系统繁忙请稍后再试")
 	}

--- a/internal/app/repository/repository.go
+++ b/internal/app/repository/repository.go
@@ -799,29 +799,7 @@ func makeEmptyShortLinkListResult() *shortLinkListResult {
 }
 
 func (r *shortLinkRepository) List(tenantID string, start, pageSize int64) (*shortLinkListResult, error) {
-	result := makeEmptyShortLinkListResult()
-
-	err := r.db.QueryRow(context.Background(),
-		`SELECT COUNT(*) FROM short_links WHERE tenant_id = $1`, tenantID).Scan(&result.Total)
-	if err != nil || result.Total == 0 {
-		return result, nil
-	}
-
-	rows, err := r.db.Query(context.Background(),
-		`SELECT id, tenant_id, url, description, is_enabled, created_by, created_at, updated_at
-		 FROM short_links WHERE tenant_id = $1 ORDER BY created_at DESC LIMIT $2 OFFSET $3`,
-		tenantID, pageSize, start)
-	if err != nil {
-		return result, errors.New("系统繁忙请稍后再试")
-	}
-	defer rows.Close()
-
-	for rows.Next() {
-		s := &models.ShortLink{}
-		rows.Scan(&s.Id, &s.TenantID, &s.Url, &s.Description, &s.IsEnable, &s.CreatedBy, &s.CreateTime, &s.UpdateTime)
-		result.ShortLinks = append(result.ShortLinks, s)
-	}
-	return result, nil
+	return r.ListByTenantID(tenantID, start, pageSize)
 }
 
 func (r *shortLinkRepository) ListByTenantID(tenantID string, start, pageSize int64) (*shortLinkListResult, error) {
@@ -829,7 +807,10 @@ func (r *shortLinkRepository) ListByTenantID(tenantID string, start, pageSize in
 
 	err := r.db.QueryRow(context.Background(),
 		`SELECT COUNT(*) FROM short_links WHERE tenant_id = $1`, tenantID).Scan(&result.Total)
-	if err != nil || result.Total == 0 {
+	if err != nil {
+		return nil, fmt.Errorf("查询短链接总数失败: %w", err)
+	}
+	if result.Total == 0 {
 		return result, nil
 	}
 
@@ -838,19 +819,19 @@ func (r *shortLinkRepository) ListByTenantID(tenantID string, start, pageSize in
 		 FROM short_links WHERE tenant_id = $1 ORDER BY created_at DESC LIMIT $2 OFFSET $3`,
 		tenantID, pageSize, start)
 	if err != nil {
-		return result, errors.New("系统繁忙请稍后再试")
+		return nil, errors.New("系统繁忙请稍后再试")
 	}
 	defer rows.Close()
 
 	for rows.Next() {
 		s := &models.ShortLink{}
 		if err := rows.Scan(&s.Id, &s.TenantID, &s.Url, &s.Description, &s.IsEnable, &s.CreatedBy, &s.CreateTime, &s.UpdateTime); err != nil {
-			return result, err
+			return nil, err
 		}
 		result.ShortLinks = append(result.ShortLinks, s)
 	}
 	if err := rows.Err(); err != nil {
-		return result, err
+		return nil, err
 	}
 	return result, nil
 }

--- a/internal/app/repository/repository_test.go
+++ b/internal/app/repository/repository_test.go
@@ -32,17 +32,23 @@ func init() {
 }
 
 func TestShortLinkRepository_Save(t *testing.T) {
+	userRepo := GetUserRepo(getTestPool())
+	u, err := userRepo.FindByUsername("mj")
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	l := &models.ShortLink{
 		Id:          "mj",
 		TenantID:    "00000000-0000-0000-0000-000000000001",
 		Url:         "http://anmuji.com",
 		Description: "安木鸡",
 		IsEnable:    true,
-		CreatedBy:   "mj",
+		CreatedBy:   u.ID,
 	}
 
 	repo := GetShortLinkRepo(getTestPool(), getTestRDB())
-	err := repo.Save(l)
+	err = repo.Save(l)
 
 	if err != nil {
 		t.Error(err)
@@ -83,7 +89,7 @@ func TestShortLinkRepository_Update(t *testing.T) {
 
 func TestShortLinkRepository_List(t *testing.T) {
 	repo := GetShortLinkRepo(getTestPool(), getTestRDB())
-	rs, err := repo.List("00000000-0000-0000-0000-000000000001", "mj", false, 0, 10)
+	rs, err := repo.List("00000000-0000-0000-0000-000000000001", 0, 10)
 
 	if err != nil {
 		t.Error(err)
@@ -109,16 +115,22 @@ func TestShortLinkRepository_Delete(t *testing.T) {
 }
 
 func TestRequestHistoryRepository_Save(t *testing.T) {
+	userRepo := GetUserRepo(getTestPool())
+	u, err := userRepo.FindByUsername("mj")
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	l := &models.ShortLink{
 		Id:          "testrh",
 		TenantID:    "00000000-0000-0000-0000-000000000001",
 		Url:         "http://anmuji.com",
 		Description: "",
 		IsEnable:    true,
-		CreatedBy:   "mj",
+		CreatedBy:   u.ID,
 	}
 	slRepo := GetShortLinkRepo(getTestPool(), getTestRDB())
-	err := slRepo.Save(l)
+	err = slRepo.Save(l)
 
 	if err != nil {
 		t.Error(err)

--- a/internal/app/routers/router.go
+++ b/internal/app/routers/router.go
@@ -149,6 +149,7 @@ func SetupRouter() *gin.Engine {
 	{
 		userAPI.GET("/preferences", handlers.GetUserPreferencesAPI())
 		userAPI.PATCH("/preferences", handlers.UpdateUserPreferencesAPI())
+		userAPI.POST("/logout", handlers.LogoutAPI())
 	}
 
 	// User routes — JWT + TenantContext (need role info)
@@ -156,7 +157,6 @@ func SetupRouter() *gin.Engine {
 	userTenantAPI.Use(handlers.JWTAuthenticatorMiddleware(), handlers.TenantContextMiddleware())
 	{
 		userTenantAPI.GET("/info", handlers.GetUserInfoAPI())
-		userTenantAPI.POST("/logout", handlers.LogoutAPI())
 	}
 
 	// Short link routes — JWT + TenantContext (X-Tenant-ID required)

--- a/internal/app/routers/router.go
+++ b/internal/app/routers/router.go
@@ -95,6 +95,7 @@ func SetupRouter() *gin.Engine {
 	{
 		auth.POST("/login", handlers.LoginAPI)
 		auth.GET("/info", handlers.JWTAuthenticatorMiddleware(), handlers.GetAuthInfoAPI())
+		auth.POST("/change-password", handlers.JWTAuthenticatorMiddleware(), handlers.ChangePasswordAPI())
 	}
 
 	// Super admin routes — JWT + SuperAdmin middleware
@@ -142,15 +143,20 @@ func SetupRouter() *gin.Engine {
 		tenantAPI.POST("/:id/leave", handlers.LeaveTenantAPI())
 	}
 
-	// User routes — JWT + TenantContext (X-Tenant-ID required for role info)
+	// User routes — JWT only (global, no tenant context needed)
 	userAPI := r.Group("/v1/user")
-	userAPI.Use(handlers.JWTAuthenticatorMiddleware(), handlers.TenantContextMiddleware())
+	userAPI.Use(handlers.JWTAuthenticatorMiddleware())
 	{
-		userAPI.GET("/info", handlers.GetUserInfoAPI())
-		userAPI.POST("/logout", handlers.LogoutAPI())
-		userAPI.POST("/change-password", handlers.ChangePasswordAPI())
 		userAPI.GET("/preferences", handlers.GetUserPreferencesAPI())
-		userAPI.PUT("/preferences", handlers.UpdateUserPreferencesAPI())
+		userAPI.PATCH("/preferences", handlers.UpdateUserPreferencesAPI())
+	}
+
+	// User routes — JWT + TenantContext (need role info)
+	userTenantAPI := r.Group("/v1/user")
+	userTenantAPI.Use(handlers.JWTAuthenticatorMiddleware(), handlers.TenantContextMiddleware())
+	{
+		userTenantAPI.GET("/info", handlers.GetUserInfoAPI())
+		userTenantAPI.POST("/logout", handlers.LogoutAPI())
 	}
 
 	// Short link routes — JWT + TenantContext (X-Tenant-ID required)


### PR DESCRIPTION
## Summary
- Adapt short link APIs for the new many-to-many user-tenant model
- Change `short_links.created_by` from username (VARCHAR) to user UUID with foreign key
- Remove role-based permission checks — all tenant members have equal CRUD access
- Move change-password API to `/v1/auth/change-password` (no tenant context needed)
- Change preferences API from PUT to PATCH, move to JWT-only route group
- Add batch username resolution for API responses

## Test plan
- [ ] Verify short link CRUD operations work for all tenant members (no role distinction)
- [ ] Verify `created_by` stores user UUID and API returns resolved username
- [ ] Verify `POST /v1/auth/change-password` works without `X-Tenant-ID` header
- [ ] Verify `PATCH /v1/user/preferences` works without `X-Tenant-ID` header
- [ ] Verify super admin can still list tenant short links via `GET /v1/super/tenants/{id}/short-links`

🤖 Generated with [Claude Code](https://claude.com/claude-code)