### PR TITLE
feat(web-ui): route loading bar with NProgress

### DIFF
--- a/web-ui/src/router/index.ts
+++ b/web-ui/src/router/index.ts
@@ -1,6 +1,9 @@
 import { createRouter, createWebHistory } from 'vue-router'
+import NProgress from 'nprogress'
 import { useAuthStore } from '@/stores/auth'
 import { UserRole } from '@/types/api'
+
+NProgress.configure({ showSpinner: false })
 
 const router = createRouter({
   history: createWebHistory(import.meta.env.BASE_URL),
@@ -146,6 +149,7 @@ const router = createRouter({
 })
 
 router.beforeEach(async (to) => {
+  NProgress.start()
   const auth = useAuthStore()
 
   if (to.meta.requiresAuth !== false && !auth.isLoggedIn) {
@@ -190,6 +194,10 @@ router.beforeEach(async (to) => {
   if (to.name === 'login' && auth.isLoggedIn) {
     return { name: auth.currentTenantId ? 'dashboard' : 'select-tenant' }
   }
+})
+
+router.afterEach(() => {
+  NProgress.done()
 })
 
 export default router

--- a/web-ui/src/style.css
+++ b/web-ui/src/style.css
@@ -1,4 +1,10 @@
 @import 'tailwindcss';
+@import 'nprogress/nprogress.css';
+
+#nprogress .bar {
+  background: #3b82f6;
+  height: 2px;
+}
 
 button,
 [type="button"],


### PR DESCRIPTION
## Summary
- Integrate NProgress library to display a slim blue progress bar at the top of the page during route transitions
- Configure NProgress with spinner disabled for a cleaner look
- Add NProgress lifecycle hooks to router beforeEach/afterEach guards

## Test plan
- [ ] Navigate between pages and verify the progress bar appears during transitions
- [ ] Verify progress bar color matches the app's blue accent (#3b82f6)
- [ ] Verify no spinner appears (only the bar)
- [ ] Verify bar disappears after route change completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)