### PR TITLE
fix: remove Chinese text dependency in frontend error handling

### DIFF
--- a/internal/app/handlers/middleware.go
+++ b/internal/app/handlers/middleware.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"errors"
 	"fmt"
 	"log"
 	"net/http"
@@ -15,6 +16,16 @@ import (
 	"github.com/jwma/jump-jump/internal/app/utils"
 	"slices"
 )
+
+// writeErrorResponse returns 404 for NotFoundError, 200 for other errors.
+func writeErrorResponse(c *gin.Context, err error) {
+	status := http.StatusOK
+	var nf *models.NotFoundError
+	if errors.As(err, &nf) {
+		status = http.StatusNotFound
+	}
+	c.JSON(status, models.NewErrorResponse(err.Error()))
+}
 
 // AuthContext carries the authenticated user and their tenant membership for the current request.
 type AuthContext struct {

--- a/internal/app/handlers/preferences.go
+++ b/internal/app/handlers/preferences.go
@@ -24,7 +24,7 @@ func GetUserPreferencesAPI() gin.HandlerFunc {
 		repo := repository.GetUserPreferenceRepo(db.GetPostgresPool())
 		prefs, err := repo.GetAll(ctx.User.ID)
 		if err != nil {
-			c.JSON(http.StatusOK, models.NewErrorResponse(err.Error()))
+			writeErrorResponse(c, err)
 			return
 		}
 		c.JSON(http.StatusOK, models.NewSuccessResponse(map[string]interface{}{
@@ -58,7 +58,7 @@ func UpdateUserPreferencesAPI() gin.HandlerFunc {
 
 		repo := repository.GetUserPreferenceRepo(db.GetPostgresPool())
 		if err := repo.Upsert(ctx.User.ID, req.Preferences); err != nil {
-			c.JSON(http.StatusOK, models.NewErrorResponse(err.Error()))
+			writeErrorResponse(c, err)
 			return
 		}
 

--- a/internal/app/handlers/shortlink.go
+++ b/internal/app/handlers/shortlink.go
@@ -64,7 +64,7 @@ func toShortLinkDataWithUsername(s *models.ShortLink) *models.ShortLinkData {
 // checkTenantOwnership verifies that a short link belongs to the current tenant.
 func checkTenantOwnership(c *gin.Context, s *models.ShortLink) bool {
 	if s.TenantID != getTenantID(c) {
-		c.JSON(http.StatusOK, models.NewErrorResponse("短链接不存在"))
+		c.JSON(http.StatusNotFound, models.NewErrorResponse("短链接不存在"))
 		return false
 	}
 	return true
@@ -86,7 +86,7 @@ func GetShortLinkAPI() gin.HandlerFunc {
 		slRepo := repository.GetShortLinkRepo(db.GetPostgresPool(), db.GetRedisClient())
 		s, err := slRepo.Get(c.Param("id"))
 		if err != nil {
-			c.JSON(http.StatusOK, models.NewErrorResponse(err.Error()))
+			writeErrorResponse(c, err)
 			return
 		}
 
@@ -150,7 +150,7 @@ func CreateShortLinkAPI() gin.HandlerFunc {
 		}
 
 		if err := repo.Save(s); err != nil {
-			c.JSON(http.StatusOK, models.NewErrorResponse(err.Error()))
+			writeErrorResponse(c, err)
 			return
 		}
 
@@ -177,7 +177,7 @@ func UpdateShortLinkAPI() gin.HandlerFunc {
 		slRepo := repository.GetShortLinkRepo(db.GetPostgresPool(), db.GetRedisClient())
 		s, err := slRepo.Get(c.Param("id"))
 		if err != nil {
-			c.JSON(http.StatusOK, models.NewErrorResponse(err.Error()))
+			writeErrorResponse(c, err)
 			return
 		}
 
@@ -187,12 +187,12 @@ func UpdateShortLinkAPI() gin.HandlerFunc {
 
 		updateShortLink := &models.UpdateShortLinkAPIRequest{}
 		if err := c.ShouldBindJSON(updateShortLink); err != nil {
-			c.JSON(http.StatusOK, models.NewErrorResponse(err.Error()))
+			writeErrorResponse(c, err)
 			return
 		}
 
 		if err := slRepo.Update(s, updateShortLink); err != nil {
-			c.JSON(http.StatusOK, models.NewErrorResponse(err.Error()))
+			writeErrorResponse(c, err)
 			return
 		}
 
@@ -218,7 +218,7 @@ func DeleteShortLinkAPI() gin.HandlerFunc {
 		slRepo := repository.GetShortLinkRepo(db.GetPostgresPool(), db.GetRedisClient())
 		s, err := slRepo.Get(c.Param("id"))
 		if err != nil {
-			c.JSON(http.StatusOK, models.NewErrorResponse(err.Error()))
+			writeErrorResponse(c, err)
 			return
 		}
 
@@ -252,7 +252,7 @@ func ListShortLinksAPI() gin.HandlerFunc {
 		slRepo := repository.GetShortLinkRepo(db.GetPostgresPool(), db.GetRedisClient())
 		result, err := slRepo.List(getTenantID(c), start, int64(pageSize))
 		if err != nil {
-			c.JSON(http.StatusOK, models.NewErrorResponse(err.Error()))
+			writeErrorResponse(c, err)
 			return
 		}
 
@@ -282,7 +282,7 @@ func ShortLinkActionAPI() gin.HandlerFunc {
 			slRepo := repository.GetShortLinkRepo(db.GetPostgresPool(), db.GetRedisClient())
 			s, err := slRepo.Get(c.Param("id"))
 			if err != nil {
-				c.JSON(http.StatusOK, models.NewErrorResponse(err.Error()))
+				writeErrorResponse(c, err)
 				return
 			}
 
@@ -320,6 +320,6 @@ func ShortLinkActionAPI() gin.HandlerFunc {
 			return
 		}
 
-		c.JSON(http.StatusOK, models.NewErrorResponse("请求资源不存在"))
+		c.JSON(http.StatusNotFound, models.NewErrorResponse("请求资源不存在"))
 	})
 }

--- a/internal/app/handlers/super_admin.go
+++ b/internal/app/handlers/super_admin.go
@@ -93,7 +93,7 @@ func GetUserAPI(c *gin.Context) {
 
 	u, err := userRepo.FindByID(id)
 	if err != nil {
-		c.JSON(http.StatusNotFound, models.NewErrorResponse("用户不存在"))
+		writeErrorResponse(c, err)
 		return
 	}
 

--- a/internal/app/handlers/super_admin.go
+++ b/internal/app/handlers/super_admin.go
@@ -32,7 +32,7 @@ func CreateUserAPI(c *gin.Context) {
 	userRepo := repository.GetUserRepo(db.GetPostgresPool())
 	u := &models.User{Username: strings.TrimSpace(req.Username), RawPassword: req.Password}
 	if err := userRepo.Save(u); err != nil {
-		c.JSON(http.StatusOK, models.NewErrorResponse(err.Error()))
+		writeErrorResponse(c, err)
 		return
 	}
 
@@ -62,7 +62,7 @@ func ListUsersAPI(c *gin.Context) {
 		Query: query, Page: page, PageSize: pageSize,
 	})
 	if err != nil {
-		c.JSON(http.StatusOK, models.NewErrorResponse(err.Error()))
+		writeErrorResponse(c, err)
 		return
 	}
 
@@ -93,13 +93,13 @@ func GetUserAPI(c *gin.Context) {
 
 	u, err := userRepo.FindByID(id)
 	if err != nil {
-		c.JSON(http.StatusOK, models.NewErrorResponse("用户不存在"))
+		c.JSON(http.StatusNotFound, models.NewErrorResponse("用户不存在"))
 		return
 	}
 
 	tenants, err := userRepo.GetUserTenants(u)
 	if err != nil {
-		c.JSON(http.StatusOK, models.NewErrorResponse(err.Error()))
+		writeErrorResponse(c, err)
 		return
 	}
 	c.JSON(http.StatusOK, models.NewSuccessResponse(models.UserDetailData{
@@ -131,7 +131,7 @@ func ResetPasswordAPI(c *gin.Context) {
 
 	userRepo := repository.GetUserRepo(db.GetPostgresPool())
 	if err := userRepo.UpdatePasswordByID(id, req.NewPassword); err != nil {
-		c.JSON(http.StatusOK, models.NewErrorResponse(err.Error()))
+		writeErrorResponse(c, err)
 		return
 	}
 
@@ -160,7 +160,7 @@ func UpdateUserStatusAPI(c *gin.Context) {
 
 	userRepo := repository.GetUserRepo(db.GetPostgresPool())
 	if err := userRepo.UpdateStatus(id, *req.IsActive); err != nil {
-		c.JSON(http.StatusOK, models.NewErrorResponse(err.Error()))
+		writeErrorResponse(c, err)
 		return
 	}
 
@@ -188,7 +188,7 @@ func ListAllTenantsAPI(c *gin.Context) {
 	tenantRepo := repository.GetTenantRepo(db.GetPostgresPool())
 	tenants, total, err := tenantRepo.ListAll(page, pageSize)
 	if err != nil {
-		c.JSON(http.StatusOK, models.NewErrorResponse(err.Error()))
+		writeErrorResponse(c, err)
 		return
 	}
 
@@ -220,7 +220,7 @@ func UpdateTenantStatusAPI(c *gin.Context) {
 
 	tenantRepo := repository.GetTenantRepo(db.GetPostgresPool())
 	if err := tenantRepo.UpdateStatus(id, *req.IsActive); err != nil {
-		c.JSON(http.StatusOK, models.NewErrorResponse(err.Error()))
+		writeErrorResponse(c, err)
 		return
 	}
 
@@ -255,7 +255,7 @@ func SuperListTenantShortLinksAPI(c *gin.Context) {
 	slRepo := repository.GetShortLinkRepo(db.GetPostgresPool(), db.GetRedisClient())
 	result, err := slRepo.ListByTenantID(tenantID, start, pageSize)
 	if err != nil {
-		c.JSON(http.StatusOK, models.NewErrorResponse(err.Error()))
+		writeErrorResponse(c, err)
 		return
 	}
 
@@ -321,7 +321,7 @@ func SuperListTenantDomainsAPI(c *gin.Context) {
 	tenantRepo := repository.GetTenantRepo(db.GetPostgresPool())
 	domains, err := tenantRepo.ListDomains(tenantID)
 	if err != nil {
-		c.JSON(http.StatusOK, models.NewErrorResponse(err.Error()))
+		writeErrorResponse(c, err)
 		return
 	}
 

--- a/internal/app/handlers/tenant.go
+++ b/internal/app/handlers/tenant.go
@@ -32,7 +32,7 @@ func CreateTenantAPI() gin.HandlerFunc {
 		repo := repository.GetTenantRepo(db.GetPostgresPool())
 		t, err := repo.Create(p)
 		if err != nil {
-			c.JSON(http.StatusOK, models.NewErrorResponse(err.Error()))
+			writeErrorResponse(c, err)
 			return
 		}
 
@@ -72,7 +72,7 @@ func GetTenantAPI() gin.HandlerFunc {
 		repo := repository.GetTenantRepo(db.GetPostgresPool())
 		t, err := repo.GetByID(tenantID)
 		if err != nil {
-			c.JSON(http.StatusOK, models.NewErrorResponse(err.Error()))
+			writeErrorResponse(c, err)
 			return
 		}
 
@@ -95,7 +95,7 @@ func ListTenantsAPI() gin.HandlerFunc {
 		repo := repository.GetTenantRepo(db.GetPostgresPool())
 		tenants, err := repo.ListByUser(ctx.User.ID)
 		if err != nil {
-			c.JSON(http.StatusOK, models.NewErrorResponse(err.Error()))
+			writeErrorResponse(c, err)
 			return
 		}
 
@@ -133,7 +133,7 @@ func UpdateTenantAPI() gin.HandlerFunc {
 		repo := repository.GetTenantRepo(db.GetPostgresPool())
 		t, err := repo.Update(tenantID, p)
 		if err != nil {
-			c.JSON(http.StatusOK, models.NewErrorResponse(err.Error()))
+			writeErrorResponse(c, err)
 			return
 		}
 
@@ -170,7 +170,7 @@ func AddDomainAPI() gin.HandlerFunc {
 
 		repo := repository.GetTenantRepo(db.GetPostgresPool())
 		if err := repo.AddDomain(tenantID, p.Domain, p.IsDefault); err != nil {
-			c.JSON(http.StatusOK, models.NewErrorResponse(err.Error()))
+			writeErrorResponse(c, err)
 			return
 		}
 
@@ -208,7 +208,7 @@ func RemoveDomainAPI() gin.HandlerFunc {
 
 		repo := repository.GetTenantRepo(db.GetPostgresPool())
 		if err := repo.RemoveDomain(tenantID, domain); err != nil {
-			c.JSON(http.StatusOK, models.NewErrorResponse(err.Error()))
+			writeErrorResponse(c, err)
 			return
 		}
 
@@ -239,7 +239,7 @@ func ListDomainsAPI() gin.HandlerFunc {
 		repo := repository.GetTenantRepo(db.GetPostgresPool())
 		domains, err := repo.ListDomains(tenantID)
 		if err != nil {
-			c.JSON(http.StatusOK, models.NewErrorResponse(err.Error()))
+			writeErrorResponse(c, err)
 			return
 		}
 

--- a/internal/app/handlers/tenant_member.go
+++ b/internal/app/handlers/tenant_member.go
@@ -107,7 +107,7 @@ func InviteUserAPI() gin.HandlerFunc {
 		userRepo := repository.GetUserRepo(db.GetPostgresPool())
 		invitee, err := userRepo.FindByUsername(req.Username)
 		if err != nil {
-			c.JSON(http.StatusNotFound, models.NewErrorResponse("用户不存在"))
+			writeErrorResponse(c, err)
 			return
 		}
 
@@ -207,7 +207,7 @@ func AcceptInvitationAPI() gin.HandlerFunc {
 
 		inv, err := invRepo.Get(invID)
 		if err != nil {
-			c.JSON(http.StatusNotFound, models.NewErrorResponse("邀请不存在"))
+			writeErrorResponse(c, err)
 			return
 		}
 
@@ -258,7 +258,7 @@ func RejectInvitationAPI() gin.HandlerFunc {
 
 		inv, err := invRepo.Get(invID)
 		if err != nil {
-			c.JSON(http.StatusNotFound, models.NewErrorResponse("邀请不存在"))
+			writeErrorResponse(c, err)
 			return
 		}
 

--- a/internal/app/handlers/tenant_member.go
+++ b/internal/app/handlers/tenant_member.go
@@ -107,7 +107,7 @@ func InviteUserAPI() gin.HandlerFunc {
 		userRepo := repository.GetUserRepo(db.GetPostgresPool())
 		invitee, err := userRepo.FindByUsername(req.Username)
 		if err != nil {
-			c.JSON(http.StatusOK, models.NewErrorResponse("用户不存在"))
+			c.JSON(http.StatusNotFound, models.NewErrorResponse("用户不存在"))
 			return
 		}
 
@@ -207,7 +207,7 @@ func AcceptInvitationAPI() gin.HandlerFunc {
 
 		inv, err := invRepo.Get(invID)
 		if err != nil {
-			c.JSON(http.StatusOK, models.NewErrorResponse("邀请不存在"))
+			c.JSON(http.StatusNotFound, models.NewErrorResponse("邀请不存在"))
 			return
 		}
 
@@ -258,7 +258,7 @@ func RejectInvitationAPI() gin.HandlerFunc {
 
 		inv, err := invRepo.Get(invID)
 		if err != nil {
-			c.JSON(http.StatusOK, models.NewErrorResponse("邀请不存在"))
+			c.JSON(http.StatusNotFound, models.NewErrorResponse("邀请不存在"))
 			return
 		}
 

--- a/internal/app/handlers/user.go
+++ b/internal/app/handlers/user.go
@@ -65,7 +65,7 @@ func GetAuthInfoAPI() gin.HandlerFunc {
 		userRepo := repository.GetUserRepo(db.GetPostgresPool())
 		tenants, err := userRepo.GetUserTenants(ctx.User)
 		if err != nil {
-			c.JSON(http.StatusOK, models.NewErrorResponse(err.Error()))
+			writeErrorResponse(c, err)
 			return
 		}
 
@@ -151,7 +151,7 @@ func ChangePasswordAPI() gin.HandlerFunc {
 		ctx.User.RawPassword = p.NewPassword
 		repo := repository.GetUserRepo(db.GetPostgresPool())
 		if err := repo.UpdatePassword(ctx.User); err != nil {
-			c.JSON(http.StatusOK, models.NewErrorResponse(err.Error()))
+			writeErrorResponse(c, err)
 			return
 		}
 

--- a/internal/app/models/models.go
+++ b/internal/app/models/models.go
@@ -28,6 +28,14 @@ func NewErrorResponse(msg string) *Response {
 	return &Response{Msg: msg, Code: 4999, Data: nil}
 }
 
+type NotFoundError struct {
+	Msg string
+}
+
+func (e *NotFoundError) Error() string {
+	return e.Msg
+}
+
 // --- Tenant ---
 
 type Tenant struct {

--- a/internal/app/repository/repository.go
+++ b/internal/app/repository/repository.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"time"
 
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/jwma/jump-jump/internal/app/models"
 	"github.com/jwma/jump-jump/internal/app/utils"
@@ -47,7 +48,10 @@ func (r *TenantRepository) GetByID(id string) (*models.Tenant, error) {
 		`SELECT id, name, slug, is_active, created_at, updated_at FROM tenants WHERE id = $1`, id).
 		Scan(&t.ID, &t.Name, &t.Slug, &t.IsActive, &t.CreatedAt, &t.UpdatedAt)
 	if err != nil {
-		return nil, &models.NotFoundError{Msg: "租户不存在"}
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, &models.NotFoundError{Msg: "租户不存在"}
+		}
+		return nil, err
 	}
 	return t, nil
 }
@@ -267,7 +271,10 @@ func (r *userRepository) FindByUsername(username string) (*models.User, error) {
 		 FROM users WHERE username = $1`,
 		username).Scan(&u.ID, &u.Username, &u.Password, &u.Salt, &u.IsActive, &u.IsSuper, &u.CreatedAt, &u.UpdatedAt)
 	if err != nil {
-		return nil, &models.NotFoundError{Msg: "用户不存在"}
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, &models.NotFoundError{Msg: "用户不存在"}
+		}
+		return nil, err
 	}
 	return u, nil
 }
@@ -283,7 +290,10 @@ func (r *userRepository) FindByID(userID string) (*models.User, error) {
 		 FROM users WHERE id = $1`,
 		userID).Scan(&u.ID, &u.Username, &u.Password, &u.Salt, &u.IsActive, &u.IsSuper, &u.CreatedAt, &u.UpdatedAt)
 	if err != nil {
-		return nil, &models.NotFoundError{Msg: "用户不存在"}
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, &models.NotFoundError{Msg: "用户不存在"}
+		}
+		return nil, err
 	}
 	return u, nil
 }
@@ -494,7 +504,10 @@ func (r *TenantMemberRepository) Get(tenantID, userID string) (*models.TenantMem
 		 FROM tenant_members WHERE tenant_id = $1 AND user_id = $2`,
 		tenantID, userID).Scan(&m.TenantID, &m.UserID, &m.Role, &m.JoinedAt)
 	if err != nil {
-		return nil, &models.NotFoundError{Msg: "成员关系不存在"}
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, &models.NotFoundError{Msg: "成员关系不存在"}
+		}
+		return nil, err
 	}
 	return m, nil
 }
@@ -601,7 +614,10 @@ func (r *TenantInvitationRepository) Get(id string) (*models.TenantInvitation, e
 		 FROM tenant_invitations WHERE id = $1`, id).
 		Scan(&inv.ID, &inv.TenantID, &inv.InviterID, &inv.InviteeID, &inv.Status, &inv.CreatedAt)
 	if err != nil {
-		return nil, &models.NotFoundError{Msg: "邀请不存在"}
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, &models.NotFoundError{Msg: "邀请不存在"}
+		}
+		return nil, err
 	}
 	return inv, nil
 }
@@ -781,7 +797,10 @@ func (r *shortLinkRepository) Get(id string) (*models.ShortLink, error) {
 		 FROM short_links WHERE id = $1`, id).Scan(
 		&s.Id, &s.TenantID, &s.Url, &s.Description, &s.IsEnable, &s.CreatedBy, &s.CreateTime, &s.UpdateTime)
 	if err != nil {
-		return nil, &models.NotFoundError{Msg: "短链接不存在"}
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, &models.NotFoundError{Msg: "短链接不存在"}
+		}
+		return nil, err
 	}
 
 	j, _ := json.Marshal(s)

--- a/internal/app/repository/repository.go
+++ b/internal/app/repository/repository.go
@@ -47,7 +47,7 @@ func (r *TenantRepository) GetByID(id string) (*models.Tenant, error) {
 		`SELECT id, name, slug, is_active, created_at, updated_at FROM tenants WHERE id = $1`, id).
 		Scan(&t.ID, &t.Name, &t.Slug, &t.IsActive, &t.CreatedAt, &t.UpdatedAt)
 	if err != nil {
-		return nil, fmt.Errorf("租户不存在")
+		return nil, &models.NotFoundError{Msg: "租户不存在"}
 	}
 	return t, nil
 }
@@ -88,7 +88,7 @@ func (r *TenantRepository) UpdateStatus(id string, isActive bool) error {
 		return err
 	}
 	if ct.RowsAffected() == 0 {
-		return fmt.Errorf("租户不存在")
+		return &models.NotFoundError{Msg: "租户不存在"}
 	}
 	return nil
 }
@@ -267,7 +267,7 @@ func (r *userRepository) FindByUsername(username string) (*models.User, error) {
 		 FROM users WHERE username = $1`,
 		username).Scan(&u.ID, &u.Username, &u.Password, &u.Salt, &u.IsActive, &u.IsSuper, &u.CreatedAt, &u.UpdatedAt)
 	if err != nil {
-		return nil, fmt.Errorf("用户不存在")
+		return nil, &models.NotFoundError{Msg: "用户不存在"}
 	}
 	return u, nil
 }
@@ -283,7 +283,7 @@ func (r *userRepository) FindByID(userID string) (*models.User, error) {
 		 FROM users WHERE id = $1`,
 		userID).Scan(&u.ID, &u.Username, &u.Password, &u.Salt, &u.IsActive, &u.IsSuper, &u.CreatedAt, &u.UpdatedAt)
 	if err != nil {
-		return nil, fmt.Errorf("用户不存在")
+		return nil, &models.NotFoundError{Msg: "用户不存在"}
 	}
 	return u, nil
 }
@@ -368,7 +368,7 @@ func (r *userRepository) UpdatePasswordByID(userID, newPassword string) error {
 		return err
 	}
 	if ct.RowsAffected() == 0 {
-		return fmt.Errorf("用户不存在")
+		return &models.NotFoundError{Msg: "用户不存在"}
 	}
 	return nil
 }
@@ -381,7 +381,7 @@ func (r *userRepository) UpdateStatus(userID string, isActive bool) error {
 		return err
 	}
 	if ct.RowsAffected() == 0 {
-		return fmt.Errorf("用户不存在")
+		return &models.NotFoundError{Msg: "用户不存在"}
 	}
 	return nil
 }
@@ -494,7 +494,7 @@ func (r *TenantMemberRepository) Get(tenantID, userID string) (*models.TenantMem
 		 FROM tenant_members WHERE tenant_id = $1 AND user_id = $2`,
 		tenantID, userID).Scan(&m.TenantID, &m.UserID, &m.Role, &m.JoinedAt)
 	if err != nil {
-		return nil, fmt.Errorf("成员关系不存在")
+		return nil, &models.NotFoundError{Msg: "成员关系不存在"}
 	}
 	return m, nil
 }
@@ -533,7 +533,7 @@ func (r *TenantMemberRepository) UpdateRole(tenantID, userID, role string) error
 		return err
 	}
 	if ct.RowsAffected() == 0 {
-		return fmt.Errorf("成员不存在")
+		return &models.NotFoundError{Msg: "成员不存在"}
 	}
 	return nil
 }
@@ -601,7 +601,7 @@ func (r *TenantInvitationRepository) Get(id string) (*models.TenantInvitation, e
 		 FROM tenant_invitations WHERE id = $1`, id).
 		Scan(&inv.ID, &inv.TenantID, &inv.InviterID, &inv.InviteeID, &inv.Status, &inv.CreatedAt)
 	if err != nil {
-		return nil, fmt.Errorf("邀请不存在")
+		return nil, &models.NotFoundError{Msg: "邀请不存在"}
 	}
 	return inv, nil
 }
@@ -761,7 +761,7 @@ func (r *shortLinkRepository) Delete(s *models.ShortLink) {
 
 func (r *shortLinkRepository) Get(id string) (*models.ShortLink, error) {
 	if id == "" {
-		return nil, fmt.Errorf("短链接不存在")
+		return nil, &models.NotFoundError{Msg: "短链接不存在"}
 	}
 
 	// Try cache
@@ -781,7 +781,7 @@ func (r *shortLinkRepository) Get(id string) (*models.ShortLink, error) {
 		 FROM short_links WHERE id = $1`, id).Scan(
 		&s.Id, &s.TenantID, &s.Url, &s.Description, &s.IsEnable, &s.CreatedBy, &s.CreateTime, &s.UpdateTime)
 	if err != nil {
-		return nil, fmt.Errorf("短链接不存在")
+		return nil, &models.NotFoundError{Msg: "短链接不存在"}
 	}
 
 	j, _ := json.Marshal(s)

--- a/web-ui/src/api/http.ts
+++ b/web-ui/src/api/http.ts
@@ -3,6 +3,18 @@ import type { ApiResponse } from '@/types/api'
 import { useAuthStore } from '@/stores/auth'
 import router from '@/router'
 
+export class ApiError extends Error {
+  status: number
+  code: number
+
+  constructor(message: string, status: number = 0, code: number = 0) {
+    super(message)
+    this.name = 'ApiError'
+    this.status = status
+    this.code = code
+  }
+}
+
 const http = axios.create({
   baseURL: import.meta.env.VITE_API_BASE_URL || '/v1',
   timeout: 10000,
@@ -27,7 +39,11 @@ http.interceptors.response.use(
       auth.clearAuth()
       router.push({ name: 'login' })
     }
-    return Promise.reject(error)
+    return Promise.reject(new ApiError(
+      error.response?.data?.msg || error.message || 'Request failed',
+      error.response?.status || 0,
+      error.response?.data?.code || 0,
+    ))
   },
 )
 
@@ -39,7 +55,7 @@ export async function request<T>(method: string, url: string, data?: unknown): P
     params: method === 'GET' ? data : undefined,
   })
   if (res.data.code !== 0) {
-    return Promise.reject(new Error(res.data.msg || '请求失败'))
+    return Promise.reject(new ApiError(res.data.msg || 'Request failed', res.status, res.data.code))
   }
   return res.data.data
 }

--- a/web-ui/src/pages/ShortLinkEditPage.vue
+++ b/web-ui/src/pages/ShortLinkEditPage.vue
@@ -2,6 +2,7 @@
 import { ref, computed, onMounted } from 'vue'
 import { useRouter, useRoute } from 'vue-router'
 import { getShortLink, updateShortLink } from '@/api/short-link'
+import { ApiError } from '@/api/http'
 import { ArrowLeft } from 'lucide-vue-next'
 
 defineOptions({ name: 'ShortLinkEditPage' })
@@ -43,7 +44,7 @@ async function fetchData() {
     createdBy.value = sl.createdBy
     createTime.value = sl.createTime
   } catch (e) {
-    if (e instanceof Error && e.message.includes('不存在')) {
+    if (e instanceof ApiError && e.status === 404) {
       notFound.value = true
     } else {
       error.value = 'Failed to load short link. Please try again.'

--- a/web-ui/src/pages/TenantDetailPage.vue
+++ b/web-ui/src/pages/TenantDetailPage.vue
@@ -2,6 +2,7 @@
 import { ref, onMounted, nextTick, watch } from 'vue'
 import { useRouter, useRoute } from 'vue-router'
 import { getTenant, listDomains, addDomain, removeDomain } from '@/api/tenant'
+import { ApiError } from '@/api/http'
 import type { Tenant, TenantDomain } from '@/types/api'
 import {
   ArrowLeft,
@@ -42,10 +43,10 @@ async function fetchTenant() {
   try {
     tenant.value = await getTenant(tenantId)
   } catch (e) {
-    const msg = e instanceof Error ? e.message : ''
-    if (msg.includes('不存在')) {
+    if (e instanceof ApiError && e.status === 404) {
       notFound.value = true
     } else {
+      const msg = e instanceof Error ? e.message : ''
       pageError.value = msg || 'Failed to load tenant.'
     }
   } finally {

--- a/web-ui/src/pages/super/SuperTenantDetailPage.vue
+++ b/web-ui/src/pages/super/SuperTenantDetailPage.vue
@@ -3,6 +3,7 @@ import { ref, onMounted } from 'vue'
 import { useRouter, useRoute } from 'vue-router'
 import { getTenant, listDomains, addDomain, removeDomain } from '@/api/tenant'
 import { listSuperTenantMembers, listSuperTenantShortLinks, setSuperTenantStatus } from '@/api/super'
+import { ApiError } from '@/api/http'
 import type { Tenant, TenantDomain, ShortLinkData } from '@/types/api'
 import type { SuperTenantMember } from '@/types/api'
 import {
@@ -54,10 +55,10 @@ async function fetchTenant() {
   try {
     tenant.value = await getTenant(tenantId)
   } catch (e) {
-    const msg = e instanceof Error ? e.message : ''
-    if (msg.includes('不存在') || msg.includes('not found')) {
+    if (e instanceof ApiError && e.status === 404) {
       notFound.value = true
     } else {
+      const msg = e instanceof Error ? e.message : ''
       pageError.value = msg || 'Failed to load tenant.'
     }
   } finally {


### PR DESCRIPTION
## Summary
- Backend now returns proper HTTP 404 status codes for not-found resources (tenant, short link, user, invitation, member) instead of always returning HTTP 200 with Chinese error messages
- Frontend uses a new `ApiError` class that carries HTTP status codes, replacing fragile Chinese text matching (`e.message.includes('不存在')`) with robust status code checks (`e.status === 404`)
- Fallback error message changed from Chinese `'请求失败'` to English `'Request failed'`

## Changes

### Backend
- Added `NotFoundError` type in `models/models.go` for typed not-found errors
- Updated `repository.go` to use `NotFoundError` for all "不存在" errors
- Added `writeErrorResponse()` helper that returns HTTP 404 for `NotFoundError`, HTTP 200 otherwise
- Updated all handlers to use `writeErrorResponse` for repository errors

### Frontend
- Added `ApiError` class in `http.ts` with `status` and `code` properties
- Normalized all errors (HTTP and application-level) through `ApiError`
- Updated `ShortLinkEditPage.vue`, `TenantDetailPage.vue`, `SuperTenantDetailPage.vue` to check `e.status === 404`

## Test plan
- [ ] Verify short link edit page shows "not found" when accessing a non-existent short link ID
- [ ] Verify tenant detail page shows "not found" when accessing a non-existent tenant ID
- [ ] Verify super admin tenant detail page shows "not found" for non-existent tenant
- [ ] Verify other error types (permission errors, server errors) still display correctly
- [ ] Verify Go backend compiles and frontend builds without errors

Closes #JWM-58

🤖 Generated with [Claude Code](https://claude.com/claude-code)