### PR TITLE
fix(web-ui): Super Admin page improvements + global empty state unification

### DIFF
--- a/web-ui/src/pages/MembersPage.vue
+++ b/web-ui/src/pages/MembersPage.vue
@@ -297,8 +297,18 @@ onMounted(fetchMembers)
       <div v-if="filteredMembers.length === 0 && members.length > 0" class="py-12 text-center text-sm text-gray-400">
         No members match "{{ searchQuery }}".
       </div>
-      <div v-else-if="members.length === 0" class="py-12 text-center text-sm text-gray-400">
-        No members found.
+      <div v-else-if="members.length === 0" class="py-12 text-center">
+        <Users class="mx-auto h-10 w-10 text-gray-300" />
+        <p class="mt-3 text-sm font-medium text-gray-500">No members yet</p>
+        <p class="mt-1 text-sm text-gray-400">Invite a member to start collaborating.</p>
+        <button
+          v-if="auth.isAdmin"
+          class="mt-3 inline-flex items-center gap-1.5 rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-blue-700"
+          @click="openInviteModal"
+        >
+          <UserPlus class="h-4 w-4" />
+          Invite Member
+        </button>
       </div>
     </div>
 

--- a/web-ui/src/pages/super/SuperDashboardPage.vue
+++ b/web-ui/src/pages/super/SuperDashboardPage.vue
@@ -96,8 +96,16 @@ onMounted(fetchDashboardData)
       <div v-if="loading" class="flex items-center justify-center p-8">
         <Loader2 class="h-5 w-5 animate-spin text-gray-400" />
       </div>
-      <div v-else-if="recentTenants.length === 0" class="px-5 py-8 text-center text-sm text-gray-400">
-        No tenants found.
+      <div v-else-if="recentTenants.length === 0" class="px-5 py-12 text-center">
+        <Building2 class="mx-auto h-10 w-10 text-gray-300" />
+        <p class="mt-3 text-sm font-medium text-gray-500">No tenants yet</p>
+        <p class="mt-1 text-sm text-gray-400">Tenants will appear here once created.</p>
+        <router-link
+          :to="{ name: 'super-tenants' }"
+          class="mt-3 inline-flex items-center gap-1.5 rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-blue-700"
+        >
+          View all tenants
+        </router-link>
       </div>
       <div v-else class="overflow-x-auto">
         <table class="w-full text-sm">

--- a/web-ui/src/pages/super/SuperTenantDetailPage.vue
+++ b/web-ui/src/pages/super/SuperTenantDetailPage.vue
@@ -180,8 +180,21 @@ onMounted(fetchTenant)
       </div>
     </div>
 
-    <div v-if="loading" class="mt-6 text-center text-gray-400">
-      <Loader2 class="inline h-5 w-5 animate-spin" />
+    <div v-if="loading" class="mt-6 space-y-4">
+      <div class="rounded-lg border bg-white p-5">
+        <div class="flex items-center gap-3">
+          <div class="h-10 w-10 animate-pulse rounded-lg bg-gray-200" />
+          <div class="flex-1">
+            <div class="h-5 w-40 animate-pulse rounded bg-gray-200" />
+            <div class="mt-2 h-4 w-24 animate-pulse rounded bg-gray-200" />
+          </div>
+        </div>
+        <div class="mt-4 grid gap-4 sm:grid-cols-3">
+          <div class="h-10 animate-pulse rounded bg-gray-100" />
+          <div class="h-10 animate-pulse rounded bg-gray-100" />
+          <div class="h-10 animate-pulse rounded bg-gray-100" />
+        </div>
+      </div>
     </div>
 
     <div v-else-if="notFound" class="mt-6 text-center text-gray-400">
@@ -292,7 +305,7 @@ onMounted(fetchTenant)
               </thead>
               <tbody class="divide-y">
                 <tr v-if="members.length === 0">
-                  <td colspan="3" class="px-4 py-8 text-center text-gray-400">No members.</td>
+                  <td colspan="3" class="px-4 py-8 text-center text-gray-400">No members in this tenant.</td>
                 </tr>
                 <tr v-for="m in members" :key="m.userId" class="transition-colors hover:bg-gray-50">
                   <td class="px-4 py-3">
@@ -338,7 +351,7 @@ onMounted(fetchTenant)
               </thead>
               <tbody class="divide-y">
                 <tr v-if="shortLinks.length === 0">
-                  <td colspan="5" class="px-4 py-8 text-center text-gray-400">No short links.</td>
+                  <td colspan="5" class="px-4 py-8 text-center text-gray-400">No short links in this tenant.</td>
                 </tr>
                 <tr v-for="sl in shortLinks" :key="sl.id" class="transition-colors hover:bg-gray-50">
                   <td class="px-4 py-3 font-mono text-sm font-medium text-gray-900">{{ sl.id }}</td>
@@ -442,7 +455,7 @@ onMounted(fetchTenant)
             </table>
           </div>
           <div v-else class="rounded-lg border bg-white py-8 text-center text-sm text-gray-400">
-            No domains configured.
+            No domains configured for this tenant.
           </div>
         </div>
       </div>

--- a/web-ui/src/pages/super/SuperTenantsPage.vue
+++ b/web-ui/src/pages/super/SuperTenantsPage.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, onMounted } from 'vue'
+import { ref, computed, onMounted } from 'vue'
 import { useRouter } from 'vue-router'
 import { listSuperTenants, setSuperTenantStatus } from '@/api/super'
 import type { SuperTenant } from '@/types/api'
@@ -9,6 +9,9 @@ import {
   ChevronLeft,
   ChevronRight,
   Loader2,
+  ArrowUpDown,
+  ArrowUp,
+  ArrowDown,
 } from 'lucide-vue-next'
 
 defineOptions({ name: 'SuperTenantsPage' })
@@ -21,6 +24,42 @@ const page = ref(1)
 const pageSize = 20
 const total = ref(0)
 const toggleLoading = ref<string | null>(null)
+
+type SortField = 'name' | 'slug' | 'createdAt'
+type SortDirection = 'asc' | 'desc'
+const sortField = ref<SortField>('createdAt')
+const sortDirection = ref<SortDirection>('desc')
+
+const sortedTenants = computed(() => {
+  const arr = [...tenants.value]
+  const dir = sortDirection.value === 'asc' ? 1 : -1
+  return arr.sort((a, b) => {
+    switch (sortField.value) {
+      case 'name':
+        return dir * a.name.localeCompare(b.name)
+      case 'slug':
+        return dir * a.slug.localeCompare(b.slug)
+      case 'createdAt':
+        return dir * (new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime())
+      default:
+        return 0
+    }
+  })
+})
+
+function toggleSort(field: SortField) {
+  if (sortField.value === field) {
+    sortDirection.value = sortDirection.value === 'asc' ? 'desc' : 'asc'
+  } else {
+    sortField.value = field
+    sortDirection.value = 'desc'
+  }
+}
+
+function SortIcon({ field }: { field: SortField }) {
+  if (sortField.value !== field) return ArrowUpDown
+  return sortDirection.value === 'asc' ? ArrowUp : ArrowDown
+}
 
 async function fetchTenants() {
   loading.value = true
@@ -80,10 +119,25 @@ onMounted(fetchTenants)
         <table class="w-full text-sm">
           <thead>
             <tr class="border-b bg-gray-50 text-left text-xs font-medium uppercase tracking-wider text-gray-500">
-              <th class="px-4 py-3">Name</th>
-              <th class="px-4 py-3">Slug</th>
+              <th class="cursor-pointer select-none px-4 py-3" @click="toggleSort('name')">
+                <div class="flex items-center gap-1">
+                  Name
+                  <component :is="SortIcon({ field: 'name' })" class="h-3.5 w-3.5" />
+                </div>
+              </th>
+              <th class="cursor-pointer select-none px-4 py-3" @click="toggleSort('slug')">
+                <div class="flex items-center gap-1">
+                  Slug
+                  <component :is="SortIcon({ field: 'slug' })" class="h-3.5 w-3.5" />
+                </div>
+              </th>
               <th class="px-4 py-3">Status</th>
-              <th class="hidden px-4 py-3 lg:table-cell">Created</th>
+              <th class="hidden cursor-pointer select-none px-4 py-3 lg:table-cell" @click="toggleSort('createdAt')">
+                <div class="flex items-center gap-1">
+                  Created
+                  <component :is="SortIcon({ field: 'createdAt' })" class="h-3.5 w-3.5" />
+                </div>
+              </th>
               <th class="px-4 py-3 text-right">Actions</th>
             </tr>
           </thead>
@@ -94,15 +148,14 @@ onMounted(fetchTenants)
               </td>
             </tr>
             <tr v-else-if="tenants.length === 0">
-              <td colspan="5" class="px-4 py-8 text-center text-gray-400">
-                <div class="flex flex-col items-center gap-2">
-                  <Building2 class="h-8 w-8 text-gray-300" />
-                  <span>No tenants found.</span>
-                </div>
+              <td colspan="5" class="px-4 py-12 text-center">
+                <Building2 class="mx-auto h-10 w-10 text-gray-300" />
+                <p class="mt-3 text-sm font-medium text-gray-500">No tenants yet</p>
+                <p class="mt-1 text-sm text-gray-400">Tenants will appear here once created by users.</p>
               </td>
             </tr>
             <tr
-              v-for="tenant in tenants"
+              v-for="tenant in sortedTenants"
               :key="tenant.id"
               class="transition-colors hover:bg-gray-50"
             >

--- a/web-ui/src/pages/super/SuperTenantsPage.vue
+++ b/web-ui/src/pages/super/SuperTenantsPage.vue
@@ -119,24 +119,33 @@ onMounted(fetchTenants)
         <table class="w-full text-sm">
           <thead>
             <tr class="border-b bg-gray-50 text-left text-xs font-medium uppercase tracking-wider text-gray-500">
-              <th class="cursor-pointer select-none px-4 py-3" @click="toggleSort('name')">
-                <div class="flex items-center gap-1">
+              <th
+                class="px-4 py-3"
+                :aria-sort="sortField === 'name' ? (sortDirection === 'asc' ? 'ascending' : 'descending') : 'none'"
+              >
+                <button class="flex items-center gap-1" @click="toggleSort('name')">
                   Name
                   <component :is="SortIcon({ field: 'name' })" class="h-3.5 w-3.5" />
-                </div>
+                </button>
               </th>
-              <th class="cursor-pointer select-none px-4 py-3" @click="toggleSort('slug')">
-                <div class="flex items-center gap-1">
+              <th
+                class="px-4 py-3"
+                :aria-sort="sortField === 'slug' ? (sortDirection === 'asc' ? 'ascending' : 'descending') : 'none'"
+              >
+                <button class="flex items-center gap-1" @click="toggleSort('slug')">
                   Slug
                   <component :is="SortIcon({ field: 'slug' })" class="h-3.5 w-3.5" />
-                </div>
+                </button>
               </th>
               <th class="px-4 py-3">Status</th>
-              <th class="hidden cursor-pointer select-none px-4 py-3 lg:table-cell" @click="toggleSort('createdAt')">
-                <div class="flex items-center gap-1">
+              <th
+                class="hidden px-4 py-3 lg:table-cell"
+                :aria-sort="sortField === 'createdAt' ? (sortDirection === 'asc' ? 'ascending' : 'descending') : 'none'"
+              >
+                <button class="flex items-center gap-1" @click="toggleSort('createdAt')">
                   Created
                   <component :is="SortIcon({ field: 'createdAt' })" class="h-3.5 w-3.5" />
-                </div>
+                </button>
               </th>
               <th class="px-4 py-3 text-right">Actions</th>
             </tr>

--- a/web-ui/src/pages/super/SuperUsersPage.vue
+++ b/web-ui/src/pages/super/SuperUsersPage.vue
@@ -207,11 +207,17 @@ onMounted(fetchUsers)
               </td>
             </tr>
             <tr v-else-if="users.length === 0">
-              <td colspan="5" class="px-4 py-8 text-center text-gray-400">
-                <div class="flex flex-col items-center gap-2">
-                  <Users class="h-8 w-8 text-gray-300" />
-                  <span>No users found.</span>
-                </div>
+              <td colspan="5" class="px-4 py-12 text-center">
+                <Users class="mx-auto h-10 w-10 text-gray-300" />
+                <p class="mt-3 text-sm font-medium text-gray-500">No users yet</p>
+                <p class="mt-1 text-sm text-gray-400">Create a new user to get started.</p>
+                <button
+                  class="mt-3 inline-flex items-center gap-1.5 rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-blue-700"
+                  @click="showCreateModal = true"
+                >
+                  <Plus class="h-4 w-4" />
+                  Create User
+                </button>
               </td>
             </tr>
             <tr


### PR DESCRIPTION
## Summary
- **SuperTenantDetailPage**: Replace simple spinner with skeleton loading state; error handling already uses HTTP status code (`ApiError.status === 404`)
- **SuperDashboardPage**: Add icon + descriptive text + action button to empty state for tenants section
- **SuperTenantsPage**: Add client-side column sorting (Name, Slug, Created) with keyboard-accessible buttons and `aria-sort` attributes
- **SuperUsersPage**: Add guidance text ("Create a new user to get started.") and action button to empty state
- **MembersPage**: Unify empty state with icon + description + "Invite Member" action button
- **SuperTenantsPage/SuperTenantDetailPage**: Improve empty state text clarity

### Empty state pattern
Most empty states follow the standard pattern: **icon + title + description + action button** (matching ShortLinksPage as reference).

**Exceptions:** SuperTenantsPage has an informational-only empty state (icon + title + description) because there is no tenant creation route in the super admin UI — tenants are created by users through the normal flow.

Closes: [JWM-66](mention://issue/5f9c79f6-75d8-487c-95c5-fdeffbaa1daa)

## Test plan
- [ ] Verify SuperTenantDetailPage shows skeleton loader while loading tenant data
- [ ] Verify SuperDashboardPage empty state shows Building2 icon + guidance + "View all tenants" button when no tenants
- [ ] Verify SuperTenantsPage column headers (Name, Slug, Created) are sortable via click and keyboard (Tab + Enter)
- [ ] Verify SuperTenantsPage active sorted column has correct `aria-sort` attribute
- [ ] Verify SuperUsersPage empty state shows Users icon + guidance + "Create User" button
- [ ] Verify MembersPage empty state shows Users icon + guidance + "Invite Member" button (for admins)
- [ ] Run `npm run build` — passes with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)