### PR TITLE
feat(web-ui): Layout & navigation polish

### DIFF
--- a/web-ui/src/components/AppBreadcrumb.vue
+++ b/web-ui/src/components/AppBreadcrumb.vue
@@ -26,6 +26,9 @@ const parentRoutes: Record<string, { label: string; to: string }> = {
   'short-link-create': { label: 'Short Links', to: '/short-links' },
   'short-link-detail': { label: 'Short Links', to: '/short-links' },
   'short-link-edit': { label: 'Short Links', to: '/short-links' },
+  'tenant-create': { label: 'Tenants', to: '/tenants' },
+  'tenant-detail': { label: 'Tenants', to: '/tenants' },
+  'super-tenant-detail': { label: 'Tenants', to: '/super/tenants' },
 }
 
 const items = computed<BreadcrumbItem[]>(() => {

--- a/web-ui/src/components/AppSidebar.vue
+++ b/web-ui/src/components/AppSidebar.vue
@@ -150,15 +150,16 @@ async function handleLogout() {
     </div>
 
     <!-- Expand toggle (only when collapsed, desktop) -->
-    <button
-      v-if="layout.sidebarCollapsed"
-      class="absolute -right-3 top-4 z-10 hidden h-6 w-6 items-center justify-center rounded-full border border-gray-200 bg-white shadow-sm text-gray-400 hover:text-gray-600 lg:flex"
-      aria-label="Expand sidebar"
-      title="Expand sidebar"
-      @click="layout.toggleSidebar"
-    >
-      <ChevronLeft class="h-3 w-3 rotate-180" />
-    </button>
+    <div v-if="layout.sidebarCollapsed" class="sidebar-tooltip-wrapper">
+      <button
+        class="absolute -right-3 top-4 z-10 hidden h-6 w-6 items-center justify-center rounded-full border border-gray-200 bg-white shadow-sm text-gray-400 hover:text-gray-600 lg:flex"
+        aria-label="Expand sidebar"
+        @click="layout.toggleSidebar"
+      >
+        <ChevronLeft class="h-3 w-3 rotate-180" />
+      </button>
+      <span class="sidebar-tooltip" style="left: calc(100% + 16px); top: 16px; transform: none;">Expand sidebar</span>
+    </div>
 
     <!-- Tenant switcher (hidden on super admin routes) -->
     <div v-if="!layout.sidebarCollapsed && showTenantSwitcher" class="border-b px-3 py-2">
@@ -198,7 +199,7 @@ async function handleLogout() {
     </div>
 
     <!-- Super admin toggle -->
-    <div v-if="auth.isSuper" class="border-b px-2 py-2">
+    <div v-if="auth.isSuper" class="sidebar-tooltip-wrapper border-b px-2 py-2">
       <button
         class="flex w-full items-center gap-2 rounded-lg px-2 py-1.5 text-sm transition-colors"
         :class="isSuperRoute ? 'bg-indigo-50 text-indigo-700' : 'text-gray-500 hover:bg-gray-100 hover:text-gray-700'"
@@ -207,12 +208,13 @@ async function handleLogout() {
         <Shield class="h-4 w-4 shrink-0" />
         <span v-show="!layout.sidebarCollapsed">{{ isSuperRoute ? 'Back to App' : 'Super Admin' }}</span>
       </button>
+      <span v-if="layout.sidebarCollapsed" class="sidebar-tooltip">{{ isSuperRoute ? 'Back to App' : 'Super Admin' }}</span>
     </div>
 
     <!-- Navigation -->
     <nav class="flex-1 overflow-y-auto px-2 py-3">
       <ul class="space-y-1">
-        <li v-for="item in menuItems" :key="item.label">
+        <li v-for="item in menuItems" :key="item.label" class="sidebar-tooltip-wrapper">
           <router-link
             :to="item.to"
             :class="[
@@ -221,39 +223,86 @@ async function handleLogout() {
                 ? 'bg-blue-50 text-blue-700'
                 : 'text-gray-600 hover:bg-gray-100 hover:text-gray-900',
             ]"
-            :title="layout.sidebarCollapsed ? item.label : undefined"
             @click="layout.closeMobileMenu"
           >
             <component :is="item.icon" class="h-5 w-5 shrink-0" />
             <span v-show="!layout.sidebarCollapsed">{{ item.label }}</span>
           </router-link>
+          <span
+            v-if="layout.sidebarCollapsed"
+            class="sidebar-tooltip"
+          >{{ item.label }}</span>
         </li>
       </ul>
     </nav>
 
     <!-- Invitation badge + Logout -->
     <div class="border-t px-2 py-3">
-      <router-link
-        v-if="auth.pendingInvitationCount > 0"
-        :to="{ name: 'invitations' }"
-        class="mb-1 flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium text-amber-600 transition-colors hover:bg-amber-50"
-        @click="layout.closeMobileMenu"
-      >
-        <span class="relative">
-          <Bell class="h-5 w-5 shrink-0" />
-          <span class="absolute -right-1.5 -top-1.5 flex h-4 min-w-4 items-center justify-center rounded-full bg-red-500 px-1 text-[10px] font-bold text-white">
-            {{ auth.pendingInvitationCount > 9 ? '9+' : auth.pendingInvitationCount }}
+      <div v-if="auth.pendingInvitationCount > 0" class="sidebar-tooltip-wrapper">
+        <router-link
+          :to="{ name: 'invitations' }"
+          class="mb-1 flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium text-amber-600 transition-colors hover:bg-amber-50"
+          @click="layout.closeMobileMenu"
+        >
+          <span class="relative">
+            <Bell class="h-5 w-5 shrink-0" />
+            <span class="absolute -right-1.5 -top-1.5 flex h-4 min-w-4 items-center justify-center rounded-full bg-red-500 px-1 text-[10px] font-bold text-white">
+              {{ auth.pendingInvitationCount > 9 ? '9+' : auth.pendingInvitationCount }}
+            </span>
           </span>
-        </span>
-        <span v-show="!layout.sidebarCollapsed">Invitations</span>
-      </router-link>
-      <button
-        class="flex w-full items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium text-gray-600 transition-colors hover:bg-red-50 hover:text-red-600"
-        @click="handleLogout"
-      >
-        <LogOut class="h-5 w-5 shrink-0" />
-        <span v-show="!layout.sidebarCollapsed">Logout</span>
-      </button>
+          <span v-show="!layout.sidebarCollapsed">Invitations</span>
+        </router-link>
+        <span v-if="layout.sidebarCollapsed" class="sidebar-tooltip">Invitations</span>
+      </div>
+      <div class="sidebar-tooltip-wrapper">
+        <button
+          class="flex w-full items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium text-gray-600 transition-colors hover:bg-red-50 hover:text-red-600"
+          @click="handleLogout"
+        >
+          <LogOut class="h-5 w-5 shrink-0" />
+          <span v-show="!layout.sidebarCollapsed">Logout</span>
+        </button>
+        <span v-if="layout.sidebarCollapsed" class="sidebar-tooltip">Logout</span>
+      </div>
     </div>
   </aside>
 </template>
+
+<style scoped>
+.sidebar-tooltip-wrapper {
+  position: relative;
+}
+
+.sidebar-tooltip {
+  position: absolute;
+  left: calc(100% + 8px);
+  top: 50%;
+  transform: translateY(-50%);
+  white-space: nowrap;
+  border-radius: 6px;
+  background: #1f2937;
+  color: #fff;
+  font-size: 12px;
+  line-height: 1;
+  padding: 6px 10px;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.15s ease;
+  z-index: 100;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+}
+
+.sidebar-tooltip::before {
+  content: '';
+  position: absolute;
+  right: 100%;
+  top: 50%;
+  transform: translateY(-50%);
+  border: 5px solid transparent;
+  border-right-color: #1f2937;
+}
+
+.sidebar-tooltip-wrapper:hover .sidebar-tooltip {
+  opacity: 1;
+}
+</style>

--- a/web-ui/src/components/AppSidebar.vue
+++ b/web-ui/src/components/AppSidebar.vue
@@ -217,6 +217,7 @@ async function handleLogout() {
         <li v-for="item in menuItems" :key="item.label" class="sidebar-tooltip-wrapper">
           <router-link
             :to="item.to"
+            :aria-label="layout.sidebarCollapsed ? item.label : undefined"
             :class="[
               'flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium transition-colors',
               isActive(item.to)
@@ -302,7 +303,8 @@ async function handleLogout() {
   border-right-color: #1f2937;
 }
 
-.sidebar-tooltip-wrapper:hover .sidebar-tooltip {
+.sidebar-tooltip-wrapper:hover .sidebar-tooltip,
+.sidebar-tooltip-wrapper:focus-within .sidebar-tooltip {
   opacity: 1;
 }
 </style>

--- a/web-ui/src/components/AppTopBar.vue
+++ b/web-ui/src/components/AppTopBar.vue
@@ -61,6 +61,9 @@ onBeforeUnmount(() => document.removeEventListener('click', closeDropdowns))
       <div class="topbar-dropdown relative">
         <button
           class="relative rounded p-1.5 text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-600"
+          aria-label="Open notifications"
+          aria-haspopup="menu"
+          :aria-expanded="notifDropdownOpen"
           @click.stop="notifDropdownOpen = !notifDropdownOpen"
         >
           <Bell class="h-5 w-5" />
@@ -81,6 +84,7 @@ onBeforeUnmount(() => document.removeEventListener('click', closeDropdowns))
             <h3 class="text-sm font-semibold text-gray-900">Notifications</h3>
             <button
               class="rounded p-1 text-gray-400 hover:bg-gray-100 hover:text-gray-600"
+              aria-label="Close notifications"
               @click="notifDropdownOpen = false"
             >
               <X class="h-4 w-4" />
@@ -129,6 +133,9 @@ onBeforeUnmount(() => document.removeEventListener('click', closeDropdowns))
       <div class="topbar-dropdown relative">
         <button
           class="flex items-center gap-2 rounded-lg px-2 py-1.5 transition-colors hover:bg-gray-100"
+          aria-label="User menu"
+          aria-haspopup="menu"
+          :aria-expanded="userDropdownOpen"
           @click.stop="userDropdownOpen = !userDropdownOpen"
         >
           <div

--- a/web-ui/src/components/AppTopBar.vue
+++ b/web-ui/src/components/AppTopBar.vue
@@ -1,10 +1,45 @@
 <script setup lang="ts">
+import { ref, computed, onMounted, onBeforeUnmount } from 'vue'
+import { useRouter } from 'vue-router'
 import { useAuthStore } from '@/stores/auth'
 import { useLayoutStore } from '@/stores/layout'
-import { Menu, Bell } from 'lucide-vue-next'
+import {
+  Menu,
+  Bell,
+  LogOut,
+  KeyRound,
+  ChevronDown,
+  Clock,
+  X,
+} from 'lucide-vue-next'
 
 const auth = useAuthStore()
 const layout = useLayoutStore()
+const router = useRouter()
+
+const userDropdownOpen = ref(false)
+const notifDropdownOpen = ref(false)
+
+const pendingInvitations = computed(() =>
+  auth.invitations.filter((i) => i.status === 'pending'),
+)
+
+async function handleLogout() {
+  userDropdownOpen.value = false
+  await auth.logout()
+  router.push({ name: 'login' })
+}
+
+function closeDropdowns(e: MouseEvent) {
+  const target = e.target as HTMLElement
+  if (!target.closest('.topbar-dropdown')) {
+    userDropdownOpen.value = false
+    notifDropdownOpen.value = false
+  }
+}
+
+onMounted(() => document.addEventListener('click', closeDropdowns))
+onBeforeUnmount(() => document.removeEventListener('click', closeDropdowns))
 </script>
 
 <template>
@@ -21,28 +56,116 @@ const layout = useLayoutStore()
       <slot name="breadcrumb" />
     </div>
 
-    <div class="flex items-center gap-3">
-      <!-- Invitations -->
-      <router-link
-        :to="{ name: 'invitations' }"
-        class="relative rounded p-1.5 text-gray-400 hover:bg-gray-100 hover:text-gray-600"
-      >
-        <Bell class="h-5 w-5" />
-        <span
-          v-if="auth.pendingInvitationCount > 0"
-          class="absolute -right-0.5 -top-0.5 flex h-4 items-center justify-center rounded-full bg-red-500 px-1 text-[10px] font-bold text-white"
+    <div class="flex items-center gap-2">
+      <!-- Notification center -->
+      <div class="topbar-dropdown relative">
+        <button
+          class="relative rounded p-1.5 text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-600"
+          @click.stop="notifDropdownOpen = !notifDropdownOpen"
         >
-          {{ auth.pendingInvitationCount > 9 ? '9+' : auth.pendingInvitationCount }}
-        </span>
-      </router-link>
+          <Bell class="h-5 w-5" />
+          <span
+            v-if="auth.pendingInvitationCount > 0"
+            class="absolute -right-0.5 -top-0.5 flex h-4 items-center justify-center rounded-full bg-red-500 px-1 text-[10px] font-bold text-white"
+          >
+            {{ auth.pendingInvitationCount > 9 ? '9+' : auth.pendingInvitationCount }}
+          </span>
+        </button>
 
-      <div class="flex items-center gap-2">
         <div
-          class="flex h-8 w-8 items-center justify-center rounded-full bg-blue-100 text-sm font-medium text-blue-700"
+          v-if="notifDropdownOpen"
+          class="absolute right-0 top-full z-50 mt-2 w-80 overflow-hidden rounded-xl border border-gray-200 bg-white shadow-lg"
+          @click.stop
         >
-          {{ auth.username.charAt(0).toUpperCase() }}
+          <div class="flex items-center justify-between border-b px-4 py-3">
+            <h3 class="text-sm font-semibold text-gray-900">Notifications</h3>
+            <button
+              class="rounded p-1 text-gray-400 hover:bg-gray-100 hover:text-gray-600"
+              @click="notifDropdownOpen = false"
+            >
+              <X class="h-4 w-4" />
+            </button>
+          </div>
+
+          <div class="max-h-80 overflow-y-auto">
+            <template v-if="pendingInvitations.length > 0">
+              <div
+                v-for="inv in pendingInvitations"
+                :key="inv.id"
+                class="flex items-start gap-3 border-b border-gray-50 px-4 py-3 transition-colors hover:bg-gray-50"
+              >
+                <div class="mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-amber-100">
+                  <Bell class="h-4 w-4 text-amber-600" />
+                </div>
+                <div class="min-w-0 flex-1">
+                  <p class="text-sm text-gray-700">
+                    Invited to <span class="font-medium">{{ inv.tenantName }}</span>
+                  </p>
+                  <p class="mt-0.5 text-xs text-gray-400">
+                    <Clock class="mr-0.5 inline h-3 w-3" />
+                    Invited by {{ inv.inviterUsername }}
+                  </p>
+                </div>
+              </div>
+            </template>
+            <div v-else class="px-4 py-8 text-center">
+              <Bell class="mx-auto h-8 w-8 text-gray-200" />
+              <p class="mt-2 text-sm text-gray-400">No new notifications</p>
+            </div>
+          </div>
+
+          <router-link
+            v-if="pendingInvitations.length > 0"
+            :to="{ name: 'invitations' }"
+            class="block border-t px-4 py-2.5 text-center text-sm font-medium text-blue-600 transition-colors hover:bg-gray-50"
+            @click="notifDropdownOpen = false"
+          >
+            View all invitations
+          </router-link>
         </div>
-        <span class="hidden text-sm font-medium text-gray-700 sm:inline">{{ auth.username }}</span>
+      </div>
+
+      <!-- User avatar dropdown -->
+      <div class="topbar-dropdown relative">
+        <button
+          class="flex items-center gap-2 rounded-lg px-2 py-1.5 transition-colors hover:bg-gray-100"
+          @click.stop="userDropdownOpen = !userDropdownOpen"
+        >
+          <div
+            class="flex h-8 w-8 items-center justify-center rounded-full bg-blue-100 text-sm font-medium text-blue-700"
+          >
+            {{ auth.username.charAt(0).toUpperCase() }}
+          </div>
+          <span class="hidden text-sm font-medium text-gray-700 sm:inline">{{ auth.username }}</span>
+          <ChevronDown class="hidden h-3.5 w-3.5 text-gray-400 sm:block" :class="{ 'rotate-180': userDropdownOpen }" />
+        </button>
+
+        <div
+          v-if="userDropdownOpen"
+          class="absolute right-0 top-full z-50 mt-2 w-56 overflow-hidden rounded-xl border border-gray-200 bg-white shadow-lg"
+          @click.stop
+        >
+          <div class="border-b px-4 py-3">
+            <p class="text-sm font-medium text-gray-900">{{ auth.username }}</p>
+            <p v-if="auth.currentTenant" class="mt-0.5 text-xs text-gray-400">{{ auth.currentTenant.tenantName }}</p>
+          </div>
+          <div class="py-1">
+            <button
+              class="flex w-full items-center gap-2.5 px-4 py-2 text-sm text-gray-600 transition-colors hover:bg-gray-50 hover:text-gray-900"
+              @click="userDropdownOpen = false; router.push({ name: 'change-password' })"
+            >
+              <KeyRound class="h-4 w-4 text-gray-400" />
+              Change Password
+            </button>
+            <button
+              class="flex w-full items-center gap-2.5 px-4 py-2 text-sm text-red-600 transition-colors hover:bg-red-50"
+              @click="handleLogout"
+            >
+              <LogOut class="h-4 w-4" />
+              Logout
+            </button>
+          </div>
+        </div>
       </div>
     </div>
   </header>

--- a/web-ui/src/pages/DashboardPage.vue
+++ b/web-ui/src/pages/DashboardPage.vue
@@ -242,9 +242,9 @@ const chartOption = computed(() => {
     },
     grid: {
       top: 16,
-      right: 16,
+      right: 12,
       bottom: 40,
-      left: 48,
+      left: 36,
     },
     xAxis: {
       type: 'category' as const,
@@ -446,38 +446,38 @@ onMounted(() => fetchDashboardData())
     <!-- Welcome area -->
     <div class="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
       <div>
-        <h1 class="text-2xl font-bold text-gray-900">{{ greeting }}, {{ auth.username }}</h1>
+        <h1 class="text-xl font-bold text-gray-900 sm:text-2xl">{{ greeting }}, {{ auth.username }}</h1>
         <p class="mt-1 text-sm text-gray-500">
           Here's an overview of your short links performance.
         </p>
       </div>
-      <div class="flex items-center gap-2">
+      <div class="flex flex-wrap items-center gap-2">
         <button
           :disabled="loading || refreshing"
-          class="inline-flex items-center gap-2 rounded-lg border border-gray-200 bg-white px-4 py-2.5 text-sm font-medium text-gray-700 shadow-sm transition-colors hover:bg-gray-50 focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:outline-none disabled:opacity-50"
+          class="inline-flex items-center gap-2 rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm font-medium text-gray-700 shadow-sm transition-colors hover:bg-gray-50 focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:outline-none disabled:opacity-50 sm:px-4 sm:py-2.5"
           @click="handleRefresh"
         >
           <RefreshCw class="h-4 w-4" :class="{ 'animate-spin': refreshing }" />
-          Refresh
+          <span class="hidden sm:inline">Refresh</span>
         </button>
         <router-link
           :to="{ name: 'short-link-create' }"
-          class="inline-flex items-center gap-2 rounded-lg bg-blue-600 px-4 py-2.5 text-sm font-medium text-white shadow-sm transition-colors hover:bg-blue-700 focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:outline-none"
+          class="inline-flex items-center gap-2 rounded-lg bg-blue-600 px-3 py-2 text-sm font-medium text-white shadow-sm transition-colors hover:bg-blue-700 focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:outline-none sm:px-4 sm:py-2.5"
         >
           <Plus class="h-4 w-4" />
-          Create Short Link
+          Create
         </router-link>
       </div>
     </div>
 
     <!-- Stats cards -->
-    <div class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+    <div class="grid grid-cols-2 gap-3 sm:gap-4 lg:grid-cols-4">
       <!-- Total Links -->
-      <div class="rounded-xl border border-gray-200 bg-white p-5 shadow-sm">
+      <div class="rounded-xl border border-gray-200 bg-white p-3 shadow-sm sm:p-5">
         <div class="flex items-center justify-between">
           <div>
-            <p class="text-sm font-medium text-gray-500">Total Links</p>
-            <p class="mt-1 text-2xl font-bold text-gray-900">
+            <p class="text-xs font-medium text-gray-500 sm:text-sm">Total Links</p>
+            <p class="mt-1 text-xl font-bold text-gray-900 sm:text-2xl">
               <span
                 v-if="loading"
                 class="inline-block h-7 w-16 animate-pulse rounded bg-gray-200"
@@ -485,18 +485,18 @@ onMounted(() => fetchDashboardData())
               <template v-else>{{ totalLinks.toLocaleString() }}</template>
             </p>
           </div>
-          <div class="flex h-10 w-10 items-center justify-center rounded-lg bg-blue-50">
-            <Link class="h-5 w-5 text-blue-600" />
+          <div class="flex h-8 w-8 items-center justify-center rounded-lg bg-blue-50 sm:h-10 sm:w-10">
+            <Link class="h-4 w-4 text-blue-600 sm:h-5 sm:w-5" />
           </div>
         </div>
       </div>
 
       <!-- Active Links -->
-      <div class="rounded-xl border border-gray-200 bg-white p-5 shadow-sm">
+      <div class="rounded-xl border border-gray-200 bg-white p-3 shadow-sm sm:p-5">
         <div class="flex items-center justify-between">
           <div>
-            <p class="text-sm font-medium text-gray-500">Active Links</p>
-            <p class="mt-1 text-2xl font-bold text-gray-900">
+            <p class="text-xs font-medium text-gray-500 sm:text-sm">Active Links</p>
+            <p class="mt-1 text-xl font-bold text-gray-900 sm:text-2xl">
               <span
                 v-if="loading"
                 class="inline-block h-7 w-16 animate-pulse rounded bg-gray-200"
@@ -504,19 +504,19 @@ onMounted(() => fetchDashboardData())
               <template v-else>{{ activeLinks.toLocaleString() }}</template>
             </p>
           </div>
-          <div class="flex h-10 w-10 items-center justify-center rounded-lg bg-green-50">
-            <LinkIcon class="h-5 w-5 text-green-600" />
+          <div class="flex h-8 w-8 items-center justify-center rounded-lg bg-green-50 sm:h-10 sm:w-10">
+            <LinkIcon class="h-4 w-4 text-green-600 sm:h-5 sm:w-5" />
           </div>
         </div>
       </div>
 
       <!-- Today's Visits -->
-      <div class="rounded-xl border border-gray-200 bg-white p-5 shadow-sm">
+      <div class="rounded-xl border border-gray-200 bg-white p-3 shadow-sm sm:p-5">
         <div class="flex items-center justify-between">
           <div>
-            <p class="text-sm font-medium text-gray-500">Today's Visits</p>
+            <p class="text-xs font-medium text-gray-500 sm:text-sm">Today's Visits</p>
             <div class="mt-1 flex items-baseline gap-2">
-              <p class="text-2xl font-bold text-gray-900">
+              <p class="text-xl font-bold text-gray-900 sm:text-2xl">
                 <span
                   v-if="loading"
                   class="inline-block h-7 w-16 animate-pulse rounded bg-gray-200"
@@ -535,20 +535,20 @@ onMounted(() => fetchDashboardData())
               </span>
             </div>
           </div>
-          <div class="flex h-10 w-10 items-center justify-center rounded-lg bg-purple-50">
-            <MousePointerClick class="h-5 w-5 text-purple-600" />
+          <div class="flex h-8 w-8 items-center justify-center rounded-lg bg-purple-50 sm:h-10 sm:w-10">
+            <MousePointerClick class="h-4 w-4 text-purple-600 sm:h-5 sm:w-5" />
           </div>
         </div>
         <p v-if="!loading && todayTrend" class="mt-1 text-xs text-gray-400">vs yesterday</p>
       </div>
 
       <!-- Period Visits -->
-      <div class="rounded-xl border border-gray-200 bg-white p-5 shadow-sm">
+      <div class="rounded-xl border border-gray-200 bg-white p-3 shadow-sm sm:p-5">
         <div class="flex items-center justify-between">
           <div>
-            <p class="text-sm font-medium text-gray-500">{{ periodLabel }}</p>
+            <p class="text-xs font-medium text-gray-500 sm:text-sm">{{ periodLabel }}</p>
             <div class="mt-1 flex items-baseline gap-2">
-              <p class="text-2xl font-bold text-gray-900">
+              <p class="text-xl font-bold text-gray-900 sm:text-2xl">
                 <span
                   v-if="loading"
                   class="inline-block h-7 w-16 animate-pulse rounded bg-gray-200"
@@ -567,8 +567,8 @@ onMounted(() => fetchDashboardData())
               </span>
             </div>
           </div>
-          <div class="flex h-10 w-10 items-center justify-center rounded-lg bg-orange-50">
-            <BarChart3 class="h-5 w-5 text-orange-600" />
+          <div class="flex h-8 w-8 items-center justify-center rounded-lg bg-orange-50 sm:h-10 sm:w-10">
+            <BarChart3 class="h-4 w-4 text-orange-600 sm:h-5 sm:w-5" />
           </div>
         </div>
         <p v-if="!loading && periodTrend" class="mt-1 text-xs text-gray-400">vs previous {{ trendDays }} days</p>
@@ -576,9 +576,9 @@ onMounted(() => fetchDashboardData())
     </div>
 
     <!-- Chart + Recent Links -->
-    <div class="grid grid-cols-1 gap-6 lg:grid-cols-5">
+    <div class="grid grid-cols-1 gap-4 lg:grid-cols-5 lg:gap-6">
       <!-- Visit Trend Chart -->
-      <div class="rounded-xl border border-gray-200 bg-white p-5 shadow-sm lg:col-span-3">
+      <div class="rounded-xl border border-gray-200 bg-white p-3 shadow-sm sm:p-5 lg:col-span-3">
         <div class="mb-4 flex items-center justify-between">
           <div class="flex items-center gap-2">
             <TrendingUp class="h-4 w-4 text-gray-500" />
@@ -623,7 +623,7 @@ onMounted(() => fetchDashboardData())
             <div class="h-2.5 w-10 animate-pulse rounded bg-gray-100" />
           </div>
         </div>
-        <div v-else class="h-64">
+        <div v-else class="h-48 sm:h-64">
           <VChart
             :option="chartOption"
             :autoresize="true"
@@ -635,7 +635,7 @@ onMounted(() => fetchDashboardData())
       </div>
 
       <!-- Recent Links -->
-      <div class="rounded-xl border border-gray-200 bg-white p-5 shadow-sm lg:col-span-2">
+      <div class="rounded-xl border border-gray-200 bg-white p-3 shadow-sm sm:p-5 lg:col-span-2">
         <div class="mb-4 flex items-center justify-between">
           <div class="flex items-center gap-2">
             <Clock class="h-4 w-4 text-gray-500" />
@@ -725,55 +725,88 @@ onMounted(() => fetchDashboardData())
         <BarChart3 class="mx-auto h-8 w-8 text-gray-300" />
         <p class="mt-2 text-sm text-gray-400">No visit data available yet</p>
       </div>
-      <div v-else class="overflow-x-auto">
-        <table class="w-full text-sm">
-          <thead>
-            <tr
-              class="border-b border-gray-100 text-left text-xs font-medium uppercase tracking-wider text-gray-500"
+      <div v-else>
+        <!-- Mobile cards -->
+        <div class="divide-y divide-gray-50 md:hidden">
+          <div
+            v-for="(item, index) in topLinks"
+            :key="item.link.id"
+            class="flex items-center gap-3 px-4 py-3"
+          >
+            <span
+              :class="[
+                'inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-full text-xs font-semibold',
+                index < 3 ? 'bg-blue-100 text-blue-700' : 'bg-gray-100 text-gray-500',
+              ]"
             >
-              <th class="w-12 px-5 py-3">#</th>
-              <th class="px-5 py-3">Short Link</th>
-              <th class="hidden px-5 py-3 md:table-cell">Destination URL</th>
-              <th class="px-5 py-3 text-right">PV</th>
-              <th class="px-5 py-3 text-right">UV</th>
-            </tr>
-          </thead>
-          <tbody class="divide-y divide-gray-50">
-            <tr
-              v-for="(item, index) in topLinks"
-              :key="item.link.id"
-              class="transition-colors hover:bg-gray-50"
-            >
-              <td class="px-5 py-3">
-                <span
-                  :class="[
-                    'inline-flex h-6 w-6 items-center justify-center rounded-full text-xs font-semibold',
-                    index < 3 ? 'bg-blue-100 text-blue-700' : 'bg-gray-100 text-gray-500',
-                  ]"
-                >
-                  {{ index + 1 }}
-                </span>
-              </td>
-              <td class="px-5 py-3">
-                <router-link
-                  :to="{ name: 'short-link-detail', params: { id: item.link.id } }"
-                  class="inline-flex items-center gap-1 font-mono text-sm font-medium text-blue-600 hover:text-blue-700"
-                >
-                  {{ item.link.id }}
-                </router-link>
-              </td>
-              <td class="hidden max-w-[280px] truncate px-5 py-3 text-gray-500 md:table-cell">
-                {{ item.link.url }}
-              </td>
-              <td class="whitespace-nowrap px-5 py-3 text-right font-semibold text-gray-900">
-                {{ item.pv.toLocaleString() }}
-              </td>
-              <td class="whitespace-nowrap px-5 py-3 text-right text-gray-600">
-                {{ item.uv.toLocaleString() }}
-              </td>
-            </tr>
-          </tbody>
-        </table>
+              {{ index + 1 }}
+            </span>
+            <div class="min-w-0 flex-1">
+              <router-link
+                :to="{ name: 'short-link-detail', params: { id: item.link.id } }"
+                class="font-mono text-sm font-medium text-blue-600 hover:text-blue-700"
+              >
+                {{ item.link.id }}
+              </router-link>
+              <p class="truncate text-xs text-gray-400">{{ item.link.url }}</p>
+            </div>
+            <div class="shrink-0 text-right text-sm">
+              <p class="font-semibold text-gray-900">{{ item.pv.toLocaleString() }}</p>
+              <p class="text-xs text-gray-400">{{ item.uv.toLocaleString() }} uv</p>
+            </div>
+          </div>
+        </div>
+        <!-- Desktop table -->
+        <div class="hidden overflow-x-auto md:block">
+          <table class="w-full text-sm">
+            <thead>
+              <tr
+                class="border-b border-gray-100 text-left text-xs font-medium uppercase tracking-wider text-gray-500"
+              >
+                <th class="w-12 px-5 py-3">#</th>
+                <th class="px-5 py-3">Short Link</th>
+                <th class="px-5 py-3">Destination URL</th>
+                <th class="px-5 py-3 text-right">PV</th>
+                <th class="px-5 py-3 text-right">UV</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-gray-50">
+              <tr
+                v-for="(item, index) in topLinks"
+                :key="item.link.id"
+                class="transition-colors hover:bg-gray-50"
+              >
+                <td class="px-5 py-3">
+                  <span
+                    :class="[
+                      'inline-flex h-6 w-6 items-center justify-center rounded-full text-xs font-semibold',
+                      index < 3 ? 'bg-blue-100 text-blue-700' : 'bg-gray-100 text-gray-500',
+                    ]"
+                  >
+                    {{ index + 1 }}
+                  </span>
+                </td>
+                <td class="px-5 py-3">
+                  <router-link
+                    :to="{ name: 'short-link-detail', params: { id: item.link.id } }"
+                    class="inline-flex items-center gap-1 font-mono text-sm font-medium text-blue-600 hover:text-blue-700"
+                  >
+                    {{ item.link.id }}
+                  </router-link>
+                </td>
+                <td class="max-w-[280px] truncate px-5 py-3 text-gray-500">
+                  {{ item.link.url }}
+                </td>
+                <td class="whitespace-nowrap px-5 py-3 text-right font-semibold text-gray-900">
+                  {{ item.pv.toLocaleString() }}
+                </td>
+                <td class="whitespace-nowrap px-5 py-3 text-right text-gray-600">
+                  {{ item.uv.toLocaleString() }}
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
       </div>
     </div>
   </div>

--- a/web-ui/src/pages/DashboardPage.vue
+++ b/web-ui/src/pages/DashboardPage.vue
@@ -455,6 +455,7 @@ onMounted(() => fetchDashboardData())
         <button
           :disabled="loading || refreshing"
           class="inline-flex items-center gap-2 rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm font-medium text-gray-700 shadow-sm transition-colors hover:bg-gray-50 focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:outline-none disabled:opacity-50 sm:px-4 sm:py-2.5"
+          aria-label="Refresh dashboard"
           @click="handleRefresh"
         >
           <RefreshCw class="h-4 w-4" :class="{ 'animate-spin': refreshing }" />

--- a/web-ui/src/pages/SettingsPage.vue
+++ b/web-ui/src/pages/SettingsPage.vue
@@ -455,11 +455,15 @@ onMounted(fetchAll)
                     target="_blank"
                     rel="noopener noreferrer"
                     class="rounded p-1.5 text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-600"
+                    title="Open domain"
+                    aria-label="Open domain"
                   >
                     <ExternalLink class="h-4 w-4" />
                   </a>
                   <button
                     class="rounded p-1.5 text-gray-400 transition-colors hover:bg-red-50 hover:text-red-600"
+                    title="Delete domain"
+                    aria-label="Delete domain"
                     @click="confirmDeleteDomain = d.domain"
                   >
                     <Trash2 class="h-4 w-4" />

--- a/web-ui/src/pages/SettingsPage.vue
+++ b/web-ui/src/pages/SettingsPage.vue
@@ -321,7 +321,7 @@ onMounted(fetchAll)
 </script>
 
 <template>
-  <div class="space-y-6">
+  <div class="space-y-4 sm:space-y-6">
     <!-- Header -->
     <div>
       <h1 class="flex items-center gap-2 text-xl font-semibold text-gray-900">
@@ -343,12 +343,12 @@ onMounted(fetchAll)
     <template v-else>
       <!-- Tenant Basic Info (admin only) -->
       <div v-if="isAdmin && tenant" class="rounded-xl border border-gray-200 bg-white shadow-sm">
-        <div class="flex items-center gap-2 border-b border-gray-100 px-5 py-4">
+        <div class="flex items-center gap-2 border-b border-gray-100 px-4 py-3 sm:px-5 sm:py-4">
           <Building2 class="h-4 w-4 text-blue-600" />
           <h2 class="text-base font-semibold text-gray-900">Tenant Information</h2>
         </div>
-        <div class="p-5">
-          <div class="max-w-md space-y-4">
+        <div class="p-4 sm:p-5">
+          <div class="space-y-4">
             <div>
               <label class="mb-1 block text-sm font-medium text-gray-700">Name</label>
               <input
@@ -385,14 +385,14 @@ onMounted(fetchAll)
 
       <!-- Domain Management (admin only) -->
       <div v-if="isAdmin" class="rounded-xl border border-gray-200 bg-white shadow-sm">
-        <div class="flex items-center gap-2 border-b border-gray-100 px-5 py-4">
+        <div class="flex items-center gap-2 border-b border-gray-100 px-4 py-3 sm:px-5 sm:py-4">
           <Globe class="h-4 w-4 text-green-600" />
           <h2 class="text-base font-semibold text-gray-900">Domains</h2>
           <span class="rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-600">
             {{ domains.length }}
           </span>
         </div>
-        <div class="p-5">
+        <div class="p-4 sm:p-5">
           <!-- Add domain form -->
           <div class="rounded-lg border bg-gray-50 p-4">
             <div class="flex flex-col gap-3 sm:flex-row sm:items-end">
@@ -429,7 +429,46 @@ onMounted(fetchAll)
             <Loader2 class="h-5 w-5 animate-spin text-gray-400" />
           </div>
           <div v-else-if="domains.length > 0" class="mt-4 overflow-hidden rounded-lg border">
-            <table class="w-full text-sm">
+            <!-- Mobile cards -->
+            <div class="divide-y lg:hidden">
+              <div
+                v-for="d in domains"
+                :key="d.id"
+                class="flex items-center justify-between px-4 py-3"
+              >
+                <div class="min-w-0 flex-1">
+                  <div class="flex items-center gap-2">
+                    <Globe class="h-4 w-4 text-gray-400" />
+                    <span class="font-mono text-sm text-gray-900">{{ d.domain }}</span>
+                  </div>
+                  <div class="mt-1 flex items-center gap-2 pl-6">
+                    <span v-if="d.isDefault" class="inline-flex items-center gap-1 text-xs font-medium text-yellow-600">
+                      <Star class="h-3 w-3 fill-yellow-500 text-yellow-500" />
+                      Default
+                    </span>
+                    <span class="text-xs text-gray-400">{{ formatDate(d.createdAt) }}</span>
+                  </div>
+                </div>
+                <div class="flex items-center gap-1">
+                  <a
+                    :href="'https://' + d.domain"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    class="rounded p-1.5 text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-600"
+                  >
+                    <ExternalLink class="h-4 w-4" />
+                  </a>
+                  <button
+                    class="rounded p-1.5 text-gray-400 transition-colors hover:bg-red-50 hover:text-red-600"
+                    @click="confirmDeleteDomain = d.domain"
+                  >
+                    <Trash2 class="h-4 w-4" />
+                  </button>
+                </div>
+              </div>
+            </div>
+            <!-- Desktop table -->
+            <table class="hidden w-full text-sm lg:table">
               <thead>
                 <tr class="border-b bg-gray-50 text-left text-xs font-medium uppercase tracking-wider text-gray-500">
                   <th class="px-4 py-3">Domain</th>
@@ -484,11 +523,11 @@ onMounted(fetchAll)
 
       <!-- ID Length Config (admin only) -->
       <div v-if="isAdmin" class="rounded-xl border border-gray-200 bg-white shadow-sm">
-        <div class="flex items-center gap-2 border-b border-gray-100 px-5 py-4">
+        <div class="flex items-center gap-2 border-b border-gray-100 px-4 py-3 sm:px-5 sm:py-4">
           <Hash class="h-4 w-4 text-blue-600" />
           <h2 class="text-base font-semibold text-gray-900">ID Length Configuration</h2>
         </div>
-        <div class="p-5">
+        <div class="p-4 sm:p-5">
           <div class="max-w-md space-y-4">
             <div>
               <label class="mb-1 block text-sm font-medium text-gray-700">Default ID Length</label>
@@ -544,11 +583,11 @@ onMounted(fetchAll)
 
       <!-- 404 Config (admin only) -->
       <div v-if="isAdmin" class="rounded-xl border border-gray-200 bg-white shadow-sm">
-        <div class="flex items-center gap-2 border-b border-gray-100 px-5 py-4">
+        <div class="flex items-center gap-2 border-b border-gray-100 px-4 py-3 sm:px-5 sm:py-4">
           <AlertTriangle class="h-4 w-4 text-orange-500" />
           <h2 class="text-base font-semibold text-gray-900">404 Handling Configuration</h2>
         </div>
-        <div class="p-5">
+        <div class="p-4 sm:p-5">
           <div class="max-w-md space-y-4">
             <div>
               <label id="mode-label" class="mb-1 block text-sm font-medium text-gray-700">Handling Mode</label>
@@ -608,11 +647,11 @@ onMounted(fetchAll)
 
       <!-- Config Preview (admin only) -->
       <div v-if="isAdmin" class="rounded-xl border border-gray-200 bg-white shadow-sm">
-        <div class="flex items-center gap-2 border-b border-gray-100 px-5 py-4">
+        <div class="flex items-center gap-2 border-b border-gray-100 px-4 py-3 sm:px-5 sm:py-4">
           <Eye class="h-4 w-4 text-purple-600" />
           <h2 class="text-base font-semibold text-gray-900">Configuration Preview</h2>
         </div>
-        <div class="p-5">
+        <div class="p-4 sm:p-5">
           <div class="grid grid-cols-1 gap-4 sm:grid-cols-2">
             <div class="rounded-lg border border-gray-100 bg-gray-50 p-4">
               <div class="mb-3 flex items-center justify-between">

--- a/web-ui/src/pages/ShortLinksPage.vue
+++ b/web-ui/src/pages/ShortLinksPage.vue
@@ -322,7 +322,7 @@ onMounted(fetchLinks)
       </div>
       <select
         v-model="filterEnabled"
-        class="rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
+        class="rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none sm:w-auto"
       >
         <option value="">All Status</option>
         <option value="true">Enabled</option>
@@ -331,7 +331,7 @@ onMounted(fetchLinks)
     </div>
 
     <!-- Batch actions -->
-    <div v-if="selectedIds.size > 0" class="mt-3 flex items-center gap-3">
+    <div v-if="selectedIds.size > 0" class="mt-3 flex flex-wrap items-center gap-2">
       <span class="text-sm text-gray-600">{{ selectedIds.size }} selected</span>
       <button
         :disabled="batchUpdating"
@@ -357,8 +357,139 @@ onMounted(fetchLinks)
       </button>
     </div>
 
-    <!-- Table -->
-    <div class="mt-4 overflow-hidden rounded-lg border bg-white">
+    <!-- Mobile card layout (hidden on md+) -->
+    <div class="mt-4 space-y-3 md:hidden">
+      <!-- Loading skeleton -->
+      <template v-if="loading">
+        <div v-for="i in 5" :key="`skel-${i}`" class="rounded-lg border bg-white p-4">
+          <div class="flex items-center justify-between">
+            <div class="h-4 w-24 animate-pulse rounded bg-gray-200" />
+            <div class="h-5 w-16 animate-pulse rounded-full bg-gray-200" />
+          </div>
+          <div class="mt-2 h-3 w-full animate-pulse rounded bg-gray-100" />
+          <div class="mt-2 flex items-center justify-between">
+            <div class="h-3 w-20 animate-pulse rounded bg-gray-100" />
+            <div class="h-6 w-6 animate-pulse rounded bg-gray-100" />
+          </div>
+        </div>
+      </template>
+      <!-- Empty state -->
+      <div v-else-if="filteredLinks.length === 0 && total === 0" class="rounded-lg border bg-white py-12 text-center">
+        <Link class="mx-auto h-10 w-10 text-gray-300" />
+        <p class="mt-3 text-sm font-medium text-gray-500">No short links yet</p>
+        <router-link
+          :to="{ name: 'short-link-create' }"
+          class="mt-3 inline-flex items-center gap-1.5 rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700"
+        >
+          <Plus class="h-4 w-4" />
+          Create your first link
+        </router-link>
+      </div>
+      <div v-else-if="filteredLinks.length === 0" class="rounded-lg border bg-white py-8 text-center text-sm text-gray-400">
+        No short links match your search.
+      </div>
+      <!-- Link cards -->
+      <div
+        v-for="link in sortedLinks"
+        :key="link.id"
+        class="rounded-lg border bg-white transition-colors"
+        :class="{ 'border-blue-200 bg-blue-50/30': selectedIds.has(link.id) }"
+      >
+        <div class="flex items-center justify-between p-4">
+          <div class="flex items-center gap-2">
+            <input
+              type="checkbox"
+              :checked="selectedIds.has(link.id)"
+              class="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+              @change="toggleSelect(link.id)"
+            />
+            <span class="font-mono text-sm font-medium text-gray-900">{{ link.id }}</span>
+            <button
+              class="rounded p-0.5 text-gray-400 hover:text-blue-600"
+              @click="copyLink(link.id)"
+            >
+              <Copy v-if="copiedId !== link.id" class="h-3.5 w-3.5" />
+              <Check v-else class="h-3.5 w-3.5 text-green-500" />
+            </button>
+          </div>
+          <button
+            :disabled="togglingId === link.id"
+            class="inline-flex items-center gap-1.5 rounded-full px-2 py-0.5 text-xs font-medium"
+            :class="link.isEnable ? 'bg-green-50 text-green-700' : 'bg-gray-100 text-gray-500'"
+            @click="handleToggleEnable(link)"
+          >
+            <Loader2 v-if="togglingId === link.id" class="h-3 w-3 animate-spin" />
+            <span v-else class="h-1.5 w-1.5 rounded-full" :class="link.isEnable ? 'bg-green-500' : 'bg-gray-400'" />
+            {{ link.isEnable ? 'On' : 'Off' }}
+          </button>
+        </div>
+        <div class="border-t px-4 py-3">
+          <a
+            :href="link.url"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="flex items-center gap-1 text-sm text-blue-600 hover:underline"
+          >
+            <span class="truncate">{{ link.url }}</span>
+            <ExternalLink class="h-3 w-3 shrink-0" />
+          </a>
+          <p v-if="link.description" class="mt-1 truncate text-xs text-gray-400">{{ link.description }}</p>
+        </div>
+        <div class="flex items-center justify-between border-t px-4 py-2">
+          <span class="text-xs text-gray-400">{{ formatDate(link.createTime) }}</span>
+          <div class="flex items-center gap-1">
+            <button
+              class="rounded p-1.5 text-gray-400 hover:bg-gray-100 hover:text-gray-600"
+              @click="router.push({ name: 'short-link-detail', params: { id: link.id } })"
+            >
+              <Eye class="h-4 w-4" />
+            </button>
+            <button
+              class="rounded p-1.5 text-gray-400 hover:bg-gray-100 hover:text-gray-600"
+              @click="router.push({ name: 'short-link-edit', params: { id: link.id } })"
+            >
+              <Pencil class="h-4 w-4" />
+            </button>
+            <button
+              class="rounded p-1.5 text-gray-400 hover:bg-red-50 hover:text-red-600"
+              @click="confirmDeleteId = link.id"
+            >
+              <Trash2 class="h-4 w-4" />
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <!-- Mobile pagination -->
+      <div
+        v-if="totalPages > 1"
+        class="mt-3 flex items-center justify-between"
+      >
+        <span class="text-xs text-gray-400">
+          {{ (page - 1) * pageSize + 1 }}–{{ Math.min(page * pageSize, total) }} of {{ total }}
+        </span>
+        <div class="flex items-center gap-1">
+          <button
+            :disabled="page <= 1"
+            class="rounded p-1.5 text-gray-400 transition-colors hover:bg-gray-100 disabled:opacity-30"
+            @click="goPage(page - 1)"
+          >
+            <ChevronLeft class="h-5 w-5" />
+          </button>
+          <span class="min-w-[60px] text-center text-sm font-medium text-gray-700">{{ page }} / {{ totalPages }}</span>
+          <button
+            :disabled="page >= totalPages"
+            class="rounded p-1.5 text-gray-400 transition-colors hover:bg-gray-100 disabled:opacity-30"
+            @click="goPage(page + 1)"
+          >
+            <ChevronRight class="h-5 w-5" />
+          </button>
+        </div>
+      </div>
+    </div>
+
+    <!-- Desktop table (hidden below md) -->
+    <div class="mt-4 hidden overflow-hidden rounded-lg border bg-white md:block">
       <div class="overflow-x-auto">
         <table class="w-full text-sm">
           <thead>

--- a/web-ui/src/pages/ShortLinksPage.vue
+++ b/web-ui/src/pages/ShortLinksPage.vue
@@ -406,6 +406,8 @@ onMounted(fetchLinks)
             <span class="font-mono text-sm font-medium text-gray-900">{{ link.id }}</span>
             <button
               class="rounded p-0.5 text-gray-400 hover:text-blue-600"
+              title="Copy short link"
+              aria-label="Copy short link"
               @click="copyLink(link.id)"
             >
               <Copy v-if="copiedId !== link.id" class="h-3.5 w-3.5" />
@@ -440,18 +442,24 @@ onMounted(fetchLinks)
           <div class="flex items-center gap-1">
             <button
               class="rounded p-1.5 text-gray-400 hover:bg-gray-100 hover:text-gray-600"
+              title="View details"
+              aria-label="View details"
               @click="router.push({ name: 'short-link-detail', params: { id: link.id } })"
             >
               <Eye class="h-4 w-4" />
             </button>
             <button
               class="rounded p-1.5 text-gray-400 hover:bg-gray-100 hover:text-gray-600"
+              title="Edit"
+              aria-label="Edit"
               @click="router.push({ name: 'short-link-edit', params: { id: link.id } })"
             >
               <Pencil class="h-4 w-4" />
             </button>
             <button
               class="rounded p-1.5 text-gray-400 hover:bg-red-50 hover:text-red-600"
+              title="Delete"
+              aria-label="Delete"
               @click="confirmDeleteId = link.id"
             >
               <Trash2 class="h-4 w-4" />
@@ -472,6 +480,7 @@ onMounted(fetchLinks)
           <button
             :disabled="page <= 1"
             class="rounded p-1.5 text-gray-400 transition-colors hover:bg-gray-100 disabled:opacity-30"
+            aria-label="Previous page"
             @click="goPage(page - 1)"
           >
             <ChevronLeft class="h-5 w-5" />
@@ -480,6 +489,7 @@ onMounted(fetchLinks)
           <button
             :disabled="page >= totalPages"
             class="rounded p-1.5 text-gray-400 transition-colors hover:bg-gray-100 disabled:opacity-30"
+            aria-label="Next page"
             @click="goPage(page + 1)"
           >
             <ChevronRight class="h-5 w-5" />


### PR DESCRIPTION
## Summary
- **Sidebar**: Custom CSS hover tooltips for collapsed state — replaces native `title` attributes with styled dark tooltips on nav items, super admin toggle, and logout button
- **Breadcrumb**: Adds missing parent route mappings for tenant-create, tenant-detail, and super-tenant-detail pages
- **TopBar**: User avatar dropdown menu with Change Password and Logout actions
- **TopBar**: Notification center dropdown showing pending invitations with bell icon
- **Responsive — ShortLinksPage**: Mobile card layout replaces table on small screens (<768px), with mobile pagination
- **Responsive — Dashboard**: Compact stat cards on mobile, smaller chart height, mobile top-links card layout
- **Responsive — SettingsPage**: Responsive padding, mobile domain list cards

Closes [JWM-67](mention://issue/62682cf5-462f-4020-86aa-a7031899d5f0)

## Test plan
- [ ] Verify sidebar tooltips appear when hovering collapsed nav items
- [ ] Verify breadcrumb shows correct parent path on tenant detail/create pages
- [ ] Click user avatar → dropdown with Change Password and Logout appears
- [ ] Click bell icon → notification dropdown shows pending invitations
- [ ] View ShortLinksPage on mobile viewport → card layout appears
- [ ] View Dashboard on mobile → compact cards and chart sizing
- [ ] View SettingsPage on mobile → responsive section padding

🤖 Generated with [Claude Code](https://claude.com/claude-code)