### PR TITLE
feat: improve login/auth page UX

### DIFF
--- a/web-ui/src/pages/ChangePasswordPage.vue
+++ b/web-ui/src/pages/ChangePasswordPage.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, computed } from 'vue'
+import { ref, computed, onUnmounted } from 'vue'
 import { changePassword } from '@/api/user'
 import { useToast } from '@/composables/useToast'
 import { Eye, EyeOff, CheckCircle2 } from 'lucide-vue-next'
@@ -15,6 +15,11 @@ const success = ref(false)
 const showCurrentPassword = ref(false)
 const showNewPassword = ref(false)
 const showConfirmPassword = ref(false)
+let successTimer: ReturnType<typeof setTimeout> | null = null
+
+onUnmounted(() => {
+  if (successTimer) clearTimeout(successTimer)
+})
 
 const passwordStrength = computed(() => {
   const pw = newPassword.value
@@ -35,8 +40,9 @@ const passwordStrength = computed(() => {
     { label: 'Strong', color: 'bg-green-500' },
   ]
 
-  const level = levels[Math.min(score, levels.length) - 1] || levels[0]
-  return { score, ...level }
+  const clampedScore = Math.max(1, Math.min(score, levels.length))
+  const level = levels[clampedScore - 1]
+  return { score: clampedScore, ...level }
 })
 
 async function handleSubmit() {
@@ -61,7 +67,10 @@ async function handleSubmit() {
     currentPassword.value = ''
     newPassword.value = ''
     confirmPassword.value = ''
-    setTimeout(() => (success.value = false), 4000)
+    successTimer = setTimeout(() => {
+      success.value = false
+      successTimer = null
+    }, 4000)
   } catch {
     error.value = 'Failed to change password. Please check your current password.'
   } finally {
@@ -88,6 +97,8 @@ async function handleSubmit() {
             />
             <button
               type="button"
+              :aria-label="showCurrentPassword ? 'Hide current password' : 'Show current password'"
+              :aria-pressed="showCurrentPassword"
               class="absolute inset-y-0 right-0 flex items-center pr-3 text-gray-400 hover:text-gray-600"
               @click="showCurrentPassword = !showCurrentPassword"
             >
@@ -108,6 +119,8 @@ async function handleSubmit() {
             />
             <button
               type="button"
+              :aria-label="showNewPassword ? 'Hide new password' : 'Show new password'"
+              :aria-pressed="showNewPassword"
               class="absolute inset-y-0 right-0 flex items-center pr-3 text-gray-400 hover:text-gray-600"
               @click="showNewPassword = !showNewPassword"
             >
@@ -142,6 +155,8 @@ async function handleSubmit() {
             />
             <button
               type="button"
+              :aria-label="showConfirmPassword ? 'Hide confirm password' : 'Show confirm password'"
+              :aria-pressed="showConfirmPassword"
               class="absolute inset-y-0 right-0 flex items-center pr-3 text-gray-400 hover:text-gray-600"
               @click="showConfirmPassword = !showConfirmPassword"
             >

--- a/web-ui/src/pages/ChangePasswordPage.vue
+++ b/web-ui/src/pages/ChangePasswordPage.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts">
-import { ref } from 'vue'
+import { ref, computed } from 'vue'
 import { changePassword } from '@/api/user'
 import { useToast } from '@/composables/useToast'
+import { Eye, EyeOff, CheckCircle2 } from 'lucide-vue-next'
 
 defineOptions({ name: 'ChangePasswordPage' })
 const toast = useToast()
@@ -10,9 +11,37 @@ const newPassword = ref('')
 const confirmPassword = ref('')
 const loading = ref(false)
 const error = ref('')
+const success = ref(false)
+const showCurrentPassword = ref(false)
+const showNewPassword = ref(false)
+const showConfirmPassword = ref(false)
+
+const passwordStrength = computed(() => {
+  const pw = newPassword.value
+  if (!pw) return { score: 0, label: '', color: '' }
+
+  let score = 0
+  if (pw.length >= 6) score++
+  if (pw.length >= 10) score++
+  if (/[a-z]/.test(pw) && /[A-Z]/.test(pw)) score++
+  if (/\d/.test(pw)) score++
+  if (/[^a-zA-Z0-9]/.test(pw)) score++
+
+  const levels = [
+    { label: 'Very weak', color: 'bg-red-500' },
+    { label: 'Weak', color: 'bg-orange-500' },
+    { label: 'Fair', color: 'bg-yellow-500' },
+    { label: 'Good', color: 'bg-blue-500' },
+    { label: 'Strong', color: 'bg-green-500' },
+  ]
+
+  const level = levels[Math.min(score, levels.length) - 1] || levels[0]
+  return { score, ...level }
+})
 
 async function handleSubmit() {
   error.value = ''
+  success.value = false
 
   if (newPassword.value !== confirmPassword.value) {
     error.value = 'New passwords do not match.'
@@ -27,10 +56,12 @@ async function handleSubmit() {
   loading.value = true
   try {
     await changePassword({ password: currentPassword.value, newPassword: newPassword.value })
-    toast.success('Password changed successfully')
+    toast.success('Password changed successfully!')
+    success.value = true
     currentPassword.value = ''
     newPassword.value = ''
     confirmPassword.value = ''
+    setTimeout(() => (success.value = false), 4000)
   } catch {
     error.value = 'Failed to change password. Please check your current password.'
   } finally {
@@ -48,36 +79,94 @@ async function handleSubmit() {
       <div class="space-y-4">
         <div>
           <label class="mb-1 block text-sm font-medium text-gray-700">Current Password</label>
-          <input
-            v-model="currentPassword"
-            type="password"
-            required
-            class="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
-          />
+          <div class="relative">
+            <input
+              v-model="currentPassword"
+              :type="showCurrentPassword ? 'text' : 'password'"
+              required
+              class="w-full rounded-md border border-gray-300 px-3 py-2 pr-10 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
+            />
+            <button
+              type="button"
+              class="absolute inset-y-0 right-0 flex items-center pr-3 text-gray-400 hover:text-gray-600"
+              @click="showCurrentPassword = !showCurrentPassword"
+            >
+              <Eye v-if="!showCurrentPassword" class="h-4 w-4" />
+              <EyeOff v-else class="h-4 w-4" />
+            </button>
+          </div>
         </div>
         <div>
           <label class="mb-1 block text-sm font-medium text-gray-700">New Password</label>
-          <input
-            v-model="newPassword"
-            type="password"
-            required
-            minlength="6"
-            class="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
-          />
+          <div class="relative">
+            <input
+              v-model="newPassword"
+              :type="showNewPassword ? 'text' : 'password'"
+              required
+              minlength="6"
+              class="w-full rounded-md border border-gray-300 px-3 py-2 pr-10 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
+            />
+            <button
+              type="button"
+              class="absolute inset-y-0 right-0 flex items-center pr-3 text-gray-400 hover:text-gray-600"
+              @click="showNewPassword = !showNewPassword"
+            >
+              <Eye v-if="!showNewPassword" class="h-4 w-4" />
+              <EyeOff v-else class="h-4 w-4" />
+            </button>
+          </div>
+          <div v-if="newPassword" class="mt-2">
+            <div class="flex gap-1">
+              <div
+                v-for="i in 5"
+                :key="i"
+                class="h-1.5 flex-1 rounded-full"
+                :class="i <= passwordStrength.score ? passwordStrength.color : 'bg-gray-200'"
+              />
+            </div>
+            <p class="mt-1 text-xs text-gray-500">
+              Strength: <span class="font-medium">{{ passwordStrength.label }}</span>
+            </p>
+          </div>
         </div>
         <div>
           <label class="mb-1 block text-sm font-medium text-gray-700">Confirm New Password</label>
-          <input
-            v-model="confirmPassword"
-            type="password"
-            required
-            minlength="6"
-            class="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
-          />
+          <div class="relative">
+            <input
+              v-model="confirmPassword"
+              :type="showConfirmPassword ? 'text' : 'password'"
+              required
+              minlength="6"
+              class="w-full rounded-md border border-gray-300 px-3 py-2 pr-10 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
+              :class="confirmPassword && newPassword !== confirmPassword ? 'border-red-300' : ''"
+            />
+            <button
+              type="button"
+              class="absolute inset-y-0 right-0 flex items-center pr-3 text-gray-400 hover:text-gray-600"
+              @click="showConfirmPassword = !showConfirmPassword"
+            >
+              <Eye v-if="!showConfirmPassword" class="h-4 w-4" />
+              <EyeOff v-else class="h-4 w-4" />
+            </button>
+          </div>
+          <p
+            v-if="confirmPassword && newPassword !== confirmPassword"
+            class="mt-1 text-xs text-red-500"
+          >
+            Passwords do not match
+          </p>
         </div>
       </div>
 
       <p v-if="error" class="mt-4 text-sm text-red-600">{{ error }}</p>
+
+      <div
+        v-if="success"
+        class="mt-4 flex items-center gap-2 rounded-md bg-green-50 px-3 py-2 text-sm text-green-700"
+      >
+        <CheckCircle2 class="h-4 w-4" />
+        Password changed successfully!
+      </div>
 
       <button
         type="submit"

--- a/web-ui/src/pages/LoginPage.vue
+++ b/web-ui/src/pages/LoginPage.vue
@@ -67,6 +67,8 @@ async function handleLogin() {
             />
             <button
               type="button"
+              :aria-label="showPassword ? 'Hide password' : 'Show password'"
+              :aria-pressed="showPassword"
               class="absolute inset-y-0 right-0 flex items-center pr-3 text-gray-400 hover:text-gray-600"
               @click="togglePassword"
             >

--- a/web-ui/src/pages/LoginPage.vue
+++ b/web-ui/src/pages/LoginPage.vue
@@ -2,6 +2,7 @@
 import { ref } from 'vue'
 import { useRouter, useRoute } from 'vue-router'
 import { useAuthStore } from '@/stores/auth'
+import { Eye, EyeOff, Link2 } from 'lucide-vue-next'
 
 const auth = useAuthStore()
 const router = useRouter()
@@ -11,12 +12,18 @@ const username = ref('')
 const password = ref('')
 const error = ref('')
 const loading = ref(false)
+const showPassword = ref(false)
+const rememberMe = ref(true)
+
+function togglePassword() {
+  showPassword.value = !showPassword.value
+}
 
 async function handleLogin() {
   error.value = ''
   loading.value = true
   try {
-    await auth.login(username.value, password.value)
+    await auth.login(username.value, password.value, rememberMe.value)
     await auth.fetchAuthInfo()
     const redirect = (route.query.redirect as string) || ''
     router.push({ name: 'select-tenant', query: redirect ? { redirect } : undefined })
@@ -31,7 +38,13 @@ async function handleLogin() {
 <template>
   <div class="flex min-h-screen items-center justify-center bg-gray-50">
     <div class="w-full max-w-sm">
-      <h1 class="mb-8 text-center text-2xl font-bold">Jump Jump</h1>
+      <div class="mb-8 text-center">
+        <div class="mx-auto mb-3 flex h-12 w-12 items-center justify-center rounded-xl bg-blue-600">
+          <Link2 class="h-7 w-7 text-white" />
+        </div>
+        <h1 class="text-2xl font-bold text-gray-900">Jump Jump</h1>
+        <p class="mt-1 text-sm text-gray-500">Short URL Management Platform</p>
+      </div>
       <form class="rounded-lg border bg-white p-6 shadow-sm" @submit.prevent="handleLogin">
         <div class="mb-4">
           <label class="mb-1 block text-sm font-medium text-gray-700">Username</label>
@@ -39,17 +52,37 @@ async function handleLogin() {
             v-model="username"
             type="text"
             required
+            autofocus
             class="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
           />
         </div>
         <div class="mb-4">
           <label class="mb-1 block text-sm font-medium text-gray-700">Password</label>
+          <div class="relative">
+            <input
+              v-model="password"
+              :type="showPassword ? 'text' : 'password'"
+              required
+              class="w-full rounded-md border border-gray-300 px-3 py-2 pr-10 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
+            />
+            <button
+              type="button"
+              class="absolute inset-y-0 right-0 flex items-center pr-3 text-gray-400 hover:text-gray-600"
+              @click="togglePassword"
+            >
+              <Eye v-if="!showPassword" class="h-4 w-4" />
+              <EyeOff v-else class="h-4 w-4" />
+            </button>
+          </div>
+        </div>
+        <div class="mb-4 flex items-center">
           <input
-            v-model="password"
-            type="password"
-            required
-            class="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
+            id="remember-me"
+            v-model="rememberMe"
+            type="checkbox"
+            class="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
           />
+          <label for="remember-me" class="ml-2 text-sm text-gray-600">Remember me</label>
         </div>
         <p v-if="error" class="mb-4 text-sm text-red-600">{{ error }}</p>
         <button

--- a/web-ui/src/pages/SelectTenantPage.vue
+++ b/web-ui/src/pages/SelectTenantPage.vue
@@ -1,18 +1,39 @@
 <script setup lang="ts">
-import { ref, reactive, onMounted } from 'vue'
+import { ref, reactive, onMounted, watch } from 'vue'
 import { useRouter, useRoute } from 'vue-router'
 import { useAuthStore } from '@/stores/auth'
 import { createTenant } from '@/api/tenant'
-import { ArrowRight, Plus, Shield, Building2 } from 'lucide-vue-next'
+import { ArrowRight, Plus, Shield, Building2, Loader2 } from 'lucide-vue-next'
 
 const router = useRouter()
 const route = useRoute()
 const auth = useAuthStore()
 
+const loading = ref(!auth.authUser)
 const showCreateDialog = ref(false)
 const createLoading = ref(false)
 const createForm = reactive({ name: '', slug: '' })
 const createError = ref('')
+const slugManuallyEdited = ref(false)
+
+function generateSlug(name: string): string {
+  return name
+    .toLowerCase()
+    .trim()
+    .replace(/[^\w\s-]/g, '')
+    .replace(/[\s_]+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-+|-+$/g, '')
+}
+
+watch(
+  () => createForm.name,
+  (name) => {
+    if (!slugManuallyEdited.value) {
+      createForm.slug = generateSlug(name)
+    }
+  },
+)
 
 onMounted(async () => {
   if (!auth.authUser) {
@@ -20,6 +41,8 @@ onMounted(async () => {
       await auth.fetchAuthInfo()
     } catch {
       router.push({ name: 'login' })
+    } finally {
+      loading.value = false
     }
   }
 })
@@ -34,6 +57,14 @@ function enterSuperAdmin() {
   auth.clearTenant()
   const redirect = (route.query.redirect as string) || '/'
   router.push(redirect)
+}
+
+function openCreateDialog() {
+  createForm.name = ''
+  createForm.slug = ''
+  createError.value = ''
+  slugManuallyEdited.value = false
+  showCreateDialog.value = true
 }
 
 async function handleCreateTenant() {
@@ -63,111 +94,121 @@ async function handleLogout() {
 <template>
   <div class="flex min-h-screen items-center justify-center bg-gray-50">
     <div class="w-full max-w-md">
-      <h1 class="mb-2 text-center text-2xl font-bold">Select Tenant</h1>
-      <p class="mb-6 text-center text-sm text-gray-500">
-        Welcome, {{ auth.authUser?.username }}. Choose a tenant to continue.
-      </p>
+      <template v-if="loading">
+        <div class="flex flex-col items-center gap-3">
+          <Loader2 class="h-8 w-8 animate-spin text-blue-600" />
+          <p class="text-sm text-gray-500">Loading...</p>
+        </div>
+      </template>
+      <template v-else>
+        <h1 class="mb-2 text-center text-2xl font-bold">Select Tenant</h1>
+        <p class="mb-6 text-center text-sm text-gray-500">
+          Welcome, {{ auth.authUser?.username }}. Choose a tenant to continue.
+        </p>
 
-      <div class="space-y-3">
+        <div class="space-y-3">
+          <button
+            v-for="tenant in auth.tenants"
+            :key="tenant.tenantId"
+            class="flex w-full items-center justify-between rounded-lg border bg-white p-4 text-left shadow-sm transition hover:border-blue-300 hover:shadow"
+            @click="selectTenant(tenant.tenantId)"
+          >
+            <div class="flex items-center gap-3">
+              <div class="flex h-10 w-10 items-center justify-center rounded-lg bg-blue-50">
+                <Building2 class="h-5 w-5 text-blue-600" />
+              </div>
+              <div>
+                <div class="font-medium text-gray-900">{{ tenant.tenantName }}</div>
+                <span
+                  class="inline-block rounded-full px-2 py-0.5 text-xs font-medium"
+                  :class="tenant.role === 'admin' ? 'bg-red-50 text-red-700' : 'bg-gray-100 text-gray-600'"
+                >
+                  {{ tenant.role }}
+                </span>
+              </div>
+            </div>
+            <ArrowRight class="h-4 w-4 text-gray-400" />
+          </button>
+        </div>
+
         <button
-          v-for="tenant in auth.tenants"
-          :key="tenant.tenantId"
-          class="flex w-full items-center justify-between rounded-lg border bg-white p-4 text-left shadow-sm transition hover:border-blue-300 hover:shadow"
-          @click="selectTenant(tenant.tenantId)"
+          v-if="auth.isSuper"
+          class="mt-3 flex w-full items-center justify-between rounded-lg border-2 border-dashed border-amber-300 bg-amber-50 p-4 text-left transition hover:border-amber-400"
+          @click="enterSuperAdmin"
         >
           <div class="flex items-center gap-3">
-            <div class="flex h-10 w-10 items-center justify-center rounded-lg bg-blue-50">
-              <Building2 class="h-5 w-5 text-blue-600" />
-            </div>
-            <div>
-              <div class="font-medium text-gray-900">{{ tenant.tenantName }}</div>
-              <span
-                class="inline-block rounded-full px-2 py-0.5 text-xs font-medium"
-                :class="tenant.role === 'admin' ? 'bg-red-50 text-red-700' : 'bg-gray-100 text-gray-600'"
-              >
-                {{ tenant.role }}
-              </span>
-            </div>
+            <Shield class="h-5 w-5 text-amber-600" />
+            <span class="font-medium text-amber-700">Super Admin Panel</span>
           </div>
-          <ArrowRight class="h-4 w-4 text-gray-400" />
+          <ArrowRight class="h-4 w-4 text-amber-400" />
         </button>
-      </div>
 
-      <button
-        v-if="auth.isSuper"
-        class="mt-3 flex w-full items-center justify-between rounded-lg border-2 border-dashed border-amber-300 bg-amber-50 p-4 text-left transition hover:border-amber-400"
-        @click="enterSuperAdmin"
-      >
-        <div class="flex items-center gap-3">
-          <Shield class="h-5 w-5 text-amber-600" />
-          <span class="font-medium text-amber-700">Super Admin Panel</span>
-        </div>
-        <ArrowRight class="h-4 w-4 text-amber-400" />
-      </button>
-
-      <button
-        class="mt-4 flex w-full items-center justify-center gap-2 rounded-lg border border-dashed border-gray-300 bg-white p-3 text-sm font-medium text-gray-600 transition hover:border-gray-400 hover:text-gray-800"
-        @click="showCreateDialog = true"
-      >
-        <Plus class="h-4 w-4" />
-        Create New Tenant
-      </button>
-
-      <div class="mt-6 text-center">
-        <button class="text-sm text-gray-400 hover:text-gray-600" @click="handleLogout">
-          Sign out
+        <button
+          class="mt-4 flex w-full items-center justify-center gap-2 rounded-lg border border-dashed border-gray-300 bg-white p-3 text-sm font-medium text-gray-600 transition hover:border-gray-400 hover:text-gray-800"
+          @click="openCreateDialog"
+        >
+          <Plus class="h-4 w-4" />
+          Create New Tenant
         </button>
-      </div>
 
-      <!-- Create tenant dialog -->
-      <div
-        v-if="showCreateDialog"
-        class="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
-        @click.self="showCreateDialog = false"
-      >
-        <div class="w-full max-w-sm rounded-lg border bg-white p-6 shadow-lg">
-          <h2 class="mb-4 text-lg font-semibold">Create Tenant</h2>
-          <form @submit.prevent="handleCreateTenant">
-            <div class="mb-3">
-              <label class="mb-1 block text-sm font-medium text-gray-700">Name</label>
-              <input
-                v-model="createForm.name"
-                type="text"
-                required
-                class="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
-              />
-            </div>
-            <div class="mb-3">
-              <label class="mb-1 block text-sm font-medium text-gray-700">Slug</label>
-              <input
-                v-model="createForm.slug"
-                type="text"
-                required
-                pattern="[a-z0-9-]+"
-                class="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
-              />
-              <p class="mt-1 text-xs text-gray-400">Lowercase letters, numbers, and hyphens</p>
-            </div>
-            <p v-if="createError" class="mb-3 text-sm text-red-600">{{ createError }}</p>
-            <div class="flex justify-end gap-2">
-              <button
-                type="button"
-                class="rounded-md border px-3 py-1.5 text-sm text-gray-600 hover:bg-gray-50"
-                @click="showCreateDialog = false"
-              >
-                Cancel
-              </button>
-              <button
-                type="submit"
-                :disabled="createLoading"
-                class="rounded-md bg-blue-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50"
-              >
-                {{ createLoading ? 'Creating...' : 'Create' }}
-              </button>
-            </div>
-          </form>
+        <div class="mt-6 text-center">
+          <button class="text-sm text-gray-400 hover:text-gray-600" @click="handleLogout">
+            Sign out
+          </button>
         </div>
-      </div>
+
+        <!-- Create tenant dialog -->
+        <div
+          v-if="showCreateDialog"
+          class="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+          @click.self="showCreateDialog = false"
+        >
+          <div class="w-full max-w-sm rounded-lg border bg-white p-6 shadow-lg">
+            <h2 class="mb-4 text-lg font-semibold">Create Tenant</h2>
+            <form @submit.prevent="handleCreateTenant">
+              <div class="mb-3">
+                <label class="mb-1 block text-sm font-medium text-gray-700">Name</label>
+                <input
+                  v-model="createForm.name"
+                  type="text"
+                  required
+                  autofocus
+                  class="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
+                />
+              </div>
+              <div class="mb-3">
+                <label class="mb-1 block text-sm font-medium text-gray-700">Slug</label>
+                <input
+                  v-model="createForm.slug"
+                  type="text"
+                  required
+                  pattern="[a-z0-9-]+"
+                  class="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
+                  @input="slugManuallyEdited = true"
+                />
+                <p class="mt-1 text-xs text-gray-400">Auto-generated from name. Edit to customize.</p>
+              </div>
+              <p v-if="createError" class="mb-3 text-sm text-red-600">{{ createError }}</p>
+              <div class="flex justify-end gap-2">
+                <button
+                  type="button"
+                  class="rounded-md border px-3 py-1.5 text-sm text-gray-600 hover:bg-gray-50"
+                  @click="showCreateDialog = false"
+                >
+                  Cancel
+                </button>
+                <button
+                  type="submit"
+                  :disabled="createLoading"
+                  class="rounded-md bg-blue-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50"
+                >
+                  {{ createLoading ? 'Creating...' : 'Create' }}
+                </button>
+              </div>
+            </form>
+          </div>
+        </div>
+      </template>
     </div>
   </div>
 </template>

--- a/web-ui/src/stores/auth.ts
+++ b/web-ui/src/stores/auth.ts
@@ -10,7 +10,9 @@ export const useAuthStore = defineStore('auth', () => {
   const user = ref<UserInfo | null>(null)
   const authUser = ref<AuthInfoUser | null>(null)
   const tenants = ref<AuthInfoTenant[]>([])
-  const currentTenantId = ref<string | null>(localStorage.getItem('tenant_id') || null)
+  const currentTenantId = ref<string | null>(
+    localStorage.getItem('tenant_id') || sessionStorage.getItem('tenant_id') || null,
+  )
   const invitations = ref<Invitation[]>([])
   const invitationsLoaded = ref(false)
 
@@ -28,6 +30,10 @@ export const useAuthStore = defineStore('auth', () => {
   async function login(username: string, password: string, rememberMe = true) {
     const data = await apiLogin({ username, password })
     token.value = data.token
+    localStorage.removeItem('token')
+    localStorage.removeItem('tenant_id')
+    sessionStorage.removeItem('token')
+    sessionStorage.removeItem('tenant_id')
     const storage = rememberMe ? localStorage : sessionStorage
     storage.setItem('token', data.token)
   }

--- a/web-ui/src/stores/auth.ts
+++ b/web-ui/src/stores/auth.ts
@@ -6,7 +6,7 @@ import type { UserInfo, AuthInfoUser, AuthInfoTenant, Invitation } from '@/types
 import { UserRole } from '@/types/api'
 
 export const useAuthStore = defineStore('auth', () => {
-  const token = ref<string>(localStorage.getItem('token') || '')
+  const token = ref<string>(localStorage.getItem('token') || sessionStorage.getItem('token') || '')
   const user = ref<UserInfo | null>(null)
   const authUser = ref<AuthInfoUser | null>(null)
   const tenants = ref<AuthInfoTenant[]>([])
@@ -25,10 +25,11 @@ export const useAuthStore = defineStore('auth', () => {
     invitations.value.filter((i) => i.status === 'pending').length,
   )
 
-  async function login(username: string, password: string) {
+  async function login(username: string, password: string, rememberMe = true) {
     const data = await apiLogin({ username, password })
     token.value = data.token
-    localStorage.setItem('token', data.token)
+    const storage = rememberMe ? localStorage : sessionStorage
+    storage.setItem('token', data.token)
   }
 
   async function fetchAuthInfo() {
@@ -48,15 +49,19 @@ export const useAuthStore = defineStore('auth', () => {
     invitationsLoaded.value = true
   }
 
+  function getActiveStorage() {
+    return sessionStorage.getItem('token') ? sessionStorage : localStorage
+  }
+
   function selectTenant(tenantId: string) {
     currentTenantId.value = tenantId
-    localStorage.setItem('tenant_id', tenantId)
+    getActiveStorage().setItem('tenant_id', tenantId)
     user.value = null
   }
 
   function clearTenant() {
     currentTenantId.value = null
-    localStorage.removeItem('tenant_id')
+    getActiveStorage().removeItem('tenant_id')
     user.value = null
   }
 
@@ -70,6 +75,8 @@ export const useAuthStore = defineStore('auth', () => {
     invitationsLoaded.value = false
     localStorage.removeItem('token')
     localStorage.removeItem('tenant_id')
+    sessionStorage.removeItem('token')
+    sessionStorage.removeItem('tenant_id')
   }
 
   async function logout() {


### PR DESCRIPTION
## Summary

- **LoginPage**: Password visibility toggle (eye icon), autofocus on username, brand logo + subtitle "Short URL Management Platform", "Remember me" checkbox (localStorage vs sessionStorage)
- **SelectTenantPage**: Loading spinner during `fetchAuthInfo` to prevent blank-to-list flash, slug auto-generated from tenant name with manual edit override
- **ChangePasswordPage**: Password visibility toggles on all 3 fields, 5-level password strength indicator bar, inline success banner with auto-dismiss, real-time confirm password mismatch warning
- **Auth store**: `rememberMe` parameter controls token storage (localStorage for persistent, sessionStorage for session-only)

Closes #60

## Test plan

- [ ] Login page shows logo, subtitle, autofocus on username, password eye toggle works
- [ ] Unchecking "Remember me" stores token in sessionStorage (cleared on browser close)
- [ ] SelectTenantPage shows spinner while loading auth info
- [ ] Create tenant dialog auto-generates slug from name; manual edits are preserved
- [ ] Change password page shows/hides all 3 password fields independently
- [ ] Strength bar updates live with color progression (red → green)
- [ ] Success banner appears and auto-dismisses after password change
- [ ] Confirm password field shows red border + "do not match" hint

🤖 Generated with [Claude Code](https://claude.com/claude-code)