### PR TITLE
feat(web-ui): enhance short link management pages UX

### DIFF
--- a/web-ui/src/pages/ShortLinkCreatePage.vue
+++ b/web-ui/src/pages/ShortLinkCreatePage.vue
@@ -5,7 +5,8 @@ import { createShortLink } from '@/api/short-link'
 import { useAuthStore } from '@/stores/auth'
 import { useToast } from '@/composables/useToast'
 import { UserRole } from '@/types/api'
-import { ArrowLeft } from 'lucide-vue-next'
+import type { ShortLinkData } from '@/types/api'
+import { ArrowLeft, Copy, Check, ExternalLink } from 'lucide-vue-next'
 
 defineOptions({ name: 'ShortLinkCreatePage' })
 
@@ -19,20 +20,62 @@ const description = ref('')
 const isEnable = ref(true)
 const loading = ref(false)
 const error = ref('')
+const createdLink = ref<ShortLinkData | null>(null)
+const copiedShortLink = ref(false)
 
 const isAdmin = computed(() => auth.user?.role === UserRole.Admin)
+
+const CUSTOM_ID_REGEX = /^[a-zA-Z0-9_-]+$/
+const CUSTOM_ID_MAX_LENGTH = 64
+
+const customIdError = computed(() => {
+  if (!customId.value) return ''
+  if (customId.value.length < 2) return 'Custom ID must be at least 2 characters'
+  if (customId.value.length > CUSTOM_ID_MAX_LENGTH)
+    return `Custom ID must be at most ${CUSTOM_ID_MAX_LENGTH} characters`
+  if (!CUSTOM_ID_REGEX.test(customId.value))
+    return 'Custom ID can only contain letters, numbers, hyphens, and underscores'
+  return ''
+})
+
+function normalizeUrl(value: string): string {
+  const trimmed = value.trim()
+  if (!trimmed) return ''
+  if (/^https?:\/\//i.test(trimmed)) return trimmed
+  return `https://${trimmed}`
+}
 
 const urlError = computed(() => {
   if (!url.value) return ''
   try {
-    new URL(url.value)
+    new URL(normalizeUrl(url.value))
     return ''
   } catch {
     return 'Please enter a valid URL (e.g. https://example.com)'
   }
 })
 
-const canSubmit = computed(() => !!url.value && !urlError.value && !loading.value)
+const canSubmit = computed(
+  () =>
+    !!url.value &&
+    !urlError.value &&
+    !customIdError.value &&
+    !loading.value,
+)
+
+function getShortLinkUrl(id: string) {
+  return `${window.location.origin}/${id}`
+}
+
+function copyCreatedLink() {
+  if (!createdLink.value) return
+  navigator.clipboard.writeText(getShortLinkUrl(createdLink.value.id)).then(() => {
+    copiedShortLink.value = true
+    setTimeout(() => {
+      copiedShortLink.value = false
+    }, 2000)
+  })
+}
 
 async function handleSubmit() {
   if (!canSubmit.value) return
@@ -40,19 +83,33 @@ async function handleSubmit() {
   loading.value = true
 
   try {
-    await createShortLink({
-      url: url.value,
+    const normalizedUrl = normalizeUrl(url.value)
+    const result = await createShortLink({
+      url: normalizedUrl,
       description: description.value,
       isEnable: isEnable.value,
       ...(isAdmin.value && customId.value ? { id: customId.value } : {}),
     })
+    createdLink.value = result.shortLink
     toast.success('Short link created successfully')
-    router.push({ name: 'short-links' })
   } catch {
     error.value = 'Failed to create short link. Please try again.'
   } finally {
     loading.value = false
   }
+}
+
+function handleCreateAnother() {
+  url.value = ''
+  customId.value = ''
+  description.value = ''
+  isEnable.value = true
+  error.value = ''
+  createdLink.value = null
+}
+
+function goToLinks() {
+  router.push({ name: 'short-links' })
 }
 </script>
 
@@ -71,7 +128,63 @@ async function handleSubmit() {
       </div>
     </div>
 
-    <form class="mt-6 max-w-lg rounded-lg border bg-white p-6" @submit.prevent="handleSubmit">
+    <!-- Success state -->
+    <div
+      v-if="createdLink"
+      class="mt-6 max-w-lg rounded-lg border border-green-200 bg-green-50 p-6"
+    >
+      <h2 class="text-lg font-semibold text-green-800">Short Link Created!</h2>
+      <div class="mt-3 flex items-center gap-2 rounded-md bg-white p-3 shadow-sm">
+        <span class="font-mono text-sm font-medium text-gray-900">
+          {{ getShortLinkUrl(createdLink.id) }}
+        </span>
+        <button
+          class="rounded p-1 text-gray-400 transition-colors hover:text-green-600"
+          title="Copy short link"
+          @click="copyCreatedLink"
+        >
+          <Copy v-if="!copiedShortLink" class="h-4 w-4" />
+          <Check v-else class="h-4 w-4 text-green-500" />
+        </button>
+        <a
+          :href="getShortLinkUrl(createdLink.id)"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="rounded p-1 text-gray-400 transition-colors hover:text-blue-600"
+          title="Open short link"
+        >
+          <ExternalLink class="h-4 w-4" />
+        </a>
+      </div>
+      <p class="mt-2 text-sm text-gray-600">
+        Destination:
+        <a
+          :href="createdLink.url"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="text-blue-600 hover:underline"
+        >
+          {{ createdLink.url }}
+        </a>
+      </p>
+      <div class="mt-4 flex items-center gap-3">
+        <button
+          class="rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-blue-700"
+          @click="handleCreateAnother"
+        >
+          Create Another
+        </button>
+        <button
+          class="rounded-md px-4 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-100"
+          @click="goToLinks"
+        >
+          View All Links
+        </button>
+      </div>
+    </div>
+
+    <!-- Create form -->
+    <form v-else class="mt-6 max-w-lg rounded-lg border bg-white p-6" @submit.prevent="handleSubmit">
       <div class="space-y-5">
         <div>
           <label class="mb-1 block text-sm font-medium text-gray-700">
@@ -79,13 +192,16 @@ async function handleSubmit() {
           </label>
           <input
             v-model="url"
-            type="url"
+            type="text"
             required
-            placeholder="https://example.com/long-url"
+            placeholder="example.com/long-url or https://example.com"
             class="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
             :class="urlError ? 'border-red-300 focus:border-red-500 focus:ring-red-500' : ''"
           />
           <p v-if="urlError" class="mt-1 text-xs text-red-600">{{ urlError }}</p>
+          <p v-else class="mt-1 text-xs text-gray-400">
+            https:// will be added automatically if omitted.
+          </p>
         </div>
 
         <div v-if="isAdmin">
@@ -97,9 +213,14 @@ async function handleSubmit() {
             v-model="customId"
             type="text"
             placeholder="my-custom-id"
+            maxlength="64"
             class="w-full rounded-md border border-gray-300 px-3 py-2 font-mono text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
+            :class="customIdError ? 'border-red-300 focus:border-red-500 focus:ring-red-500' : ''"
           />
-          <p class="mt-1 text-xs text-gray-400">Leave empty to auto-generate a short ID.</p>
+          <p v-if="customIdError" class="mt-1 text-xs text-red-600">{{ customIdError }}</p>
+          <p v-else class="mt-1 text-xs text-gray-400">
+            Letters, numbers, hyphens, underscores. 2–64 characters. Leave empty to auto-generate.
+          </p>
         </div>
 
         <div>

--- a/web-ui/src/pages/ShortLinkCreatePage.vue
+++ b/web-ui/src/pages/ShortLinkCreatePage.vue
@@ -69,12 +69,17 @@ function getShortLinkUrl(id: string) {
 
 function copyCreatedLink() {
   if (!createdLink.value) return
-  navigator.clipboard.writeText(getShortLinkUrl(createdLink.value.id)).then(() => {
-    copiedShortLink.value = true
-    setTimeout(() => {
-      copiedShortLink.value = false
-    }, 2000)
-  })
+  navigator.clipboard.writeText(getShortLinkUrl(createdLink.value.id)).then(
+    () => {
+      copiedShortLink.value = true
+      setTimeout(() => {
+        copiedShortLink.value = false
+      }, 2000)
+    },
+    () => {
+      toast.error('Failed to copy link to clipboard')
+    },
+  )
 }
 
 async function handleSubmit() {

--- a/web-ui/src/pages/ShortLinkEditPage.vue
+++ b/web-ui/src/pages/ShortLinkEditPage.vue
@@ -23,10 +23,17 @@ const saving = ref(false)
 const error = ref('')
 const notFound = ref(false)
 
+function normalizeUrl(value: string): string {
+  const trimmed = value.trim()
+  if (!trimmed) return ''
+  if (/^https?:\/\//i.test(trimmed)) return trimmed
+  return `https://${trimmed}`
+}
+
 const urlError = computed(() => {
   if (!url.value) return ''
   try {
-    new URL(url.value)
+    new URL(normalizeUrl(url.value))
     return ''
   } catch {
     return 'Please enter a valid URL (e.g. https://example.com)'
@@ -62,8 +69,9 @@ async function handleSubmit() {
   saving.value = true
 
   try {
+    const normalizedUrl = normalizeUrl(url.value)
     await updateShortLink(id, {
-      url: url.value,
+      url: normalizedUrl,
       description: description.value,
       isEnable: isEnable.value,
     })
@@ -105,7 +113,30 @@ onMounted(fetchData)
       </div>
     </div>
 
-    <div v-if="loading" class="mt-6 text-center text-gray-400">Loading...</div>
+    <!-- Skeleton loading -->
+    <div v-if="loading" class="mt-6 max-w-lg rounded-lg border bg-white p-6">
+      <div class="mb-5 rounded-md bg-gray-50 p-3">
+        <div class="grid grid-cols-2 gap-2">
+          <div class="h-4 w-32 animate-pulse rounded bg-gray-200" />
+          <div class="h-4 w-28 animate-pulse rounded bg-gray-200" />
+          <div class="col-span-2 h-4 w-48 animate-pulse rounded bg-gray-200" />
+        </div>
+      </div>
+      <div class="space-y-5">
+        <div>
+          <div class="mb-1 h-4 w-16 animate-pulse rounded bg-gray-200" />
+          <div class="h-9 w-full animate-pulse rounded-md bg-gray-200" />
+        </div>
+        <div>
+          <div class="mb-1 h-4 w-20 animate-pulse rounded bg-gray-200" />
+          <div class="h-20 w-full animate-pulse rounded-md bg-gray-200" />
+        </div>
+        <div class="flex items-center gap-3">
+          <div class="h-4 w-14 animate-pulse rounded bg-gray-200" />
+          <div class="h-6 w-11 animate-pulse rounded-full bg-gray-200" />
+        </div>
+      </div>
+    </div>
 
     <div v-else-if="notFound" class="mt-6 text-center text-gray-400">
       Short link not found.
@@ -147,12 +178,16 @@ onMounted(fetchData)
           </label>
           <input
             v-model="url"
-            type="url"
+            type="text"
             required
+            placeholder="example.com/long-url or https://example.com"
             class="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
             :class="urlError ? 'border-red-300 focus:border-red-500 focus:ring-red-500' : ''"
           />
           <p v-if="urlError" class="mt-1 text-xs text-red-600">{{ urlError }}</p>
+          <p v-else class="mt-1 text-xs text-gray-400">
+            https:// will be added automatically if omitted.
+          </p>
         </div>
 
         <div>

--- a/web-ui/src/pages/ShortLinksPage.vue
+++ b/web-ui/src/pages/ShortLinksPage.vue
@@ -209,9 +209,9 @@ async function handleBatchDelete() {
 async function handleBatchToggleEnable(enable: boolean) {
   if (selectedIds.value.size === 0) return
   batchUpdating.value = true
-  const count = selectedIds.value.size
   const ids = [...selectedIds.value]
   try {
+    let updated = 0
     await Promise.all(
       ids.map(async (id) => {
         const link = links.value.find((l) => l.id === id)
@@ -222,10 +222,11 @@ async function handleBatchToggleEnable(enable: boolean) {
             isEnable: enable,
           })
           link.isEnable = enable
+          updated++
         }
       }),
     )
-    toast.success(`${count} short link${count !== 1 ? 's' : ''} ${enable ? 'enabled' : 'disabled'}`)
+    toast.success(`${updated} short link${updated !== 1 ? 's' : ''} ${enable ? 'enabled' : 'disabled'}`)
   } catch (e: unknown) {
     toast.error((e as Error).message || `Failed to ${enable ? 'enable' : 'disable'} some short links`)
   } finally {
@@ -580,7 +581,7 @@ onMounted(fetchLinks)
           >
             <ChevronLeft class="h-5 w-5" />
           </button>
-          <template v-for="p in pageNumbers" :key="p">
+          <template v-for="(p, idx) in pageNumbers" :key="`page-${idx}`">
             <span v-if="p === '...'" class="px-1 text-sm text-gray-400">...</span>
             <button
               v-else

--- a/web-ui/src/pages/ShortLinksPage.vue
+++ b/web-ui/src/pages/ShortLinksPage.vue
@@ -15,6 +15,11 @@ import {
   ChevronRight,
   Check,
   Eye,
+  ArrowUpDown,
+  ArrowUp,
+  ArrowDown,
+  Link,
+  Loader2,
 } from 'lucide-vue-next'
 
 defineOptions({ name: 'ShortLinksPage' })
@@ -27,6 +32,7 @@ const total = ref(0)
 const page = ref(1)
 const pageSize = ref(20)
 const loading = ref(false)
+const pageJump = ref('')
 
 const searchId = ref('')
 const searchUrl = ref('')
@@ -37,6 +43,12 @@ const deleting = ref<string | null>(null)
 const togglingId = ref<string | null>(null)
 const copiedId = ref<string | null>(null)
 const confirmDeleteId = ref<string | null>(null)
+const batchUpdating = ref(false)
+
+type SortField = 'createTime' | 'updateTime' | 'id'
+type SortDirection = 'asc' | 'desc'
+const sortField = ref<SortField>('createTime')
+const sortDirection = ref<SortDirection>('desc')
 
 const filteredLinks = computed(() => {
   let result = links.value
@@ -55,11 +67,48 @@ const filteredLinks = computed(() => {
   return result
 })
 
+const sortedLinks = computed(() => {
+  const arr = [...filteredLinks.value]
+  const dir = sortDirection.value === 'asc' ? 1 : -1
+  return arr.sort((a, b) => {
+    switch (sortField.value) {
+      case 'createTime':
+        return dir * (new Date(a.createTime).getTime() - new Date(b.createTime).getTime())
+      case 'updateTime':
+        return dir * (new Date(a.updateTime).getTime() - new Date(b.updateTime).getTime())
+      case 'id':
+        return dir * a.id.localeCompare(b.id)
+      default:
+        return 0
+    }
+  })
+})
+
 const totalPages = computed(() => Math.max(1, Math.ceil(total.value / pageSize.value)))
 const allSelected = computed(
   () =>
     filteredLinks.value.length > 0 && filteredLinks.value.every((l) => selectedIds.value.has(l.id)),
 )
+
+const pageNumbers = computed(() => {
+  const pages: (number | '...')[] = []
+  const tp = totalPages.value
+  const p = page.value
+  if (tp <= 7) {
+    for (let i = 1; i <= tp; i++) pages.push(i)
+  } else {
+    pages.push(1)
+    if (p > 3) pages.push('...')
+    const start = Math.max(2, p - 1)
+    const end = Math.min(tp - 1, p + 1)
+    for (let i = start; i <= end; i++) pages.push(i)
+    if (p < tp - 2) pages.push('...')
+    pages.push(tp)
+  }
+  return pages
+})
+
+const pageSizeOptions = [10, 20, 50, 100]
 
 async function fetchLinks() {
   loading.value = true
@@ -73,6 +122,20 @@ async function fetchLinks() {
   } finally {
     loading.value = false
   }
+}
+
+function toggleSort(field: SortField) {
+  if (sortField.value === field) {
+    sortDirection.value = sortDirection.value === 'asc' ? 'desc' : 'asc'
+  } else {
+    sortField.value = field
+    sortDirection.value = 'desc'
+  }
+}
+
+function SortIcon({ field }: { field: SortField }) {
+  if (sortField.value !== field) return ArrowUpDown
+  return sortDirection.value === 'asc' ? ArrowUp : ArrowDown
 }
 
 function toggleSelect(id: string) {
@@ -143,6 +206,33 @@ async function handleBatchDelete() {
   }
 }
 
+async function handleBatchToggleEnable(enable: boolean) {
+  if (selectedIds.value.size === 0) return
+  batchUpdating.value = true
+  const count = selectedIds.value.size
+  const ids = [...selectedIds.value]
+  try {
+    await Promise.all(
+      ids.map(async (id) => {
+        const link = links.value.find((l) => l.id === id)
+        if (link && link.isEnable !== enable) {
+          await updateShortLink(id, {
+            url: link.url,
+            description: link.description,
+            isEnable: enable,
+          })
+          link.isEnable = enable
+        }
+      }),
+    )
+    toast.success(`${count} short link${count !== 1 ? 's' : ''} ${enable ? 'enabled' : 'disabled'}`)
+  } catch (e: unknown) {
+    toast.error((e as Error).message || `Failed to ${enable ? 'enable' : 'disable'} some short links`)
+  } finally {
+    batchUpdating.value = false
+  }
+}
+
 function copyLink(id: string) {
   const url = `${window.location.origin}/${id}`
   navigator.clipboard.writeText(url).then(
@@ -153,7 +243,7 @@ function copyLink(id: string) {
       }, 2000)
     },
     () => {
-      // clipboard not available (non-HTTPS or no permission)
+      // clipboard not available
     },
   )
 }
@@ -161,6 +251,19 @@ function copyLink(id: string) {
 function goPage(p: number) {
   if (p < 1 || p > totalPages.value) return
   page.value = p
+  fetchLinks()
+}
+
+function handlePageJump() {
+  const n = parseInt(pageJump.value, 10)
+  if (!isNaN(n) && n >= 1 && n <= totalPages.value) {
+    goPage(n)
+  }
+  pageJump.value = ''
+}
+
+function handlePageSizeChange() {
+  page.value = 1
   fetchLinks()
 }
 
@@ -229,6 +332,20 @@ onMounted(fetchLinks)
     <div v-if="selectedIds.size > 0" class="mt-3 flex items-center gap-3">
       <span class="text-sm text-gray-600">{{ selectedIds.size }} selected</span>
       <button
+        :disabled="batchUpdating"
+        class="inline-flex items-center gap-1.5 rounded-md bg-green-50 px-3 py-1.5 text-sm font-medium text-green-600 transition-colors hover:bg-green-100 disabled:opacity-50"
+        @click="handleBatchToggleEnable(true)"
+      >
+        Enable Selected
+      </button>
+      <button
+        :disabled="batchUpdating"
+        class="inline-flex items-center gap-1.5 rounded-md bg-gray-100 px-3 py-1.5 text-sm font-medium text-gray-600 transition-colors hover:bg-gray-200 disabled:opacity-50"
+        @click="handleBatchToggleEnable(false)"
+      >
+        Disable Selected
+      </button>
+      <button
         :disabled="deleting === 'batch'"
         class="inline-flex items-center gap-1.5 rounded-md bg-red-50 px-3 py-1.5 text-sm font-medium text-red-600 transition-colors hover:bg-red-100 disabled:opacity-50"
         @click="handleBatchDelete"
@@ -254,24 +371,91 @@ onMounted(fetchLinks)
                   @change="toggleSelectAll"
                 />
               </th>
-              <th class="px-4 py-3">ID</th>
+              <th class="cursor-pointer select-none px-4 py-3" @click="toggleSort('id')">
+                <div class="flex items-center gap-1">
+                  ID
+                  <component :is="SortIcon({ field: 'id' })" class="h-3.5 w-3.5" />
+                </div>
+              </th>
               <th class="px-4 py-3">URL</th>
               <th class="hidden px-4 py-3 md:table-cell">Description</th>
               <th class="px-4 py-3">Status</th>
-              <th class="hidden px-4 py-3 lg:table-cell">Created</th>
-              <th class="hidden px-4 py-3 lg:table-cell">Updated</th>
+              <th
+                class="hidden cursor-pointer select-none px-4 py-3 lg:table-cell"
+                @click="toggleSort('createTime')"
+              >
+                <div class="flex items-center gap-1">
+                  Created
+                  <component :is="SortIcon({ field: 'createTime' })" class="h-3.5 w-3.5" />
+                </div>
+              </th>
+              <th
+                class="hidden cursor-pointer select-none px-4 py-3 lg:table-cell"
+                @click="toggleSort('updateTime')"
+              >
+                <div class="flex items-center gap-1">
+                  Updated
+                  <component :is="SortIcon({ field: 'updateTime' })" class="h-3.5 w-3.5" />
+                </div>
+              </th>
               <th class="px-4 py-3 text-right">Actions</th>
             </tr>
           </thead>
           <tbody class="divide-y">
-            <tr v-if="loading">
-              <td colspan="8" class="px-4 py-8 text-center text-gray-400">Loading...</td>
+            <!-- Skeleton loading -->
+            <template v-if="loading">
+              <tr v-for="i in 5" :key="`skeleton-${i}`">
+                <td class="px-4 py-3">
+                  <div class="h-4 w-4 animate-pulse rounded bg-gray-200" />
+                </td>
+                <td class="px-4 py-3">
+                  <div class="h-4 w-20 animate-pulse rounded bg-gray-200" />
+                </td>
+                <td class="px-4 py-3">
+                  <div class="h-4 w-40 animate-pulse rounded bg-gray-200" />
+                </td>
+                <td class="hidden px-4 py-3 md:table-cell">
+                  <div class="h-4 w-32 animate-pulse rounded bg-gray-200" />
+                </td>
+                <td class="px-4 py-3">
+                  <div class="h-5 w-16 animate-pulse rounded-full bg-gray-200" />
+                </td>
+                <td class="hidden px-4 py-3 lg:table-cell">
+                  <div class="h-4 w-28 animate-pulse rounded bg-gray-200" />
+                </td>
+                <td class="hidden px-4 py-3 lg:table-cell">
+                  <div class="h-4 w-28 animate-pulse rounded bg-gray-200" />
+                </td>
+                <td class="px-4 py-3">
+                  <div class="ml-auto h-4 w-20 animate-pulse rounded bg-gray-200" />
+                </td>
+              </tr>
+            </template>
+            <!-- Empty state -->
+            <tr v-else-if="filteredLinks.length === 0 && total === 0">
+              <td colspan="8" class="px-4 py-12 text-center">
+                <Link class="mx-auto h-10 w-10 text-gray-300" />
+                <p class="mt-3 text-sm font-medium text-gray-500">No short links yet</p>
+                <p class="mt-1 text-sm text-gray-400">
+                  Create your first short link to get started.
+                </p>
+                <router-link
+                  :to="{ name: 'short-link-create' }"
+                  class="mt-3 inline-flex items-center gap-1.5 rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-blue-700"
+                >
+                  <Plus class="h-4 w-4" />
+                  Create your first link
+                </router-link>
+              </td>
             </tr>
             <tr v-else-if="filteredLinks.length === 0">
-              <td colspan="8" class="px-4 py-8 text-center text-gray-400">No short links found.</td>
+              <td colspan="8" class="px-4 py-8 text-center text-gray-400">
+                No short links match your search.
+              </td>
             </tr>
+            <!-- Data rows -->
             <tr
-              v-for="link in filteredLinks"
+              v-for="link in sortedLinks"
               :key="link.id"
               class="transition-colors hover:bg-gray-50"
               :class="{ 'bg-blue-50/50': selectedIds.has(link.id) }"
@@ -322,7 +506,9 @@ onMounted(fetchLinks)
                   "
                   @click="handleToggleEnable(link)"
                 >
+                  <Loader2 v-if="togglingId === link.id" class="h-3 w-3 animate-spin" />
                   <span
+                    v-else
                     class="h-1.5 w-1.5 rounded-full"
                     :class="link.isEnable ? 'bg-green-500' : 'bg-gray-400'"
                   />
@@ -365,12 +551,28 @@ onMounted(fetchLinks)
         </table>
       </div>
 
-      <!-- Pagination -->
-      <div v-if="totalPages > 1" class="flex items-center justify-between border-t px-4 py-3">
-        <span class="text-sm text-gray-500">
-          Page {{ page }} of {{ totalPages }} ({{ total }} items)
-        </span>
-        <div class="flex items-center gap-1">
+      <!-- Enhanced Pagination -->
+      <div
+        v-if="totalPages > 1 || total > 0"
+        class="flex flex-col items-center justify-between gap-3 border-t px-4 py-3 sm:flex-row"
+      >
+        <div class="flex items-center gap-2">
+          <span class="text-sm text-gray-500">Show</span>
+          <select
+            v-model="pageSize"
+            class="rounded-md border border-gray-300 px-2 py-1 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
+            @change="handlePageSizeChange"
+          >
+            <option v-for="size in pageSizeOptions" :key="size" :value="size">
+              {{ size }}
+            </option>
+          </select>
+          <span class="text-sm text-gray-500">per page</span>
+          <span class="ml-2 text-sm text-gray-400">
+            {{ (page - 1) * pageSize + 1 }}–{{ Math.min(page * pageSize, total) }} of {{ total }}
+          </span>
+        </div>
+        <div v-if="totalPages > 1" class="flex items-center gap-1">
           <button
             :disabled="page <= 1"
             class="rounded p-1.5 text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-600 disabled:opacity-30"
@@ -378,6 +580,21 @@ onMounted(fetchLinks)
           >
             <ChevronLeft class="h-5 w-5" />
           </button>
+          <template v-for="p in pageNumbers" :key="p">
+            <span v-if="p === '...'" class="px-1 text-sm text-gray-400">...</span>
+            <button
+              v-else
+              :class="[
+                'min-w-[32px] rounded px-2 py-1 text-sm font-medium transition-colors',
+                p === page
+                  ? 'bg-blue-600 text-white'
+                  : 'text-gray-600 hover:bg-gray-100',
+              ]"
+              @click="goPage(p as number)"
+            >
+              {{ p }}
+            </button>
+          </template>
           <button
             :disabled="page >= totalPages"
             class="rounded p-1.5 text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-600 disabled:opacity-30"
@@ -385,6 +602,17 @@ onMounted(fetchLinks)
           >
             <ChevronRight class="h-5 w-5" />
           </button>
+          <div class="ml-2 flex items-center gap-1">
+            <span class="text-sm text-gray-400">Go to</span>
+            <input
+              v-model="pageJump"
+              type="number"
+              :min="1"
+              :max="totalPages"
+              class="w-14 rounded-md border border-gray-300 px-2 py-1 text-center text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
+              @keyup.enter="handlePageJump"
+            />
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- **ShortLinksPage**: Skeleton loading, sortable columns (ID/created/updated), page size selector + page jump navigation, batch enable/disable, improved empty state with CTA
- **ShortLinkCreatePage**: Auto-prepend `https://` to URLs, Custom ID format validation with character hints, display generated short link with copy button after creation
- **ShortLinkEditPage**: Skeleton loading, auto-prepend `https://` to URLs (already stayed on page with toast after save)

Closes: JWM-62

## Task Checklist

### ShortLinksPage (列表页)
- [x] Loading 状态：skeleton 替代文字 "Loading..."
- [x] 添加表格列排序功能（按 ID、创建时间、更新时间）
- [x] 分页增强：页码导航 + 每页条数选择 + 跳转输入
- [x] 批量操作扩展：批量启用/禁用（除已有删除外）
- [x] 空状态优化：图标 + "Create your first link" 引导按钮
- [ ] 搜索改为后端搜索（需后端配合，前端暂保持客户端过滤）

### ShortLinkCreatePage（创建页）
- [x] URL 自动补协议：输入 `example.com` 自动补 `https://`
- [x] Custom ID 格式校验：字母数字下划线连字符，2-64字符
- [x] 创建成功后展示生成的短链接（含复制按钮）
- [x] 创建成功后 Toast 反馈

### ShortLinkEditPage（编辑页）
- [x] 保存成功后留在编辑页 + Toast 提示（已有）
- [x] 加载状态改为 skeleton
- [x] URL 自动补协议

## Test plan
- [ ] Verify skeleton loading displays correctly on ShortLinksPage
- [ ] Test column sorting by clicking ID/Created/Updated headers
- [ ] Test page size selector changes and page navigation (numbered pages + jump input)
- [ ] Test batch select → Enable/Disable buttons work
- [ ] Verify empty state shows icon + CTA when no links exist
- [ ] Test URL auto-prepend: type "example.com" → submits as "https://example.com"
- [ ] Test Custom ID validation: invalid chars show error, length limits enforced
- [ ] Create a link → verify success state shows short URL with copy button
- [ ] Edit a link → verify stays on page with toast after save

🤖 Generated with [Claude Code](https://claude.com/claude-code)