### PR TITLE
feat(web-ui): super admin management UI

### DIFF
--- a/web-ui/src/api/http.ts
+++ b/web-ui/src/api/http.ts
@@ -13,7 +13,7 @@ http.interceptors.request.use((config) => {
   if (auth.token) {
     config.headers.Authorization = `Bearer ${auth.token}`
   }
-  if (auth.currentTenantId) {
+  if (auth.currentTenantId && !config.url?.startsWith('/super/')) {
     config.headers['X-Tenant-ID'] = auth.currentTenantId
   }
   return config

--- a/web-ui/src/api/super.ts
+++ b/web-ui/src/api/super.ts
@@ -8,7 +8,7 @@ import type {
   SetStatusRequest,
   ListSuperTenantsResponse,
   SuperTenantMember,
-  ListSuperTenantShortLinksResponse,
+  ListShortLinksResponse,
   SuperTenantDomain,
 } from '@/types/api'
 
@@ -49,7 +49,7 @@ export function listSuperTenantMembers(tenantId: string) {
 }
 
 export function listSuperTenantShortLinks(tenantId: string, page = 1, pageSize = 20) {
-  return request<ListSuperTenantShortLinksResponse>('GET', `/super/tenants/${tenantId}/short-links`, { page, pageSize })
+  return request<ListShortLinksResponse>('GET', `/super/tenants/${tenantId}/short-links`, { page, pageSize })
 }
 
 export function listSuperTenantDomains(tenantId: string) {

--- a/web-ui/src/api/super.ts
+++ b/web-ui/src/api/super.ts
@@ -1,0 +1,57 @@
+import { request } from './http'
+import type {
+  SuperUser,
+  SuperUserDetail,
+  ListSuperUsersResponse,
+  CreateSuperUserRequest,
+  ResetPasswordRequest,
+  SetStatusRequest,
+  ListSuperTenantsResponse,
+  SuperTenantMember,
+  ListSuperTenantShortLinksResponse,
+  SuperTenantDomain,
+} from '@/types/api'
+
+// Users
+export function listSuperUsers(page = 1, pageSize = 20, query = '') {
+  const params: Record<string, string | number> = { page, pageSize }
+  if (query) params.query = query
+  return request<ListSuperUsersResponse>('GET', '/super/users', params)
+}
+
+export function getSuperUser(id: string) {
+  return request<SuperUserDetail>('GET', `/super/users/${id}`)
+}
+
+export function createSuperUser(data: CreateSuperUserRequest) {
+  return request<SuperUser>('POST', '/super/users', data)
+}
+
+export function resetSuperUserPassword(id: string, data: ResetPasswordRequest) {
+  return request<void>('POST', `/super/users/${id}/reset-password`, data)
+}
+
+export function setSuperUserStatus(id: string, data: SetStatusRequest) {
+  return request<void>('PATCH', `/super/users/${id}/status`, data)
+}
+
+// Tenants
+export function listSuperTenants(page = 1, pageSize = 20) {
+  return request<ListSuperTenantsResponse>('GET', '/super/tenants', { page, pageSize })
+}
+
+export function setSuperTenantStatus(id: string, data: SetStatusRequest) {
+  return request<void>('PATCH', `/super/tenants/${id}/status`, data)
+}
+
+export function listSuperTenantMembers(tenantId: string) {
+  return request<SuperTenantMember[]>('GET', `/super/tenants/${tenantId}/members`)
+}
+
+export function listSuperTenantShortLinks(tenantId: string, page = 1, pageSize = 20) {
+  return request<ListSuperTenantShortLinksResponse>('GET', `/super/tenants/${tenantId}/short-links`, { page, pageSize })
+}
+
+export function listSuperTenantDomains(tenantId: string) {
+  return request<SuperTenantDomain[]>('GET', `/super/tenants/${tenantId}/domains`)
+}

--- a/web-ui/src/api/tenant.ts
+++ b/web-ui/src/api/tenant.ts
@@ -22,5 +22,5 @@ export function addDomain(tenantId: string, data: AddDomainRequest) {
 }
 
 export function removeDomain(tenantId: string, domain: string) {
-  return request<TenantDomain[]>('DELETE', `/tenant/${tenantId}/domains?domain=${encodeURIComponent(domain)}`)
+  return request<TenantDomain[]>('DELETE', `/tenant/${tenantId}/domains/${encodeURIComponent(domain)}`)
 }

--- a/web-ui/src/components/AppSidebar.vue
+++ b/web-ui/src/components/AppSidebar.vue
@@ -17,6 +17,8 @@ import {
   Bell,
   ChevronDown,
   ChevronRight,
+  Shield,
+  Users,
 } from 'lucide-vue-next'
 
 const auth = useAuthStore()
@@ -26,16 +28,26 @@ const router = useRouter()
 const tenantDropdownOpen = ref(false)
 
 const menuItems = computed(() => {
-  const items = [
-    { icon: LayoutDashboard, label: 'Dashboard', to: { name: 'dashboard' } },
-    { icon: Link, label: 'Short Links', to: { name: 'short-links' } },
-  ]
+  const items: { icon: unknown; label: string; to: { name: string } }[] = []
 
-  if (auth.user?.role === UserRole.Admin) {
+  if (isSuperRoute.value) {
     items.push(
-      { icon: Settings, label: 'System Config', to: { name: 'config' } },
-      { icon: Building2, label: 'Tenants', to: { name: 'tenants' } },
+      { icon: LayoutDashboard, label: 'Dashboard', to: { name: 'super-dashboard' } },
+      { icon: Users, label: 'Users', to: { name: 'super-users' } },
+      { icon: Building2, label: 'Tenants', to: { name: 'super-tenants' } },
     )
+  } else {
+    items.push(
+      { icon: LayoutDashboard, label: 'Dashboard', to: { name: 'dashboard' } },
+      { icon: Link, label: 'Short Links', to: { name: 'short-links' } },
+    )
+
+    if (auth.user?.role === UserRole.Admin) {
+      items.push(
+        { icon: Settings, label: 'System Config', to: { name: 'config' } },
+        { icon: Building2, label: 'Tenants', to: { name: 'tenants' } },
+      )
+    }
   }
 
   items.push(
@@ -46,10 +58,15 @@ const menuItems = computed(() => {
   return items
 })
 
+const isSuperRoute = computed(() => String(route.path).startsWith('/super'))
+
+const showTenantSwitcher = computed(() => !isSuperRoute.value)
+
 function isActive(to: { name: string }) {
   if (route.name === to.name) return true
   if (to.name === 'short-links' && String(route.name).startsWith('short-link')) return true
   if (to.name === 'tenants' && String(route.name).startsWith('tenant')) return true
+  if (to.name === 'super-tenants' && String(route.name).startsWith('super-tenant')) return true
   return false
 }
 
@@ -144,8 +161,8 @@ async function handleLogout() {
       <ChevronLeft class="h-3 w-3 rotate-180" />
     </button>
 
-    <!-- Tenant switcher -->
-    <div v-if="!layout.sidebarCollapsed" class="border-b px-3 py-2">
+    <!-- Tenant switcher (hidden on super admin routes) -->
+    <div v-if="!layout.sidebarCollapsed && showTenantSwitcher" class="border-b px-3 py-2">
       <button
         class="flex w-full items-center justify-between rounded-lg px-2 py-1.5 text-left text-sm hover:bg-gray-100"
         @click="tenantDropdownOpen = !tenantDropdownOpen"
@@ -179,6 +196,18 @@ async function handleLogout() {
           Manage tenants
         </router-link>
       </div>
+    </div>
+
+    <!-- Super admin toggle -->
+    <div v-if="auth.isSuper" class="border-b px-2 py-2">
+      <button
+        class="flex w-full items-center gap-2 rounded-lg px-2 py-1.5 text-sm transition-colors"
+        :class="isSuperRoute ? 'bg-indigo-50 text-indigo-700' : 'text-gray-500 hover:bg-gray-100 hover:text-gray-700'"
+        @click="isSuperRoute ? router.push({ name: auth.currentTenantId ? 'dashboard' : 'select-tenant' }) : router.push({ name: 'super-dashboard' })"
+      >
+        <Shield class="h-4 w-4 shrink-0" />
+        <span v-show="!layout.sidebarCollapsed">{{ isSuperRoute ? 'Back to App' : 'Super Admin' }}</span>
+      </button>
     </div>
 
     <!-- Navigation -->

--- a/web-ui/src/env.d.ts
+++ b/web-ui/src/env.d.ts
@@ -1,9 +1,21 @@
 /// <reference types="vite/client" />
 
+import 'vue-router'
+
 interface ImportMetaEnv {
   readonly VITE_API_BASE_URL: string
 }
 
 interface ImportMeta {
   readonly env: ImportMetaEnv
+}
+
+declare module 'vue-router' {
+  interface RouteMeta {
+    title?: string
+    requiresAuth?: boolean
+    requiresTenant?: boolean
+    requiresSuper?: boolean
+    requiredRole?: string
+  }
 }

--- a/web-ui/src/pages/super/SuperDashboardPage.vue
+++ b/web-ui/src/pages/super/SuperDashboardPage.vue
@@ -1,0 +1,157 @@
+<script setup lang="ts">
+import { ref, onMounted } from 'vue'
+import { listSuperUsers, listSuperTenants } from '@/api/super'
+import { Building2, Users, Link, Loader2 } from 'lucide-vue-next'
+
+defineOptions({ name: 'SuperDashboardPage' })
+
+const loading = ref(true)
+const totalTenants = ref(0)
+const totalUsers = ref(0)
+const totalShortLinks = ref(0)
+const recentTenants = ref<{ id: string; name: string; slug: string; isActive: boolean; createdAt: string }[]>([])
+
+async function fetchDashboardData() {
+  loading.value = true
+  try {
+    const [usersData, tenantsData] = await Promise.all([
+      listSuperUsers(1, 1),
+      listSuperTenants(1, 100),
+    ])
+    totalUsers.value = usersData.total
+    totalTenants.value = tenantsData.total
+
+    recentTenants.value = (tenantsData.tenants || [])
+      .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())
+      .slice(0, 8)
+  } catch {
+    // error handled by interceptor
+  } finally {
+    loading.value = false
+  }
+}
+
+function formatDate(d: string) {
+  return new Date(d).toLocaleDateString(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  })
+}
+
+onMounted(fetchDashboardData)
+</script>
+
+<template>
+  <div class="space-y-6">
+    <div>
+      <h1 class="text-2xl font-bold text-gray-900">Super Admin Dashboard</h1>
+      <p class="mt-1 text-sm text-gray-500">Platform overview and statistics.</p>
+    </div>
+
+    <div class="grid grid-cols-1 gap-4 sm:grid-cols-3">
+      <div class="rounded-xl border border-gray-200 bg-white p-5 shadow-sm">
+        <div class="flex items-center justify-between">
+          <div>
+            <p class="text-sm font-medium text-gray-500">Total Tenants</p>
+            <p class="mt-1 text-2xl font-bold text-gray-900">
+              <span v-if="loading" class="inline-block h-7 w-16 animate-pulse rounded bg-gray-200" />
+              <template v-else>{{ totalTenants.toLocaleString() }}</template>
+            </p>
+          </div>
+          <div class="flex h-10 w-10 items-center justify-center rounded-lg bg-blue-50">
+            <Building2 class="h-5 w-5 text-blue-600" />
+          </div>
+        </div>
+      </div>
+
+      <div class="rounded-xl border border-gray-200 bg-white p-5 shadow-sm">
+        <div class="flex items-center justify-between">
+          <div>
+            <p class="text-sm font-medium text-gray-500">Total Users</p>
+            <p class="mt-1 text-2xl font-bold text-gray-900">
+              <span v-if="loading" class="inline-block h-7 w-16 animate-pulse rounded bg-gray-200" />
+              <template v-else>{{ totalUsers.toLocaleString() }}</template>
+            </p>
+          </div>
+          <div class="flex h-10 w-10 items-center justify-center rounded-lg bg-green-50">
+            <Users class="h-5 w-5 text-green-600" />
+          </div>
+        </div>
+      </div>
+
+      <div class="rounded-xl border border-gray-200 bg-white p-5 shadow-sm">
+        <div class="flex items-center justify-between">
+          <div>
+            <p class="text-sm font-medium text-gray-500">Short Links</p>
+            <p class="mt-1 text-2xl font-bold text-gray-900">
+              <span v-if="loading" class="inline-block h-7 w-16 animate-pulse rounded bg-gray-200" />
+              <template v-else>{{ totalShortLinks.toLocaleString() }}</template>
+            </p>
+          </div>
+          <div class="flex h-10 w-10 items-center justify-center rounded-lg bg-purple-50">
+            <Link class="h-5 w-5 text-purple-600" />
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="rounded-xl border border-gray-200 bg-white shadow-sm">
+      <div class="flex items-center justify-between border-b border-gray-100 px-5 py-4">
+        <div class="flex items-center gap-2">
+          <Building2 class="h-4 w-4 text-gray-500" />
+          <h2 class="text-base font-semibold text-gray-900">Tenants</h2>
+        </div>
+        <router-link
+          :to="{ name: 'super-tenants' }"
+          class="text-xs font-medium text-blue-600 hover:text-blue-700"
+        >
+          View all
+        </router-link>
+      </div>
+      <div v-if="loading" class="flex items-center justify-center p-8">
+        <Loader2 class="h-5 w-5 animate-spin text-gray-400" />
+      </div>
+      <div v-else-if="recentTenants.length === 0" class="px-5 py-8 text-center text-sm text-gray-400">
+        No tenants found.
+      </div>
+      <div v-else class="overflow-x-auto">
+        <table class="w-full text-sm">
+          <thead>
+            <tr class="border-b border-gray-100 text-left text-xs font-medium uppercase tracking-wider text-gray-500">
+              <th class="px-5 py-3">Name</th>
+              <th class="px-5 py-3">Slug</th>
+              <th class="px-5 py-3">Status</th>
+              <th class="hidden px-5 py-3 md:table-cell">Created</th>
+            </tr>
+          </thead>
+          <tbody class="divide-y divide-gray-50">
+            <tr v-for="t in recentTenants" :key="t.id" class="transition-colors hover:bg-gray-50">
+              <td class="px-5 py-3">
+                <router-link
+                  :to="{ name: 'super-tenant-detail', params: { id: t.id } }"
+                  class="font-medium text-blue-600 hover:text-blue-700"
+                >
+                  {{ t.name }}
+                </router-link>
+              </td>
+              <td class="px-5 py-3 font-mono text-xs text-gray-600">{{ t.slug }}</td>
+              <td class="px-5 py-3">
+                <span
+                  class="inline-flex items-center gap-1.5 rounded-full px-2.5 py-0.5 text-xs font-medium"
+                  :class="t.isActive ? 'bg-green-50 text-green-700' : 'bg-gray-100 text-gray-500'"
+                >
+                  <span class="h-1.5 w-1.5 rounded-full" :class="t.isActive ? 'bg-green-500' : 'bg-gray-400'" />
+                  {{ t.isActive ? 'Active' : 'Inactive' }}
+                </span>
+              </td>
+              <td class="hidden whitespace-nowrap px-5 py-3 text-gray-500 md:table-cell">
+                {{ formatDate(t.createdAt) }}
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+</template>

--- a/web-ui/src/pages/super/SuperDashboardPage.vue
+++ b/web-ui/src/pages/super/SuperDashboardPage.vue
@@ -1,14 +1,13 @@
 <script setup lang="ts">
 import { ref, onMounted } from 'vue'
 import { listSuperUsers, listSuperTenants } from '@/api/super'
-import { Building2, Users, Link, Loader2 } from 'lucide-vue-next'
+import { Building2, Users, Loader2 } from 'lucide-vue-next'
 
 defineOptions({ name: 'SuperDashboardPage' })
 
 const loading = ref(true)
 const totalTenants = ref(0)
 const totalUsers = ref(0)
-const totalShortLinks = ref(0)
 const recentTenants = ref<{ id: string; name: string; slug: string; isActive: boolean; createdAt: string }[]>([])
 
 async function fetchDashboardData() {
@@ -49,7 +48,7 @@ onMounted(fetchDashboardData)
       <p class="mt-1 text-sm text-gray-500">Platform overview and statistics.</p>
     </div>
 
-    <div class="grid grid-cols-1 gap-4 sm:grid-cols-3">
+    <div class="grid grid-cols-1 gap-4 sm:grid-cols-2">
       <div class="rounded-xl border border-gray-200 bg-white p-5 shadow-sm">
         <div class="flex items-center justify-between">
           <div>
@@ -76,21 +75,6 @@ onMounted(fetchDashboardData)
           </div>
           <div class="flex h-10 w-10 items-center justify-center rounded-lg bg-green-50">
             <Users class="h-5 w-5 text-green-600" />
-          </div>
-        </div>
-      </div>
-
-      <div class="rounded-xl border border-gray-200 bg-white p-5 shadow-sm">
-        <div class="flex items-center justify-between">
-          <div>
-            <p class="text-sm font-medium text-gray-500">Short Links</p>
-            <p class="mt-1 text-2xl font-bold text-gray-900">
-              <span v-if="loading" class="inline-block h-7 w-16 animate-pulse rounded bg-gray-200" />
-              <template v-else>{{ totalShortLinks.toLocaleString() }}</template>
-            </p>
-          </div>
-          <div class="flex h-10 w-10 items-center justify-center rounded-lg bg-purple-50">
-            <Link class="h-5 w-5 text-purple-600" />
           </div>
         </div>
       </div>

--- a/web-ui/src/pages/super/SuperTenantDetailPage.vue
+++ b/web-ui/src/pages/super/SuperTenantDetailPage.vue
@@ -1,0 +1,482 @@
+<script setup lang="ts">
+import { ref, onMounted } from 'vue'
+import { useRouter, useRoute } from 'vue-router'
+import { getTenant, listDomains, addDomain, removeDomain } from '@/api/tenant'
+import { listSuperTenantMembers, listSuperTenantShortLinks, setSuperTenantStatus } from '@/api/super'
+import type { Tenant, TenantDomain } from '@/types/api'
+import type { SuperTenantMember, SuperTenantShortLink } from '@/types/api'
+import {
+  ArrowLeft,
+  Globe,
+  Plus,
+  Trash2,
+  Star,
+  Loader2,
+  ExternalLink,
+} from 'lucide-vue-next'
+
+defineOptions({ name: 'SuperTenantDetailPage' })
+
+const router = useRouter()
+const route = useRoute()
+const tenantId = route.params.id as string
+
+const tenant = ref<Tenant | null>(null)
+const loading = ref(false)
+const notFound = ref(false)
+const pageError = ref('')
+
+const activeTab = ref<'info' | 'members' | 'short-links' | 'domains'>('info')
+
+// Members
+const members = ref<SuperTenantMember[]>([])
+const membersLoading = ref(false)
+
+// Short links
+const shortLinks = ref<SuperTenantShortLink[]>([])
+const shortLinksTotal = ref(0)
+const shortLinksPage = ref(1)
+const shortLinksLoading = ref(false)
+
+// Domains
+const domains = ref<TenantDomain[]>([])
+const domainsLoading = ref(false)
+const newDomain = ref('')
+const addingDomain = ref(false)
+const confirmDeleteDomain = ref<string | null>(null)
+const deletingDomain = ref(false)
+
+// Status toggle
+const toggleLoading = ref(false)
+
+async function fetchTenant() {
+  loading.value = true
+  try {
+    tenant.value = await getTenant(tenantId)
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : ''
+    if (msg.includes('不存在') || msg.includes('not found')) {
+      notFound.value = true
+    } else {
+      pageError.value = msg || 'Failed to load tenant.'
+    }
+  } finally {
+    loading.value = false
+  }
+}
+
+async function fetchMembers() {
+  membersLoading.value = true
+  try {
+    const data = await listSuperTenantMembers(tenantId)
+    members.value = data || []
+  } catch {
+    members.value = []
+  } finally {
+    membersLoading.value = false
+  }
+}
+
+async function fetchShortLinks() {
+  shortLinksLoading.value = true
+  try {
+    const data = await listSuperTenantShortLinks(tenantId, shortLinksPage.value, 20)
+    shortLinks.value = data.shortLinks || []
+    shortLinksTotal.value = data.total
+  } catch {
+    shortLinks.value = []
+  } finally {
+    shortLinksLoading.value = false
+  }
+}
+
+async function fetchDomains() {
+  domainsLoading.value = true
+  try {
+    const data = await listDomains(tenantId)
+    domains.value = data || []
+  } catch {
+    domains.value = []
+  } finally {
+    domainsLoading.value = false
+  }
+}
+
+async function handleToggleStatus() {
+  if (!tenant.value) return
+  toggleLoading.value = true
+  try {
+    await setSuperTenantStatus(tenantId, { isActive: !tenant.value.isActive })
+    tenant.value = { ...tenant.value, isActive: !tenant.value.isActive }
+  } catch {
+    // error handled by interceptor
+  } finally {
+    toggleLoading.value = false
+  }
+}
+
+async function handleAddDomain() {
+  if (!newDomain.value.trim()) return
+  addingDomain.value = true
+  try {
+    const data = await addDomain(tenantId, { domain: newDomain.value.trim(), isDefault: false })
+    domains.value = data || []
+    newDomain.value = ''
+  } catch {
+    // error handled by interceptor
+  } finally {
+    addingDomain.value = false
+  }
+}
+
+async function handleDeleteDomain(domain: string) {
+  deletingDomain.value = true
+  try {
+    const data = await removeDomain(tenantId, domain)
+    domains.value = data || []
+  } catch {
+    // error handled by interceptor
+  } finally {
+    deletingDomain.value = false
+    confirmDeleteDomain.value = null
+  }
+}
+
+function onTabChange(tab: 'info' | 'members' | 'short-links' | 'domains') {
+  activeTab.value = tab
+  if (tab === 'members' && members.value.length === 0) fetchMembers()
+  if (tab === 'short-links' && shortLinks.value.length === 0) fetchShortLinks()
+  if (tab === 'domains' && domains.value.length === 0) fetchDomains()
+}
+
+function formatDate(d: string) {
+  return new Date(d).toLocaleDateString(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  })
+}
+
+onMounted(fetchTenant)
+</script>
+
+<template>
+  <div>
+    <div class="flex items-center gap-3">
+      <button
+        class="rounded p-1.5 text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-600"
+        @click="router.push({ name: 'super-tenants' })"
+      >
+        <ArrowLeft class="h-5 w-5" />
+      </button>
+      <div class="flex-1">
+        <h1 class="text-xl font-semibold text-gray-900">Tenant Detail</h1>
+        <p v-if="tenant" class="mt-0.5 text-sm text-gray-500">
+          <span class="font-mono font-medium text-gray-700">{{ tenant.id }}</span>
+        </p>
+      </div>
+    </div>
+
+    <div v-if="loading" class="mt-6 text-center text-gray-400">
+      <Loader2 class="inline h-5 w-5 animate-spin" />
+    </div>
+
+    <div v-else-if="notFound" class="mt-6 text-center text-gray-400">
+      Tenant not found.
+      <button class="ml-2 text-blue-600 hover:underline" @click="router.push({ name: 'super-tenants' })">
+        Back to list
+      </button>
+    </div>
+
+    <div v-else-if="pageError" class="mt-6 rounded-lg border border-red-200 bg-red-50 p-4">
+      <p class="text-sm text-red-600">{{ pageError }}</p>
+    </div>
+
+    <template v-else-if="tenant">
+      <!-- Tenant header card -->
+      <div class="mt-4 rounded-lg border bg-white p-5">
+        <div class="flex items-center gap-3">
+          <div
+            class="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-blue-50 text-sm font-bold text-blue-600"
+          >
+            {{ tenant.name.charAt(0).toUpperCase() }}
+          </div>
+          <div>
+            <h2 class="text-lg font-semibold text-gray-900">{{ tenant.name }}</h2>
+            <p class="text-sm text-gray-500">{{ tenant.slug }}</p>
+          </div>
+          <span
+            class="ml-auto inline-flex items-center gap-1.5 rounded-full px-2.5 py-0.5 text-xs font-medium"
+            :class="tenant.isActive ? 'bg-green-50 text-green-700' : 'bg-gray-100 text-gray-500'"
+          >
+            <span class="h-1.5 w-1.5 rounded-full" :class="tenant.isActive ? 'bg-green-500' : 'bg-gray-400'" />
+            {{ tenant.isActive ? 'Active' : 'Inactive' }}
+          </span>
+          <button
+            :disabled="toggleLoading"
+            class="rounded-md px-3 py-1.5 text-xs font-medium transition-colors"
+            :class="tenant.isActive
+              ? 'bg-red-50 text-red-600 hover:bg-red-100'
+              : 'bg-green-50 text-green-600 hover:bg-green-100'"
+            @click="handleToggleStatus"
+          >
+            <Loader2 v-if="toggleLoading" class="mr-1 inline h-3 w-3 animate-spin" />
+            {{ tenant.isActive ? 'Disable' : 'Enable' }}
+          </button>
+        </div>
+        <div class="mt-4 grid gap-4 sm:grid-cols-3">
+          <div>
+            <label class="text-xs font-medium uppercase text-gray-400">Tenant ID</label>
+            <p class="mt-1 font-mono text-sm text-gray-900">{{ tenant.id }}</p>
+          </div>
+          <div>
+            <label class="text-xs font-medium uppercase text-gray-400">Created</label>
+            <p class="mt-1 text-sm text-gray-700">{{ formatDate(tenant.createdAt) }}</p>
+          </div>
+          <div>
+            <label class="text-xs font-medium uppercase text-gray-400">Updated</label>
+            <p class="mt-1 text-sm text-gray-700">{{ formatDate(tenant.updatedAt) }}</p>
+          </div>
+        </div>
+      </div>
+
+      <!-- Tabs -->
+      <div class="mt-4 border-b">
+        <nav class="flex gap-6">
+          <button
+            v-for="tab in (['info', 'members', 'short-links', 'domains'] as const)"
+            :key="tab"
+            class="whitespace-nowrap border-b-2 pb-3 pt-2 text-sm font-medium transition-colors"
+            :class="activeTab === tab
+              ? 'border-blue-600 text-blue-600'
+              : 'border-transparent text-gray-500 hover:text-gray-700'"
+            @click="onTabChange(tab)"
+          >
+            {{ tab === 'short-links' ? 'Short Links' : tab.charAt(0).toUpperCase() + tab.slice(1) }}
+          </button>
+        </nav>
+      </div>
+
+      <!-- Tab content -->
+      <div class="mt-4">
+        <!-- Info tab -->
+        <div v-if="activeTab === 'info'" class="rounded-lg border bg-white p-5">
+          <div class="grid gap-4 sm:grid-cols-2">
+            <div>
+              <label class="text-xs font-medium uppercase text-gray-400">Name</label>
+              <p class="mt-1 text-sm text-gray-900">{{ tenant.name }}</p>
+            </div>
+            <div>
+              <label class="text-xs font-medium uppercase text-gray-400">Slug</label>
+              <p class="mt-1 font-mono text-sm text-gray-900">{{ tenant.slug }}</p>
+            </div>
+          </div>
+        </div>
+
+        <!-- Members tab -->
+        <div v-if="activeTab === 'members'">
+          <div v-if="membersLoading" class="flex items-center justify-center rounded-lg border bg-white py-8">
+            <Loader2 class="h-5 w-5 animate-spin text-gray-400" />
+          </div>
+          <div v-else class="overflow-hidden rounded-lg border bg-white">
+            <table class="w-full text-sm">
+              <thead>
+                <tr class="border-b bg-gray-50 text-left text-xs font-medium uppercase tracking-wider text-gray-500">
+                  <th class="px-4 py-3">Username</th>
+                  <th class="px-4 py-3">Role</th>
+                  <th class="hidden px-4 py-3 lg:table-cell">Joined</th>
+                </tr>
+              </thead>
+              <tbody class="divide-y">
+                <tr v-if="members.length === 0">
+                  <td colspan="3" class="px-4 py-8 text-center text-gray-400">No members.</td>
+                </tr>
+                <tr v-for="m in members" :key="m.userId" class="transition-colors hover:bg-gray-50">
+                  <td class="px-4 py-3">
+                    <div class="flex items-center gap-2">
+                      <div class="flex h-7 w-7 items-center justify-center rounded-full bg-gray-100 text-xs font-bold text-gray-600">
+                        {{ m.username.charAt(0).toUpperCase() }}
+                      </div>
+                      <span class="font-medium text-gray-900">{{ m.username }}</span>
+                    </div>
+                  </td>
+                  <td class="px-4 py-3">
+                    <span
+                      class="inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium"
+                      :class="m.role === 'admin' ? 'bg-blue-50 text-blue-700' : 'bg-gray-100 text-gray-600'"
+                    >
+                      {{ m.role }}
+                    </span>
+                  </td>
+                  <td class="hidden whitespace-nowrap px-4 py-3 text-gray-500 lg:table-cell">
+                    {{ formatDate(m.joinedAt) }}
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+
+        <!-- Short Links tab -->
+        <div v-if="activeTab === 'short-links'">
+          <div v-if="shortLinksLoading" class="flex items-center justify-center rounded-lg border bg-white py-8">
+            <Loader2 class="h-5 w-5 animate-spin text-gray-400" />
+          </div>
+          <div v-else class="overflow-hidden rounded-lg border bg-white">
+            <table class="w-full text-sm">
+              <thead>
+                <tr class="border-b bg-gray-50 text-left text-xs font-medium uppercase tracking-wider text-gray-500">
+                  <th class="px-4 py-3">ID</th>
+                  <th class="hidden px-4 py-3 md:table-cell">URL</th>
+                  <th class="px-4 py-3">Status</th>
+                  <th class="hidden px-4 py-3 lg:table-cell">Created By</th>
+                  <th class="hidden px-4 py-3 lg:table-cell">Created</th>
+                </tr>
+              </thead>
+              <tbody class="divide-y">
+                <tr v-if="shortLinks.length === 0">
+                  <td colspan="5" class="px-4 py-8 text-center text-gray-400">No short links.</td>
+                </tr>
+                <tr v-for="sl in shortLinks" :key="sl.id" class="transition-colors hover:bg-gray-50">
+                  <td class="px-4 py-3 font-mono text-sm font-medium text-gray-900">{{ sl.shortId || sl.id }}</td>
+                  <td class="hidden max-w-[240px] truncate px-4 py-3 text-gray-500 md:table-cell">{{ sl.originalURL }}</td>
+                  <td class="px-4 py-3">
+                    <span
+                      class="inline-flex items-center gap-1.5 rounded-full px-2 py-0.5 text-xs font-medium"
+                      :class="sl.isActive ? 'bg-green-50 text-green-700' : 'bg-gray-100 text-gray-500'"
+                    >
+                      <span class="h-1.5 w-1.5 rounded-full" :class="sl.isActive ? 'bg-green-500' : 'bg-gray-400'" />
+                      {{ sl.isActive ? 'Active' : 'Inactive' }}
+                    </span>
+                  </td>
+                  <td class="hidden px-4 py-3 text-gray-500 lg:table-cell">{{ sl.username }}</td>
+                  <td class="hidden whitespace-nowrap px-4 py-3 text-gray-500 lg:table-cell">{{ formatDate(sl.createdAt) }}</td>
+                </tr>
+              </tbody>
+            </table>
+            <div v-if="shortLinksTotal > 20" class="border-t px-4 py-3 text-center text-xs text-gray-400">
+              Showing 20 of {{ shortLinksTotal }}
+            </div>
+          </div>
+        </div>
+
+        <!-- Domains tab -->
+        <div v-if="activeTab === 'domains'">
+          <!-- Add domain -->
+          <div class="mb-4 rounded-lg border bg-white p-4">
+            <div class="flex flex-col gap-3 sm:flex-row sm:items-end">
+              <div class="flex-1">
+                <label class="mb-1 block text-sm font-medium text-gray-700">Domain</label>
+                <input
+                  v-model="newDomain"
+                  type="text"
+                  placeholder="example.com"
+                  class="w-full rounded-md border border-gray-300 px-3 py-2 font-mono text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
+                  @keydown.enter.prevent="handleAddDomain"
+                />
+              </div>
+              <button
+                :disabled="!newDomain.trim() || addingDomain"
+                class="inline-flex items-center gap-1.5 rounded-md bg-blue-600 px-3 py-2 text-sm font-medium text-white transition-colors hover:bg-blue-700 disabled:opacity-50"
+                @click="handleAddDomain"
+              >
+                <Loader2 v-if="addingDomain" class="h-3.5 w-3.5 animate-spin" />
+                <Plus v-else class="h-3.5 w-3.5" />
+                Add
+              </button>
+            </div>
+          </div>
+
+          <div v-if="domainsLoading" class="flex items-center justify-center rounded-lg border bg-white py-8">
+            <Loader2 class="h-5 w-5 animate-spin text-gray-400" />
+          </div>
+          <div v-else-if="domains.length > 0" class="overflow-hidden rounded-lg border bg-white">
+            <table class="w-full text-sm">
+              <thead>
+                <tr class="border-b bg-gray-50 text-left text-xs font-medium uppercase tracking-wider text-gray-500">
+                  <th class="px-4 py-3">Domain</th>
+                  <th class="px-4 py-3">Default</th>
+                  <th class="hidden px-4 py-3 lg:table-cell">Created</th>
+                  <th class="px-4 py-3 text-right">Actions</th>
+                </tr>
+              </thead>
+              <tbody class="divide-y">
+                <tr v-for="d in domains" :key="d.id" class="transition-colors hover:bg-gray-50">
+                  <td class="px-4 py-3">
+                    <div class="flex items-center gap-2">
+                      <Globe class="h-4 w-4 text-gray-400" />
+                      <span class="font-mono text-sm text-gray-900">{{ d.domain }}</span>
+                    </div>
+                  </td>
+                  <td class="px-4 py-3">
+                    <span v-if="d.isDefault" class="inline-flex items-center gap-1 text-xs font-medium text-yellow-600">
+                      <Star class="h-3.5 w-3.5 fill-yellow-500 text-yellow-500" />
+                      Default
+                    </span>
+                    <span v-else class="text-xs text-gray-400">-</span>
+                  </td>
+                  <td class="hidden whitespace-nowrap px-4 py-3 text-gray-500 lg:table-cell">{{ formatDate(d.createdAt) }}</td>
+                  <td class="px-4 py-3">
+                    <div class="flex items-center justify-end gap-1">
+                      <a
+                        :href="'https://' + d.domain"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        class="rounded p-1.5 text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-600"
+                      >
+                        <ExternalLink class="h-4 w-4" />
+                      </a>
+                      <button
+                        class="rounded p-1.5 text-gray-400 transition-colors hover:bg-red-50 hover:text-red-600"
+                        @click="confirmDeleteDomain = d.domain"
+                      >
+                        <Trash2 class="h-4 w-4" />
+                      </button>
+                    </div>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+          <div v-else class="rounded-lg border bg-white py-8 text-center text-sm text-gray-400">
+            No domains configured.
+          </div>
+        </div>
+      </div>
+    </template>
+
+    <!-- Delete domain confirmation -->
+    <Teleport to="body">
+      <div
+        v-if="confirmDeleteDomain"
+        class="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+        @click.self="confirmDeleteDomain = null"
+      >
+        <div class="mx-4 w-full max-w-sm rounded-lg bg-white p-6 shadow-xl">
+          <h3 class="text-lg font-semibold text-gray-900">Remove Domain</h3>
+          <p class="mt-2 text-sm text-gray-500">
+            Are you sure you want to remove
+            <span class="font-mono font-medium text-gray-700">{{ confirmDeleteDomain }}</span>?
+          </p>
+          <div class="mt-4 flex justify-end gap-2">
+            <button
+              class="rounded-md px-4 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-100"
+              @click="confirmDeleteDomain = null"
+            >
+              Cancel
+            </button>
+            <button
+              :disabled="deletingDomain"
+              class="rounded-md bg-red-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-red-700 disabled:opacity-50"
+              @click="handleDeleteDomain(confirmDeleteDomain!)"
+            >
+              {{ deletingDomain ? 'Removing...' : 'Remove' }}
+            </button>
+          </div>
+        </div>
+      </div>
+    </Teleport>
+  </div>
+</template>

--- a/web-ui/src/pages/super/SuperTenantDetailPage.vue
+++ b/web-ui/src/pages/super/SuperTenantDetailPage.vue
@@ -3,8 +3,8 @@ import { ref, onMounted } from 'vue'
 import { useRouter, useRoute } from 'vue-router'
 import { getTenant, listDomains, addDomain, removeDomain } from '@/api/tenant'
 import { listSuperTenantMembers, listSuperTenantShortLinks, setSuperTenantStatus } from '@/api/super'
-import type { Tenant, TenantDomain } from '@/types/api'
-import type { SuperTenantMember, SuperTenantShortLink } from '@/types/api'
+import type { Tenant, TenantDomain, ShortLinkData } from '@/types/api'
+import type { SuperTenantMember } from '@/types/api'
 import {
   ArrowLeft,
   Globe,
@@ -33,7 +33,7 @@ const members = ref<SuperTenantMember[]>([])
 const membersLoading = ref(false)
 
 // Short links
-const shortLinks = ref<SuperTenantShortLink[]>([])
+const shortLinks = ref<ShortLinkData[]>([])
 const shortLinksTotal = ref(0)
 const shortLinksPage = ref(1)
 const shortLinksLoading = ref(false)
@@ -340,19 +340,19 @@ onMounted(fetchTenant)
                   <td colspan="5" class="px-4 py-8 text-center text-gray-400">No short links.</td>
                 </tr>
                 <tr v-for="sl in shortLinks" :key="sl.id" class="transition-colors hover:bg-gray-50">
-                  <td class="px-4 py-3 font-mono text-sm font-medium text-gray-900">{{ sl.shortId || sl.id }}</td>
-                  <td class="hidden max-w-[240px] truncate px-4 py-3 text-gray-500 md:table-cell">{{ sl.originalURL }}</td>
+                  <td class="px-4 py-3 font-mono text-sm font-medium text-gray-900">{{ sl.id }}</td>
+                  <td class="hidden max-w-[240px] truncate px-4 py-3 text-gray-500 md:table-cell">{{ sl.url }}</td>
                   <td class="px-4 py-3">
                     <span
                       class="inline-flex items-center gap-1.5 rounded-full px-2 py-0.5 text-xs font-medium"
-                      :class="sl.isActive ? 'bg-green-50 text-green-700' : 'bg-gray-100 text-gray-500'"
+                      :class="sl.isEnable ? 'bg-green-50 text-green-700' : 'bg-gray-100 text-gray-500'"
                     >
-                      <span class="h-1.5 w-1.5 rounded-full" :class="sl.isActive ? 'bg-green-500' : 'bg-gray-400'" />
-                      {{ sl.isActive ? 'Active' : 'Inactive' }}
+                      <span class="h-1.5 w-1.5 rounded-full" :class="sl.isEnable ? 'bg-green-500' : 'bg-gray-400'" />
+                      {{ sl.isEnable ? 'Active' : 'Inactive' }}
                     </span>
                   </td>
-                  <td class="hidden px-4 py-3 text-gray-500 lg:table-cell">{{ sl.username }}</td>
-                  <td class="hidden whitespace-nowrap px-4 py-3 text-gray-500 lg:table-cell">{{ formatDate(sl.createdAt) }}</td>
+                  <td class="hidden px-4 py-3 text-gray-500 lg:table-cell">{{ sl.createdBy }}</td>
+                  <td class="hidden whitespace-nowrap px-4 py-3 text-gray-500 lg:table-cell">{{ formatDate(sl.createTime) }}</td>
                 </tr>
               </tbody>
             </table>

--- a/web-ui/src/pages/super/SuperTenantsPage.vue
+++ b/web-ui/src/pages/super/SuperTenantsPage.vue
@@ -1,0 +1,183 @@
+<script setup lang="ts">
+import { ref, onMounted } from 'vue'
+import { useRouter } from 'vue-router'
+import { listSuperTenants, setSuperTenantStatus } from '@/api/super'
+import type { SuperTenant } from '@/types/api'
+import {
+  Building2,
+  Eye,
+  ChevronLeft,
+  ChevronRight,
+  Loader2,
+} from 'lucide-vue-next'
+
+defineOptions({ name: 'SuperTenantsPage' })
+
+const router = useRouter()
+
+const tenants = ref<SuperTenant[]>([])
+const loading = ref(false)
+const page = ref(1)
+const pageSize = 20
+const total = ref(0)
+const toggleLoading = ref<string | null>(null)
+
+async function fetchTenants() {
+  loading.value = true
+  try {
+    const data = await listSuperTenants(page.value, pageSize)
+    tenants.value = data.tenants || []
+    total.value = data.total
+  } catch {
+    // error handled by interceptor
+  } finally {
+    loading.value = false
+  }
+}
+
+function goToPage(p: number) {
+  const maxPage = Math.ceil(total.value / pageSize) || 1
+  if (p < 1 || p > maxPage) return
+  page.value = p
+  fetchTenants()
+}
+
+async function handleToggleStatus(tenant: SuperTenant) {
+  toggleLoading.value = tenant.id
+  try {
+    await setSuperTenantStatus(tenant.id, { isActive: !tenant.isActive })
+    tenant.isActive = !tenant.isActive
+  } catch {
+    // error handled by interceptor
+  } finally {
+    toggleLoading.value = null
+  }
+}
+
+function formatDate(d: string) {
+  return new Date(d).toLocaleDateString(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  })
+}
+
+onMounted(fetchTenants)
+</script>
+
+<template>
+  <div>
+    <div>
+      <h1 class="text-xl font-semibold text-gray-900">Tenant Management</h1>
+      <p class="mt-1 text-sm text-gray-500">{{ total }} tenant{{ total !== 1 ? 's' : '' }} total</p>
+    </div>
+
+    <!-- Table -->
+    <div class="mt-4 overflow-hidden rounded-lg border bg-white">
+      <div class="overflow-x-auto">
+        <table class="w-full text-sm">
+          <thead>
+            <tr class="border-b bg-gray-50 text-left text-xs font-medium uppercase tracking-wider text-gray-500">
+              <th class="px-4 py-3">Name</th>
+              <th class="px-4 py-3">Slug</th>
+              <th class="px-4 py-3">Status</th>
+              <th class="hidden px-4 py-3 lg:table-cell">Created</th>
+              <th class="px-4 py-3 text-right">Actions</th>
+            </tr>
+          </thead>
+          <tbody class="divide-y">
+            <tr v-if="loading">
+              <td colspan="5" class="px-4 py-8 text-center text-gray-400">
+                <Loader2 class="inline h-5 w-5 animate-spin" />
+              </td>
+            </tr>
+            <tr v-else-if="tenants.length === 0">
+              <td colspan="5" class="px-4 py-8 text-center text-gray-400">
+                <div class="flex flex-col items-center gap-2">
+                  <Building2 class="h-8 w-8 text-gray-300" />
+                  <span>No tenants found.</span>
+                </div>
+              </td>
+            </tr>
+            <tr
+              v-for="tenant in tenants"
+              :key="tenant.id"
+              class="transition-colors hover:bg-gray-50"
+            >
+              <td class="px-4 py-3">
+                <div class="flex items-center gap-2">
+                  <div
+                    class="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-blue-50 text-xs font-bold text-blue-600"
+                  >
+                    {{ tenant.name.charAt(0).toUpperCase() }}
+                  </div>
+                  <div>
+                    <p class="font-medium text-gray-900">{{ tenant.name }}</p>
+                    <p class="text-xs text-gray-400">{{ tenant.id }}</p>
+                  </div>
+                </div>
+              </td>
+              <td class="px-4 py-3">
+                <span class="font-mono text-sm text-gray-600">{{ tenant.slug }}</span>
+              </td>
+              <td class="px-4 py-3">
+                <button
+                  :disabled="toggleLoading === tenant.id"
+                  class="inline-flex items-center gap-1.5 rounded-full px-2.5 py-0.5 text-xs font-medium transition-colors"
+                  :class="[
+                    tenant.isActive ? 'bg-green-50 text-green-700 hover:bg-green-100' : 'bg-gray-100 text-gray-500 hover:bg-gray-200',
+                    toggleLoading === tenant.id ? 'opacity-50' : 'cursor-pointer',
+                  ]"
+                  @click="handleToggleStatus(tenant)"
+                >
+                  <Loader2 v-if="toggleLoading === tenant.id" class="h-3 w-3 animate-spin" />
+                  <span v-else class="h-1.5 w-1.5 rounded-full" :class="tenant.isActive ? 'bg-green-500' : 'bg-gray-400'" />
+                  {{ tenant.isActive ? 'Active' : 'Inactive' }}
+                </button>
+              </td>
+              <td class="hidden whitespace-nowrap px-4 py-3 text-gray-500 lg:table-cell">
+                {{ formatDate(tenant.createdAt) }}
+              </td>
+              <td class="px-4 py-3">
+                <div class="flex items-center justify-end gap-1">
+                  <button
+                    class="rounded p-1.5 text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-600"
+                    title="View details"
+                    @click="router.push({ name: 'super-tenant-detail', params: { id: tenant.id } })"
+                  >
+                    <Eye class="h-4 w-4" />
+                  </button>
+                </div>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <!-- Pagination -->
+      <div v-if="total > pageSize" class="flex items-center justify-between border-t px-4 py-3">
+        <p class="text-xs text-gray-500">
+          Page {{ page }} of {{ Math.ceil(total / pageSize) }} ({{ total }} total)
+        </p>
+        <div class="flex items-center gap-1">
+          <button
+            :disabled="page <= 1"
+            class="rounded p-1.5 text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-600 disabled:opacity-50"
+            @click="goToPage(page - 1)"
+          >
+            <ChevronLeft class="h-4 w-4" />
+          </button>
+          <button
+            :disabled="page >= Math.ceil(total / pageSize)"
+            class="rounded p-1.5 text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-600 disabled:opacity-50"
+            @click="goToPage(page + 1)"
+          >
+            <ChevronRight class="h-4 w-4" />
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>

--- a/web-ui/src/pages/super/SuperUsersPage.vue
+++ b/web-ui/src/pages/super/SuperUsersPage.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, onMounted } from 'vue'
+import { ref, computed, onMounted } from 'vue'
 import {
   listSuperUsers,
   createSuperUser,
@@ -73,7 +73,7 @@ function goToPage(p: number) {
   fetchUsers()
 }
 
-const totalPages = ref(0)
+const totalPages = computed(() => Math.ceil(total.value / pageSize) || 1)
 
 async function handleCreate() {
   if (!newUsername.value.trim() || !newPassword.value.trim()) return

--- a/web-ui/src/pages/super/SuperUsersPage.vue
+++ b/web-ui/src/pages/super/SuperUsersPage.vue
@@ -1,0 +1,487 @@
+<script setup lang="ts">
+import { ref, onMounted } from 'vue'
+import {
+  listSuperUsers,
+  createSuperUser,
+  resetSuperUserPassword,
+  setSuperUserStatus,
+  getSuperUser,
+} from '@/api/super'
+import type { SuperUser, SuperUserDetail } from '@/types/api'
+import {
+  Users,
+  Search,
+  Plus,
+  KeyRound,
+  Loader2,
+  ChevronLeft,
+  ChevronRight,
+  Eye,
+  X,
+  Shield,
+} from 'lucide-vue-next'
+
+defineOptions({ name: 'SuperUsersPage' })
+
+const users = ref<SuperUser[]>([])
+const loading = ref(false)
+const search = ref('')
+const page = ref(1)
+const pageSize = 20
+const total = ref(0)
+
+const showCreateModal = ref(false)
+const createLoading = ref(false)
+const newUsername = ref('')
+const newPassword = ref('')
+const createError = ref('')
+
+const showResetModal = ref(false)
+const resetUserId = ref('')
+const resetUsername = ref('')
+const resetNewPassword = ref('')
+const resetLoading = ref(false)
+const resetError = ref('')
+
+const showDetailModal = ref(false)
+const detailLoading = ref(false)
+const userDetail = ref<SuperUserDetail | null>(null)
+
+const toggleLoading = ref<string | null>(null)
+
+async function fetchUsers() {
+  loading.value = true
+  try {
+    const data = await listSuperUsers(page.value, pageSize, search.value)
+    users.value = data.users || []
+    total.value = data.total
+  } catch {
+    // error handled by interceptor
+  } finally {
+    loading.value = false
+  }
+}
+
+function handleSearch() {
+  page.value = 1
+  fetchUsers()
+}
+
+function goToPage(p: number) {
+  if (p < 1 || p > totalPages.value) return
+  page.value = p
+  fetchUsers()
+}
+
+const totalPages = ref(0)
+
+async function handleCreate() {
+  if (!newUsername.value.trim() || !newPassword.value.trim()) return
+  createLoading.value = true
+  createError.value = ''
+  try {
+    await createSuperUser({ username: newUsername.value.trim(), password: newPassword.value.trim() })
+    showCreateModal.value = false
+    newUsername.value = ''
+    newPassword.value = ''
+    fetchUsers()
+  } catch (e) {
+    createError.value = e instanceof Error ? e.message : 'Failed to create user'
+  } finally {
+    createLoading.value = false
+  }
+}
+
+function openResetModal(user: SuperUser) {
+  resetUserId.value = user.id
+  resetUsername.value = user.username
+  resetNewPassword.value = ''
+  resetError.value = ''
+  showResetModal.value = true
+}
+
+async function handleReset() {
+  if (!resetNewPassword.value.trim()) return
+  resetLoading.value = true
+  resetError.value = ''
+  try {
+    await resetSuperUserPassword(resetUserId.value, { newPassword: resetNewPassword.value.trim() })
+    showResetModal.value = false
+  } catch (e) {
+    resetError.value = e instanceof Error ? e.message : 'Failed to reset password'
+  } finally {
+    resetLoading.value = false
+  }
+}
+
+async function handleToggleStatus(user: SuperUser) {
+  toggleLoading.value = user.id
+  try {
+    await setSuperUserStatus(user.id, { isActive: !user.isActive })
+    fetchUsers()
+  } catch {
+    // error handled by interceptor
+  } finally {
+    toggleLoading.value = null
+  }
+}
+
+async function openDetailModal(user: SuperUser) {
+  detailLoading.value = true
+  showDetailModal.value = true
+  try {
+    userDetail.value = await getSuperUser(user.id)
+  } catch {
+    // error handled by interceptor
+  } finally {
+    detailLoading.value = false
+  }
+}
+
+function formatDate(d: string) {
+  return new Date(d).toLocaleDateString(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  })
+}
+
+onMounted(fetchUsers)
+</script>
+
+<template>
+  <div>
+    <div class="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+      <div>
+        <h1 class="text-xl font-semibold text-gray-900">User Management</h1>
+        <p class="mt-1 text-sm text-gray-500">{{ total }} user{{ total !== 1 ? 's' : '' }} total</p>
+      </div>
+      <button
+        class="inline-flex items-center gap-2 rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-blue-700"
+        @click="showCreateModal = true"
+      >
+        <Plus class="h-4 w-4" />
+        Create User
+      </button>
+    </div>
+
+    <!-- Search -->
+    <div class="mt-4 flex flex-col gap-3 rounded-lg border bg-white p-4 sm:flex-row sm:items-center">
+      <div class="relative flex-1">
+        <Search class="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400" />
+        <input
+          v-model="search"
+          type="text"
+          placeholder="Search by username..."
+          class="w-full rounded-md border border-gray-300 py-2 pl-9 pr-3 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
+          @keydown.enter="handleSearch"
+        />
+      </div>
+      <button
+        class="rounded-md bg-gray-100 px-4 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-200"
+        @click="handleSearch"
+      >
+        Search
+      </button>
+    </div>
+
+    <!-- Table -->
+    <div class="mt-4 overflow-hidden rounded-lg border bg-white">
+      <div class="overflow-x-auto">
+        <table class="w-full text-sm">
+          <thead>
+            <tr class="border-b bg-gray-50 text-left text-xs font-medium uppercase tracking-wider text-gray-500">
+              <th class="px-4 py-3">Username</th>
+              <th class="px-4 py-3">Status</th>
+              <th class="hidden px-4 py-3 md:table-cell">Super Admin</th>
+              <th class="hidden px-4 py-3 lg:table-cell">Created</th>
+              <th class="px-4 py-3 text-right">Actions</th>
+            </tr>
+          </thead>
+          <tbody class="divide-y">
+            <tr v-if="loading">
+              <td colspan="5" class="px-4 py-8 text-center text-gray-400">
+                <Loader2 class="inline h-5 w-5 animate-spin" />
+              </td>
+            </tr>
+            <tr v-else-if="users.length === 0">
+              <td colspan="5" class="px-4 py-8 text-center text-gray-400">
+                <div class="flex flex-col items-center gap-2">
+                  <Users class="h-8 w-8 text-gray-300" />
+                  <span>No users found.</span>
+                </div>
+              </td>
+            </tr>
+            <tr
+              v-for="user in users"
+              :key="user.id"
+              class="transition-colors hover:bg-gray-50"
+            >
+              <td class="px-4 py-3">
+                <div class="flex items-center gap-2">
+                  <div class="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-gray-100 text-xs font-bold text-gray-600">
+                    {{ user.username.charAt(0).toUpperCase() }}
+                  </div>
+                  <div>
+                    <p class="font-medium text-gray-900">{{ user.username }}</p>
+                    <p class="text-xs text-gray-400">{{ user.id }}</p>
+                  </div>
+                </div>
+              </td>
+              <td class="px-4 py-3">
+                <button
+                  :disabled="toggleLoading === user.id || user.isSuper"
+                  class="inline-flex items-center gap-1.5 rounded-full px-2.5 py-0.5 text-xs font-medium transition-colors"
+                  :class="[
+                    user.isActive ? 'bg-green-50 text-green-700 hover:bg-green-100' : 'bg-gray-100 text-gray-500 hover:bg-gray-200',
+                    (user.isSuper || toggleLoading === user.id) ? 'cursor-not-allowed opacity-50' : 'cursor-pointer',
+                  ]"
+                  @click="handleToggleStatus(user)"
+                >
+                  <Loader2 v-if="toggleLoading === user.id" class="h-3 w-3 animate-spin" />
+                  <span v-else class="h-1.5 w-1.5 rounded-full" :class="user.isActive ? 'bg-green-500' : 'bg-gray-400'" />
+                  {{ user.isActive ? 'Active' : 'Disabled' }}
+                </button>
+              </td>
+              <td class="hidden px-4 py-3 md:table-cell">
+                <span v-if="user.isSuper" class="inline-flex items-center gap-1 text-xs font-medium text-indigo-600">
+                  <Shield class="h-3.5 w-3.5" />
+                  Super
+                </span>
+                <span v-else class="text-xs text-gray-400">-</span>
+              </td>
+              <td class="hidden whitespace-nowrap px-4 py-3 text-gray-500 lg:table-cell">
+                {{ formatDate(user.createdAt) }}
+              </td>
+              <td class="px-4 py-3">
+                <div class="flex items-center justify-end gap-1">
+                  <button
+                    class="rounded p-1.5 text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-600"
+                    title="View details"
+                    @click="openDetailModal(user)"
+                  >
+                    <Eye class="h-4 w-4" />
+                  </button>
+                  <button
+                    class="rounded p-1.5 text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-600"
+                    title="Reset password"
+                    @click="openResetModal(user)"
+                  >
+                    <KeyRound class="h-4 w-4" />
+                  </button>
+                </div>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <!-- Pagination -->
+      <div v-if="total > pageSize" class="flex items-center justify-between border-t px-4 py-3">
+        <p class="text-xs text-gray-500">
+          Page {{ page }} of {{ Math.ceil(total / pageSize) }} ({{ total }} total)
+        </p>
+        <div class="flex items-center gap-1">
+          <button
+            :disabled="page <= 1"
+            class="rounded p-1.5 text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-600 disabled:opacity-50"
+            @click="goToPage(page - 1)"
+          >
+            <ChevronLeft class="h-4 w-4" />
+          </button>
+          <button
+            :disabled="page >= Math.ceil(total / pageSize)"
+            class="rounded p-1.5 text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-600 disabled:opacity-50"
+            @click="goToPage(page + 1)"
+          >
+            <ChevronRight class="h-4 w-4" />
+          </button>
+        </div>
+      </div>
+    </div>
+
+    <!-- Create User Modal -->
+    <Teleport to="body">
+      <div
+        v-if="showCreateModal"
+        class="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+        @click.self="showCreateModal = false"
+      >
+        <div class="mx-4 w-full max-w-md rounded-lg bg-white p-6 shadow-xl">
+          <div class="flex items-center justify-between">
+            <h3 class="text-lg font-semibold text-gray-900">Create User</h3>
+            <button class="rounded p-1 text-gray-400 hover:text-gray-600" @click="showCreateModal = false">
+              <X class="h-5 w-5" />
+            </button>
+          </div>
+          <div class="mt-4 space-y-4">
+            <div>
+              <label class="mb-1 block text-sm font-medium text-gray-700">Username</label>
+              <input
+                v-model="newUsername"
+                type="text"
+                class="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
+                @keydown.enter="handleCreate"
+              />
+            </div>
+            <div>
+              <label class="mb-1 block text-sm font-medium text-gray-700">Password</label>
+              <input
+                v-model="newPassword"
+                type="password"
+                class="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
+                @keydown.enter="handleCreate"
+              />
+            </div>
+            <p v-if="createError" class="text-sm text-red-600">{{ createError }}</p>
+          </div>
+          <div class="mt-5 flex justify-end gap-2">
+            <button
+              class="rounded-md px-4 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-100"
+              @click="showCreateModal = false"
+            >
+              Cancel
+            </button>
+            <button
+              :disabled="createLoading || !newUsername.trim() || !newPassword.trim()"
+              class="rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-blue-700 disabled:opacity-50"
+              @click="handleCreate"
+            >
+              <Loader2 v-if="createLoading" class="mr-1 inline h-4 w-4 animate-spin" />
+              Create
+            </button>
+          </div>
+        </div>
+      </div>
+    </Teleport>
+
+    <!-- Reset Password Modal -->
+    <Teleport to="body">
+      <div
+        v-if="showResetModal"
+        class="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+        @click.self="showResetModal = false"
+      >
+        <div class="mx-4 w-full max-w-md rounded-lg bg-white p-6 shadow-xl">
+          <div class="flex items-center justify-between">
+            <h3 class="text-lg font-semibold text-gray-900">Reset Password</h3>
+            <button class="rounded p-1 text-gray-400 hover:text-gray-600" @click="showResetModal = false">
+              <X class="h-5 w-5" />
+            </button>
+          </div>
+          <p class="mt-2 text-sm text-gray-500">
+            Reset password for <span class="font-medium text-gray-700">{{ resetUsername }}</span>
+          </p>
+          <div class="mt-4">
+            <label class="mb-1 block text-sm font-medium text-gray-700">New Password</label>
+            <input
+              v-model="resetNewPassword"
+              type="password"
+              class="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
+              @keydown.enter="handleReset"
+            />
+            <p v-if="resetError" class="mt-2 text-sm text-red-600">{{ resetError }}</p>
+          </div>
+          <div class="mt-5 flex justify-end gap-2">
+            <button
+              class="rounded-md px-4 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-100"
+              @click="showResetModal = false"
+            >
+              Cancel
+            </button>
+            <button
+              :disabled="resetLoading || !resetNewPassword.trim()"
+              class="rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-blue-700 disabled:opacity-50"
+              @click="handleReset"
+            >
+              <Loader2 v-if="resetLoading" class="mr-1 inline h-4 w-4 animate-spin" />
+              Reset
+            </button>
+          </div>
+        </div>
+      </div>
+    </Teleport>
+
+    <!-- User Detail Modal -->
+    <Teleport to="body">
+      <div
+        v-if="showDetailModal"
+        class="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+        @click.self="showDetailModal = false"
+      >
+        <div class="mx-4 w-full max-w-lg rounded-lg bg-white p-6 shadow-xl">
+          <div class="flex items-center justify-between">
+            <h3 class="text-lg font-semibold text-gray-900">User Details</h3>
+            <button class="rounded p-1 text-gray-400 hover:text-gray-600" @click="showDetailModal = false">
+              <X class="h-5 w-5" />
+            </button>
+          </div>
+
+          <div v-if="detailLoading" class="mt-4 flex justify-center py-8">
+            <Loader2 class="h-5 w-5 animate-spin text-gray-400" />
+          </div>
+
+          <template v-else-if="userDetail">
+            <div class="mt-4 space-y-3">
+              <div class="flex items-center gap-3">
+                <div class="flex h-10 w-10 items-center justify-center rounded-full bg-gray-100 text-sm font-bold text-gray-600">
+                  {{ userDetail.username.charAt(0).toUpperCase() }}
+                </div>
+                <div>
+                  <p class="font-medium text-gray-900">{{ userDetail.username }}</p>
+                  <p class="text-xs text-gray-400 font-mono">{{ userDetail.id }}</p>
+                </div>
+                <span
+                  class="ml-auto inline-flex items-center gap-1.5 rounded-full px-2.5 py-0.5 text-xs font-medium"
+                  :class="userDetail.isActive ? 'bg-green-50 text-green-700' : 'bg-gray-100 text-gray-500'"
+                >
+                  <span class="h-1.5 w-1.5 rounded-full" :class="userDetail.isActive ? 'bg-green-500' : 'bg-gray-400'" />
+                  {{ userDetail.isActive ? 'Active' : 'Disabled' }}
+                </span>
+              </div>
+
+              <div class="rounded-lg border bg-gray-50 p-3 text-sm">
+                <div class="grid gap-2 sm:grid-cols-2">
+                  <div>
+                    <span class="text-xs text-gray-400">Super Admin</span>
+                    <p class="font-medium" :class="userDetail.isSuper ? 'text-indigo-600' : 'text-gray-600'">
+                      {{ userDetail.isSuper ? 'Yes' : 'No' }}
+                    </p>
+                  </div>
+                  <div>
+                    <span class="text-xs text-gray-400">Created</span>
+                    <p class="font-medium text-gray-600">{{ formatDate(userDetail.createdAt) }}</p>
+                  </div>
+                </div>
+              </div>
+
+              <div>
+                <h4 class="mb-2 text-sm font-medium text-gray-700">Tenant Memberships</h4>
+                <div v-if="userDetail.tenants.length === 0" class="text-sm text-gray-400">
+                  No tenant memberships.
+                </div>
+                <div v-else class="space-y-1.5">
+                  <div
+                    v-for="t in userDetail.tenants"
+                    :key="t.tenantId"
+                    class="flex items-center justify-between rounded-md border bg-white px-3 py-2"
+                  >
+                    <span class="font-mono text-sm text-gray-700">{{ t.tenantId }}</span>
+                    <span
+                      class="inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium"
+                      :class="t.role === 'admin' ? 'bg-blue-50 text-blue-700' : 'bg-gray-100 text-gray-600'"
+                    >
+                      {{ t.role }}
+                    </span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </template>
+        </div>
+      </div>
+    </Teleport>
+  </div>
+</template>

--- a/web-ui/src/router/index.ts
+++ b/web-ui/src/router/index.ts
@@ -21,6 +21,7 @@ const router = createRouter({
       path: '/super',
       component: () => import('@/layouts/DefaultLayout.vue'),
       meta: { requiresAuth: true, requiresSuper: true },
+      redirect: { name: 'super-dashboard' },
       children: [
         {
           path: 'dashboard',

--- a/web-ui/src/router/index.ts
+++ b/web-ui/src/router/index.ts
@@ -18,6 +18,37 @@ const router = createRouter({
       meta: { requiresAuth: true, requiresTenant: false },
     },
     {
+      path: '/super',
+      component: () => import('@/layouts/DefaultLayout.vue'),
+      meta: { requiresAuth: true, requiresSuper: true },
+      children: [
+        {
+          path: 'dashboard',
+          name: 'super-dashboard',
+          component: () => import('@/pages/super/SuperDashboardPage.vue'),
+          meta: { title: 'Super Dashboard' },
+        },
+        {
+          path: 'users',
+          name: 'super-users',
+          component: () => import('@/pages/super/SuperUsersPage.vue'),
+          meta: { title: 'User Management' },
+        },
+        {
+          path: 'tenants',
+          name: 'super-tenants',
+          component: () => import('@/pages/super/SuperTenantsPage.vue'),
+          meta: { title: 'Tenant Management' },
+        },
+        {
+          path: 'tenants/:id',
+          name: 'super-tenant-detail',
+          component: () => import('@/pages/super/SuperTenantDetailPage.vue'),
+          meta: { title: 'Tenant Detail' },
+        },
+      ],
+    },
+    {
       path: '/',
       component: () => import('@/layouts/DefaultLayout.vue'),
       meta: { requiresAuth: true },
@@ -144,6 +175,10 @@ router.beforeEach(async (to) => {
 
   if (to.meta.requiredRole && auth.user?.role !== to.meta.requiredRole) {
     return { name: 'dashboard' }
+  }
+
+  if (to.meta.requiresSuper && !auth.isSuper) {
+    return { name: auth.currentTenantId ? 'dashboard' : 'select-tenant' }
   }
 
   if (to.name === 'login' && auth.isLoggedIn) {

--- a/web-ui/src/types/api.ts
+++ b/web-ui/src/types/api.ts
@@ -240,24 +240,6 @@ export interface SuperTenantMember {
   joinedAt: string
 }
 
-export interface SuperTenantShortLink {
-  id: string
-  shortId: string
-  originalURL: string
-  title: string
-  description: string
-  clickCount: number
-  isActive: boolean
-  createdAt: string
-  updatedAt: string
-  username: string
-}
-
-export interface ListSuperTenantShortLinksResponse {
-  shortLinks: SuperTenantShortLink[]
-  total: number
-}
-
 export interface SuperTenantDomain {
   id: string
   domain: string

--- a/web-ui/src/types/api.ts
+++ b/web-ui/src/types/api.ts
@@ -183,6 +183,88 @@ export interface AddDomainRequest {
   isDefault: boolean
 }
 
+// Super Admin types
+export interface SuperUser {
+  id: string
+  username: string
+  isActive: boolean
+  isSuper: boolean
+  createdAt: string
+  updatedAt: string
+  tenants?: { tenantId: string; role: string }[]
+}
+
+export interface SuperUserDetail extends SuperUser {
+  tenants: { tenantId: string; role: string }[]
+}
+
+export interface ListSuperUsersResponse {
+  users: SuperUser[]
+  total: number
+}
+
+export interface CreateSuperUserRequest {
+  username: string
+  password: string
+}
+
+export interface ResetPasswordRequest {
+  newPassword: string
+}
+
+export interface SetStatusRequest {
+  isActive: boolean
+}
+
+export interface SuperTenant {
+  id: string
+  name: string
+  slug: string
+  isActive: boolean
+  createdAt: string
+  updatedAt: string
+  memberCount?: number
+  shortLinkCount?: number
+  domainCount?: number
+}
+
+export interface ListSuperTenantsResponse {
+  tenants: SuperTenant[]
+  total: number
+}
+
+export interface SuperTenantMember {
+  userId: string
+  username: string
+  role: string
+  joinedAt: string
+}
+
+export interface SuperTenantShortLink {
+  id: string
+  shortId: string
+  originalURL: string
+  title: string
+  description: string
+  clickCount: number
+  isActive: boolean
+  createdAt: string
+  updatedAt: string
+  username: string
+}
+
+export interface ListSuperTenantShortLinksResponse {
+  shortLinks: SuperTenantShortLink[]
+  total: number
+}
+
+export interface SuperTenantDomain {
+  id: string
+  domain: string
+  isDefault: boolean
+  createdAt: string
+}
+
 export const UserRole = {
   Admin: 'admin',
   Member: 'member',


### PR DESCRIPTION
## Summary

- Add super admin dashboard (`/super/dashboard`) with platform stats (tenants, users, short links)
- Add user management page (`/super/users`) with search, pagination, create user, reset password, enable/disable, and detail view with tenant memberships
- Add tenant management page (`/super/tenants`) with pagination and enable/disable toggle
- Add tenant detail page (`/super/tenants/:id`) with tabbed views: Info, Members (read-only), Short Links (read-only), Domains (manageable)
- Route guard restricting `/super/*` to `isSuper` users, redirecting others to dashboard/tenant selection
- Sidebar toggle between normal and super admin modes; tenant switcher hidden on super routes
- API module (`api/super.ts`) for all super admin endpoints; HTTP interceptor skips `X-Tenant-ID` for `/super/*` routes

Closes [JWM-54](mention://issue/bc721e8a-fb92-41ca-933b-b04922915646)

## Test plan

- [ ] Verify super admin user sees "Super Admin" toggle in sidebar
- [ ] Navigate to `/super/dashboard`, confirm stats and tenant list render
- [ ] Navigate to `/super/users`, test search, pagination, create user modal, reset password modal, toggle user status, view user detail
- [ ] Navigate to `/super/tenants`, test pagination, toggle tenant status, click into tenant detail
- [ ] On tenant detail, test all tabs (Info, Members, Short Links, Domains) and domain add/remove
- [ ] Verify non-super user is redirected away from `/super/*` routes
- [ ] Verify normal sidebar menus still work after exiting super admin mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)