### PR TITLE
feat(web-ui): unified ConfirmDialog + unsaved changes guard

### DIFF
--- a/web-ui/src/components/ConfirmDialog.vue
+++ b/web-ui/src/components/ConfirmDialog.vue
@@ -1,0 +1,92 @@
+<script setup lang="ts">
+import { ref, watch, nextTick, onBeforeUnmount } from 'vue'
+
+const props = withDefaults(defineProps<{
+  open: boolean
+  title: string
+  message?: string
+  variant?: 'danger' | 'primary'
+  confirmText?: string
+  cancelText?: string
+  loading?: boolean
+}>(), {
+  variant: 'primary',
+  confirmText: 'Confirm',
+  cancelText: 'Cancel',
+  loading: false,
+})
+
+const emit = defineEmits<{
+  confirm: []
+  cancel: []
+}>()
+
+const confirmBtnRef = ref<HTMLButtonElement | null>(null)
+let previousFocusEl: HTMLElement | null = null
+
+function handleKeydown(e: KeyboardEvent) {
+  if (e.key === 'Escape') {
+    emit('cancel')
+  }
+}
+
+watch(() => props.open, (isOpen) => {
+  if (isOpen) {
+    previousFocusEl = document.activeElement as HTMLElement
+    document.addEventListener('keydown', handleKeydown)
+    nextTick(() => confirmBtnRef.value?.focus())
+  } else {
+    document.removeEventListener('keydown', handleKeydown)
+    if (previousFocusEl) {
+      previousFocusEl.focus()
+      previousFocusEl = null
+    }
+  }
+})
+
+onBeforeUnmount(() => {
+  document.removeEventListener('keydown', handleKeydown)
+  if (previousFocusEl) {
+    previousFocusEl.focus()
+  }
+})
+</script>
+
+<template>
+  <Teleport to="body">
+    <div
+      v-if="open"
+      class="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+      @click.self="emit('cancel')"
+    >
+      <div
+        role="dialog"
+        aria-modal="true"
+        tabindex="-1"
+        class="mx-4 w-full max-w-sm rounded-lg bg-white p-6 shadow-xl"
+      >
+        <h3 class="text-lg font-semibold text-gray-900">{{ title }}</h3>
+        <slot>
+          <p v-if="message" class="mt-2 text-sm text-gray-600">{{ message }}</p>
+        </slot>
+        <div class="mt-4 flex justify-end gap-2">
+          <button
+            class="rounded-md px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-100"
+            @click="emit('cancel')"
+          >
+            {{ cancelText }}
+          </button>
+          <button
+            ref="confirmBtnRef"
+            :disabled="loading"
+            class="rounded-md px-4 py-2 text-sm font-medium text-white disabled:opacity-50"
+            :class="variant === 'danger' ? 'bg-red-600 hover:bg-red-700' : 'bg-blue-600 hover:bg-blue-700'"
+            @click="emit('confirm')"
+          >
+            {{ confirmText }}
+          </button>
+        </div>
+      </div>
+    </div>
+  </Teleport>
+</template>

--- a/web-ui/src/components/ConfirmDialog.vue
+++ b/web-ui/src/components/ConfirmDialog.vue
@@ -42,7 +42,7 @@ watch(() => props.open, (isOpen) => {
       previousFocusEl = null
     }
   }
-})
+}, { immediate: true })
 
 onBeforeUnmount(() => {
   document.removeEventListener('keydown', handleKeydown)

--- a/web-ui/src/composables/useUnsavedChanges.ts
+++ b/web-ui/src/composables/useUnsavedChanges.ts
@@ -7,6 +7,7 @@ export function useUnsavedChanges(isDirty: Ref<boolean> | (() => boolean)) {
   function handleBeforeUnload(e: BeforeUnloadEvent) {
     if (getDirty()) {
       e.preventDefault()
+      e.returnValue = ''
     }
   }
 

--- a/web-ui/src/composables/useUnsavedChanges.ts
+++ b/web-ui/src/composables/useUnsavedChanges.ts
@@ -1,0 +1,26 @@
+import { onMounted, onBeforeUnmount, type Ref } from 'vue'
+import { onBeforeRouteLeave } from 'vue-router'
+
+export function useUnsavedChanges(isDirty: Ref<boolean> | (() => boolean)) {
+  const getDirty = typeof isDirty === 'function' ? isDirty : () => isDirty.value
+
+  function handleBeforeUnload(e: BeforeUnloadEvent) {
+    if (getDirty()) {
+      e.preventDefault()
+    }
+  }
+
+  onMounted(() => {
+    window.addEventListener('beforeunload', handleBeforeUnload)
+  })
+
+  onBeforeUnmount(() => {
+    window.removeEventListener('beforeunload', handleBeforeUnload)
+  })
+
+  onBeforeRouteLeave(() => {
+    if (getDirty()) {
+      return window.confirm('You have unsaved changes. Are you sure you want to leave?')
+    }
+  })
+}

--- a/web-ui/src/pages/MembersPage.vue
+++ b/web-ui/src/pages/MembersPage.vue
@@ -4,6 +4,7 @@ import { useRouter } from 'vue-router'
 import { useAuthStore } from '@/stores/auth'
 import { listMembers, inviteMember, updateMemberRole, removeMember, leaveTenant } from '@/api/member'
 import { useToast } from '@/composables/useToast'
+import ConfirmDialog from '@/components/ConfirmDialog.vue'
 import type { TenantMember } from '@/types/api'
 import { UserRole } from '@/types/api'
 import {
@@ -55,25 +56,20 @@ const confirmLeave = ref(false)
 const leaveLoading = ref(false)
 const leaveError = ref('')
 
-// Dialog focus
-const dialogEl = ref<HTMLElement | null>(null)
-
+// Invite modal ESC handling
 function handleKeydown(e: KeyboardEvent) {
   if (e.key === 'Escape') {
-    confirmRoleChange.value = null
-    confirmRemove.value = null
-    confirmLeave.value = false
     showInvite.value = false
   }
 }
 
-watch([confirmRoleChange, confirmRemove, confirmLeave, showInvite], (values) => {
-  if (values.some(Boolean)) {
+watch(showInvite, (isOpen) => {
+  if (isOpen) {
     document.addEventListener('keydown', handleKeydown)
   } else {
     document.removeEventListener('keydown', handleKeydown)
   }
-}, { deep: true })
+})
 
 onBeforeUnmount(() => {
   document.removeEventListener('keydown', handleKeydown)
@@ -127,7 +123,6 @@ function requestRoleChange(member: TenantMember) {
     currentRole: member.role,
     newRole,
   }
-  nextTick(() => dialogEl.value?.focus())
 }
 
 async function executeRoleChange() {
@@ -148,7 +143,6 @@ async function executeRoleChange() {
 function requestRemoveMember(member: TenantMember) {
   removeError.value = ''
   confirmRemove.value = { userId: member.userId, username: member.username }
-  nextTick(() => dialogEl.value?.focus())
 }
 
 async function executeRemoveMember() {
@@ -169,7 +163,6 @@ async function executeRemoveMember() {
 function requestLeaveTenant() {
   leaveError.value = ''
   confirmLeave.value = true
-  nextTick(() => dialogEl.value?.focus())
 }
 
 async function executeLeaveTenant() {
@@ -372,137 +365,70 @@ onMounted(fetchMembers)
     </Teleport>
 
     <!-- Role Change Confirm -->
-    <Teleport to="body">
-      <div
-        v-if="confirmRoleChange"
-        class="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
-        @click.self="confirmRoleChange = null"
-      >
-        <div
-          ref="dialogEl"
-          role="dialog"
-          aria-modal="true"
-          tabindex="-1"
-          class="mx-4 w-full max-w-sm rounded-lg bg-white p-6 shadow-xl"
-        >
-          <h3 class="text-lg font-semibold text-gray-900">Change Role</h3>
-          <p class="mt-2 text-sm text-gray-600">
-            Change <span class="font-medium text-gray-900">{{ confirmRoleChange.username }}</span>'s role from
-            <span class="font-mono font-medium">{{ confirmRoleChange.currentRole }}</span> to
-            <span class="font-mono font-medium">{{ confirmRoleChange.newRole }}</span>?
-          </p>
-          <div class="mt-3 rounded-lg border bg-gray-50 p-3 text-xs text-gray-600">
-            <p class="font-medium text-gray-700">
-              {{ confirmRoleChange.newRole === UserRole.Admin ? 'Admin' : 'Member' }} permissions:
-            </p>
-            <ul v-if="confirmRoleChange.newRole === UserRole.Admin" class="mt-1 list-inside list-disc space-y-0.5 text-gray-500">
-              <li>Manage tenant settings and domains</li>
-              <li>Invite and remove members</li>
-              <li>Change member roles</li>
-              <li>Create, edit, and delete short links</li>
-            </ul>
-            <ul v-else class="mt-1 list-inside list-disc space-y-0.5 text-gray-500">
-              <li>Create, edit, and delete short links</li>
-              <li>View member list</li>
-            </ul>
-          </div>
-          <p v-if="roleError" class="mt-2 text-sm text-red-600">{{ roleError }}</p>
-          <div class="mt-4 flex justify-end gap-2">
-            <button
-              class="rounded-md px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-100"
-              @click="confirmRoleChange = null"
-            >
-              Cancel
-            </button>
-            <button
-              :disabled="roleLoading"
-              class="rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50"
-              @click="executeRoleChange"
-            >
-              {{ roleLoading ? 'Changing...' : 'Confirm' }}
-            </button>
-          </div>
-        </div>
+    <ConfirmDialog
+      :open="!!confirmRoleChange"
+      title="Change Role"
+      :confirm-text="roleLoading ? 'Changing...' : 'Confirm'"
+      :loading="roleLoading"
+      @confirm="executeRoleChange"
+      @cancel="confirmRoleChange = null"
+    >
+      <p class="mt-2 text-sm text-gray-600">
+        Change <span class="font-medium text-gray-900">{{ confirmRoleChange?.username }}</span>'s role from
+        <span class="font-mono font-medium">{{ confirmRoleChange?.currentRole }}</span> to
+        <span class="font-mono font-medium">{{ confirmRoleChange?.newRole }}</span>?
+      </p>
+      <div class="mt-3 rounded-lg border bg-gray-50 p-3 text-xs text-gray-600">
+        <p class="font-medium text-gray-700">
+          {{ confirmRoleChange?.newRole === UserRole.Admin ? 'Admin' : 'Member' }} permissions:
+        </p>
+        <ul v-if="confirmRoleChange?.newRole === UserRole.Admin" class="mt-1 list-inside list-disc space-y-0.5 text-gray-500">
+          <li>Manage tenant settings and domains</li>
+          <li>Invite and remove members</li>
+          <li>Change member roles</li>
+          <li>Create, edit, and delete short links</li>
+        </ul>
+        <ul v-else class="mt-1 list-inside list-disc space-y-0.5 text-gray-500">
+          <li>Create, edit, and delete short links</li>
+          <li>View member list</li>
+        </ul>
       </div>
-    </Teleport>
+      <p v-if="roleError" class="mt-2 text-sm text-red-600">{{ roleError }}</p>
+    </ConfirmDialog>
 
     <!-- Remove Member Confirm -->
-    <Teleport to="body">
-      <div
-        v-if="confirmRemove"
-        class="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
-        @click.self="confirmRemove = null"
-      >
-        <div
-          ref="dialogEl"
-          role="dialog"
-          aria-modal="true"
-          tabindex="-1"
-          class="mx-4 w-full max-w-sm rounded-lg bg-white p-6 shadow-xl"
-        >
-          <h3 class="text-lg font-semibold text-gray-900">Remove Member</h3>
-          <p class="mt-2 text-sm text-gray-600">
-            Are you sure you want to remove
-            <span class="font-medium text-gray-900">{{ confirmRemove.username }}</span> from this tenant?
-            This action cannot be undone.
-          </p>
-          <p v-if="removeError" class="mt-2 text-sm text-red-600">{{ removeError }}</p>
-          <div class="mt-4 flex justify-end gap-2">
-            <button
-              class="rounded-md px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-100"
-              @click="confirmRemove = null"
-            >
-              Cancel
-            </button>
-            <button
-              :disabled="removeLoading"
-              class="rounded-md bg-red-600 px-4 py-2 text-sm font-medium text-white hover:bg-red-700 disabled:opacity-50"
-              @click="executeRemoveMember"
-            >
-              {{ removeLoading ? 'Removing...' : 'Remove' }}
-            </button>
-          </div>
-        </div>
-      </div>
-    </Teleport>
+    <ConfirmDialog
+      :open="!!confirmRemove"
+      title="Remove Member"
+      variant="danger"
+      :confirm-text="removeLoading ? 'Removing...' : 'Remove'"
+      :loading="removeLoading"
+      @confirm="executeRemoveMember"
+      @cancel="confirmRemove = null"
+    >
+      <p class="mt-2 text-sm text-gray-600">
+        Are you sure you want to remove
+        <span class="font-medium text-gray-900">{{ confirmRemove?.username }}</span> from this tenant?
+        This action cannot be undone.
+      </p>
+      <p v-if="removeError" class="mt-2 text-sm text-red-600">{{ removeError }}</p>
+    </ConfirmDialog>
 
     <!-- Leave Tenant Confirm -->
-    <Teleport to="body">
-      <div
-        v-if="confirmLeave"
-        class="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
-        @click.self="confirmLeave = false"
-      >
-        <div
-          ref="dialogEl"
-          role="dialog"
-          aria-modal="true"
-          tabindex="-1"
-          class="mx-4 w-full max-w-sm rounded-lg bg-white p-6 shadow-xl"
-        >
-          <h3 class="text-lg font-semibold text-gray-900">Leave Tenant</h3>
-          <p class="mt-2 text-sm text-gray-600">
-            Are you sure you want to leave <span class="font-medium text-gray-900">{{ auth.currentTenant?.tenantName }}</span>?
-            You will need to be re-invited to join again.
-          </p>
-          <p v-if="leaveError" class="mt-2 text-sm text-red-600">{{ leaveError }}</p>
-          <div class="mt-4 flex justify-end gap-2">
-            <button
-              class="rounded-md px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-100"
-              @click="confirmLeave = false"
-            >
-              Cancel
-            </button>
-            <button
-              :disabled="leaveLoading"
-              class="rounded-md bg-red-600 px-4 py-2 text-sm font-medium text-white hover:bg-red-700 disabled:opacity-50"
-              @click="executeLeaveTenant"
-            >
-              {{ leaveLoading ? 'Leaving...' : 'Leave' }}
-            </button>
-          </div>
-        </div>
-      </div>
-    </Teleport>
+    <ConfirmDialog
+      :open="confirmLeave"
+      title="Leave Tenant"
+      variant="danger"
+      :confirm-text="leaveLoading ? 'Leaving...' : 'Leave'"
+      :loading="leaveLoading"
+      @confirm="executeLeaveTenant"
+      @cancel="confirmLeave = false"
+    >
+      <p class="mt-2 text-sm text-gray-600">
+        Are you sure you want to leave <span class="font-medium text-gray-900">{{ auth.currentTenant?.tenantName }}</span>?
+        You will need to be re-invited to join again.
+      </p>
+      <p v-if="leaveError" class="mt-2 text-sm text-red-600">{{ leaveError }}</p>
+    </ConfirmDialog>
   </div>
 </template>

--- a/web-ui/src/pages/SettingsPage.vue
+++ b/web-ui/src/pages/SettingsPage.vue
@@ -1,9 +1,11 @@
 <script setup lang="ts">
-import { ref, computed, onMounted, onBeforeUnmount, nextTick, watch } from 'vue'
+import { ref, computed, onMounted } from 'vue'
 import { useAuthStore } from '@/stores/auth'
 import { getTenant, updateTenant, listDomains, addDomain, removeDomain } from '@/api/tenant'
 import { getTenantConfig, updateTenantConfig } from '@/api/config'
 import { useToast } from '@/composables/useToast'
+import { useUnsavedChanges } from '@/composables/useUnsavedChanges'
+import ConfirmDialog from '@/components/ConfirmDialog.vue'
 import type { Tenant, TenantDomain } from '@/types/api'
 import {
   Settings,
@@ -56,13 +58,30 @@ const notFoundValue = ref('')
 const notFoundSaving = ref(false)
 const notFoundError = ref('')
 
+// Unsaved changes tracking
+const originalTenant = ref({ name: '', slug: '' })
+const originalConfig = ref({ idLength: 6, idMinimumLength: 2, idMaximumLength: 10, notFoundMode: 'content' as string, notFoundValue: '' })
+
+const isDirty = computed(() => {
+  if (!isAdmin.value || loading.value) return false
+  return (
+    (!!tenant.value && (editName.value !== originalTenant.value.name || editSlug.value !== originalTenant.value.slug)) ||
+    idLength.value !== originalConfig.value.idLength ||
+    idMinimumLength.value !== originalConfig.value.idMinimumLength ||
+    idMaximumLength.value !== originalConfig.value.idMaximumLength ||
+    notFoundMode.value !== originalConfig.value.notFoundMode ||
+    notFoundValue.value !== originalConfig.value.notFoundValue
+  )
+})
+
+useUnsavedChanges(isDirty)
+
 // Confirm dialog
 const confirmOpen = ref(false)
 const confirmTitle = ref('')
 const confirmMessage = ref('')
 const confirmAction = ref<(() => Promise<void>) | null>(null)
 const confirmSaving = ref(false)
-const dialogEl = ref<HTMLElement | null>(null)
 
 const isAdmin = computed(() => auth.isAdmin)
 
@@ -130,12 +149,20 @@ async function fetchAll() {
     tenant.value = t
     editName.value = t.name
     editSlug.value = t.slug
+    originalTenant.value = { name: t.name, slug: t.slug }
 
     idLength.value = configData.config.idConfig.idLength
     idMinimumLength.value = configData.config.idConfig.idMinimumLength
     idMaximumLength.value = configData.config.idConfig.idMaximumLength
     notFoundMode.value = configData.config.shortLinkNotFoundConfig.mode
     notFoundValue.value = configData.config.shortLinkNotFoundConfig.value
+    originalConfig.value = {
+      idLength: configData.config.idConfig.idLength,
+      idMinimumLength: configData.config.idConfig.idMinimumLength,
+      idMaximumLength: configData.config.idConfig.idMaximumLength,
+      notFoundMode: configData.config.shortLinkNotFoundConfig.mode,
+      notFoundValue: configData.config.shortLinkNotFoundConfig.value,
+    }
   } catch {
     pageError.value = 'Failed to load settings.'
   } finally {
@@ -170,6 +197,7 @@ async function handleSaveTenant() {
     tenant.value = updated
     editName.value = updated.name
     editSlug.value = updated.slug
+    originalTenant.value = { name: updated.name, slug: updated.slug }
     toast.success('Tenant information saved successfully')
     await auth.fetchAuthInfo()
   } catch (e: unknown) {
@@ -216,7 +244,6 @@ function openConfirm(title: string, message: string, action: () => Promise<void>
   confirmAction.value = action
   confirmSaving.value = false
   confirmOpen.value = true
-  nextTick(() => dialogEl.value?.focus())
 }
 
 function closeConfirm() {
@@ -235,25 +262,6 @@ async function executeConfirm() {
   }
 }
 
-function handleKeydown(e: KeyboardEvent) {
-  if (e.key === 'Escape') {
-    closeConfirm()
-    confirmDeleteDomain.value = null
-  }
-}
-
-watch([confirmOpen, confirmDeleteDomain], (values) => {
-  if (values.some(Boolean)) {
-    document.addEventListener('keydown', handleKeydown)
-  } else {
-    document.removeEventListener('keydown', handleKeydown)
-  }
-})
-
-onBeforeUnmount(() => {
-  document.removeEventListener('keydown', handleKeydown)
-})
-
 function handleSaveIdConfig() {
   openConfirm(
     'Save ID Length Configuration',
@@ -268,6 +276,7 @@ async function doSaveIdConfig() {
   idError.value = ''
   try {
     await updateTenantConfig(auth.currentTenantId!, { idLength: idLength.value, idMinimumLength: idMinimumLength.value, idMaximumLength: idMaximumLength.value })
+    originalConfig.value = { ...originalConfig.value, idLength: idLength.value, idMinimumLength: idMinimumLength.value, idMaximumLength: idMaximumLength.value }
     toast.success('ID length configuration saved successfully')
   } catch {
     idError.value = 'Failed to save ID length configuration.'
@@ -291,6 +300,7 @@ async function doSaveNotFoundConfig() {
   notFoundError.value = ''
   try {
     await updateTenantConfig(auth.currentTenantId!, { notFoundMode: notFoundMode.value, notFoundValue: notFoundValue.value })
+    originalConfig.value = { ...originalConfig.value, notFoundMode: notFoundMode.value, notFoundValue: notFoundValue.value }
     toast.success('404 handling configuration saved successfully')
   } catch {
     notFoundError.value = 'Failed to save 404 handling configuration.'
@@ -650,66 +660,30 @@ onMounted(fetchAll)
     </template>
 
     <!-- Delete domain confirm -->
-    <Teleport to="body">
-      <div
-        v-if="confirmDeleteDomain"
-        class="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
-        @click.self="confirmDeleteDomain = null"
-      >
-        <div
-          ref="dialogEl"
-          role="dialog"
-          aria-modal="true"
-          tabindex="-1"
-          class="mx-4 w-full max-w-sm rounded-lg bg-white p-6 shadow-xl"
-        >
-          <h3 class="text-lg font-semibold text-gray-900">Remove Domain</h3>
-          <p class="mt-2 text-sm text-gray-500">
-            Are you sure you want to remove
-            <span class="font-mono font-medium text-gray-700">{{ confirmDeleteDomain }}</span>?
-          </p>
-          <div class="mt-4 flex justify-end gap-2">
-            <button class="rounded-md px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-100" @click="confirmDeleteDomain = null">Cancel</button>
-            <button
-              :disabled="deleting"
-              class="rounded-md bg-red-600 px-4 py-2 text-sm font-medium text-white hover:bg-red-700 disabled:opacity-50"
-              @click="handleDeleteDomain(confirmDeleteDomain!)"
-            >
-              {{ deleting ? 'Removing...' : 'Remove' }}
-            </button>
-          </div>
-        </div>
-      </div>
-    </Teleport>
+    <ConfirmDialog
+      :open="!!confirmDeleteDomain"
+      title="Remove Domain"
+      variant="danger"
+      :confirm-text="deleting ? 'Removing...' : 'Remove'"
+      :loading="deleting"
+      @confirm="handleDeleteDomain(confirmDeleteDomain!)"
+      @cancel="confirmDeleteDomain = null"
+    >
+      <p class="mt-2 text-sm text-gray-500">
+        Are you sure you want to remove
+        <span class="font-mono font-medium text-gray-700">{{ confirmDeleteDomain }}</span>?
+      </p>
+    </ConfirmDialog>
 
     <!-- Generic confirm dialog -->
-    <Teleport to="body">
-      <div
-        v-if="confirmOpen"
-        class="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
-        @click.self="closeConfirm"
-      >
-        <div
-          ref="dialogEl"
-          role="dialog"
-          aria-modal="true"
-          tabindex="-1"
-          class="mx-4 w-full max-w-sm rounded-lg bg-white p-6 shadow-xl"
-        >
-          <h3 class="text-lg font-semibold text-gray-900">{{ confirmTitle }}</h3>
-          <p class="mt-2 text-sm text-gray-600">{{ confirmMessage }}</p>
-          <div class="mt-5 flex justify-end gap-3">
-            <button class="rounded-md px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-100" @click="closeConfirm">Cancel</button>
-            <button
-              :disabled="confirmSaving"
-              class="rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50"
-              @click="executeConfirm"
-            >
-              {{ confirmSaving ? 'Saving...' : 'Confirm' }}
-            </button>
-          </div>
-        </div>
-      </div>
-    </Teleport>
+    <ConfirmDialog
+      :open="confirmOpen"
+      :title="confirmTitle"
+      :message="confirmMessage"
+      :confirm-text="confirmSaving ? 'Saving...' : 'Confirm'"
+      :loading="confirmSaving"
+      @confirm="executeConfirm"
+      @cancel="closeConfirm"
+    />
   </div>
 </template>

--- a/web-ui/src/pages/ShortLinkCreatePage.vue
+++ b/web-ui/src/pages/ShortLinkCreatePage.vue
@@ -4,6 +4,7 @@ import { useRouter } from 'vue-router'
 import { createShortLink } from '@/api/short-link'
 import { useAuthStore } from '@/stores/auth'
 import { useToast } from '@/composables/useToast'
+import { useUnsavedChanges } from '@/composables/useUnsavedChanges'
 import { UserRole } from '@/types/api'
 import type { ShortLinkData } from '@/types/api'
 import { ArrowLeft, Copy, Check, ExternalLink } from 'lucide-vue-next'
@@ -22,6 +23,12 @@ const loading = ref(false)
 const error = ref('')
 const createdLink = ref<ShortLinkData | null>(null)
 const copiedShortLink = ref(false)
+
+const isDirty = computed(() =>
+  !createdLink.value && (!!url.value || !!customId.value || !!description.value || !isEnable.value)
+)
+
+useUnsavedChanges(isDirty)
 
 const isAdmin = computed(() => auth.user?.role === UserRole.Admin)
 

--- a/web-ui/src/pages/ShortLinkEditPage.vue
+++ b/web-ui/src/pages/ShortLinkEditPage.vue
@@ -4,6 +4,7 @@ import { useRouter, useRoute } from 'vue-router'
 import { getShortLink, updateShortLink } from '@/api/short-link'
 import { ApiError } from '@/api/http'
 import { useToast } from '@/composables/useToast'
+import { useUnsavedChanges } from '@/composables/useUnsavedChanges'
 import { ArrowLeft } from 'lucide-vue-next'
 
 defineOptions({ name: 'ShortLinkEditPage' })
@@ -22,6 +23,16 @@ const loading = ref(false)
 const saving = ref(false)
 const error = ref('')
 const notFound = ref(false)
+
+const originalData = ref({ url: '', description: '', isEnable: true })
+
+const isDirty = computed(() =>
+  url.value !== originalData.value.url ||
+  description.value !== originalData.value.description ||
+  isEnable.value !== originalData.value.isEnable
+)
+
+useUnsavedChanges(isDirty)
 
 function normalizeUrl(value: string): string {
   const trimmed = value.trim()
@@ -52,6 +63,7 @@ async function fetchData() {
     isEnable.value = sl.isEnable
     createdBy.value = sl.createdBy
     createTime.value = sl.createTime
+    originalData.value = { url: sl.url, description: sl.description, isEnable: sl.isEnable }
   } catch (e) {
     if (e instanceof ApiError && e.status === 404) {
       notFound.value = true
@@ -75,6 +87,7 @@ async function handleSubmit() {
       description: description.value,
       isEnable: isEnable.value,
     })
+    originalData.value = { url: normalizedUrl, description: description.value, isEnable: isEnable.value }
     toast.success('Short link updated successfully')
   } catch {
     error.value = 'Failed to update short link. Please try again.'

--- a/web-ui/src/pages/ShortLinksPage.vue
+++ b/web-ui/src/pages/ShortLinksPage.vue
@@ -3,6 +3,7 @@ import { ref, computed, onMounted } from 'vue'
 import { useRouter } from 'vue-router'
 import { listShortLinks, deleteShortLink, updateShortLink } from '@/api/short-link'
 import { useToast } from '@/composables/useToast'
+import ConfirmDialog from '@/components/ConfirmDialog.vue'
 import type { ShortLinkData } from '@/types/api'
 import {
   Plus,
@@ -618,37 +619,20 @@ onMounted(fetchLinks)
       </div>
     </div>
 
-    <!-- Delete confirmation modal -->
-    <Teleport to="body">
-      <div
-        v-if="confirmDeleteId"
-        class="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
-        @click.self="confirmDeleteId = null"
-      >
-        <div class="w-full max-w-sm rounded-lg bg-white p-6 shadow-xl">
-          <h3 class="text-lg font-semibold text-gray-900">Delete Short Link</h3>
-          <p class="mt-2 text-sm text-gray-500">
-            Are you sure you want to delete
-            <span class="font-mono font-medium text-gray-700">{{ confirmDeleteId }}</span
-            >? This action cannot be undone.
-          </p>
-          <div class="mt-4 flex justify-end gap-2">
-            <button
-              class="rounded-md px-4 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-100"
-              @click="confirmDeleteId = null"
-            >
-              Cancel
-            </button>
-            <button
-              :disabled="deleting === confirmDeleteId"
-              class="rounded-md bg-red-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-red-700 disabled:opacity-50"
-              @click="handleDelete(confirmDeleteId!)"
-            >
-              {{ deleting === confirmDeleteId ? 'Deleting...' : 'Delete' }}
-            </button>
-          </div>
-        </div>
-      </div>
-    </Teleport>
+    <ConfirmDialog
+      :open="!!confirmDeleteId"
+      title="Delete Short Link"
+      variant="danger"
+      :confirm-text="deleting === confirmDeleteId ? 'Deleting...' : 'Delete'"
+      :loading="deleting === confirmDeleteId"
+      @confirm="handleDelete(confirmDeleteId!)"
+      @cancel="confirmDeleteId = null"
+    >
+      <p class="mt-2 text-sm text-gray-500">
+        Are you sure you want to delete
+        <span class="font-mono font-medium text-gray-700">{{ confirmDeleteId }}</span
+        >? This action cannot be undone.
+      </p>
+    </ConfirmDialog>
   </div>
 </template>


### PR DESCRIPTION
## Summary

- Add reusable `ConfirmDialog.vue` component with ESC close, backdrop dismiss, focus management (auto-focus confirm button on open, restore focus on close), and ARIA attributes (`role="dialog"`, `aria-modal="true"`)
- Replace hand-written modals in `ShortLinksPage`, `MembersPage` (3 confirmation dialogs), and `SettingsPage` (2 dialogs) with `ConfirmDialog`
- Add `useUnsavedChanges` composable that handles both `beforeunload` (browser tab close) and `onBeforeRouteLeave` (in-app navigation) guards
- Integrate unsaved changes protection into `ShortLinkEditPage`, `ShortLinkCreatePage`, and `SettingsPage` forms, with original value tracking that resets after successful saves

## Test plan

- [ ] Verify delete confirmation in ShortLinksPage uses ConfirmDialog
- [ ] Verify role change, remove member, and leave tenant confirmations in MembersPage use ConfirmDialog
- [ ] Verify delete domain and config save confirmations in SettingsPage use ConfirmDialog
- [ ] Test ESC key closes all confirm dialogs
- [ ] Test backdrop click closes all confirm dialogs
- [ ] Test focus is restored after dialog closes
- [ ] Test browser tab close triggers warning when editing ShortLinkEditPage form with unsaved changes
- [ ] Test route navigation shows confirmation when editing forms with unsaved changes
- [ ] Verify no warning appears after saving changes

Closes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)