### PR TITLE
feat(web-ui): dark mode with theme toggle

### DIFF
--- a/web-ui/src/components/AppBreadcrumb.vue
+++ b/web-ui/src/components/AppBreadcrumb.vue
@@ -55,15 +55,15 @@ const items = computed<BreadcrumbItem[]>(() => {
 
 <template>
   <nav v-if="items.length > 0" class="flex items-center gap-1 text-sm">
-    <router-link to="/" class="text-gray-400 hover:text-gray-600">
+    <router-link to="/" class="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300">
       <Home class="h-4 w-4" />
     </router-link>
     <template v-for="(item, i) in items" :key="i">
-      <ChevronRight class="h-3.5 w-3.5 text-gray-300" />
-      <router-link v-if="item.to" class="text-gray-500 hover:text-gray-700" :to="item.to">
+      <ChevronRight class="h-3.5 w-3.5 text-gray-300 dark:text-gray-600" />
+      <router-link v-if="item.to" class="text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200" :to="item.to">
         {{ item.label }}
       </router-link>
-      <span v-else class="font-medium text-gray-900">{{ item.label }}</span>
+      <span v-else class="font-medium text-gray-900 dark:text-white">{{ item.label }}</span>
     </template>
   </nav>
 </template>

--- a/web-ui/src/components/AppSidebar.vue
+++ b/web-ui/src/components/AppSidebar.vue
@@ -100,7 +100,7 @@ async function handleLogout() {
 
   <aside
     :class="[
-      'fixed left-0 top-0 z-50 flex h-full flex-col border-r bg-white transition-all duration-300 lg:relative lg:z-auto',
+      'fixed left-0 top-0 z-50 flex h-full flex-col border-r border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-900 transition-all duration-300 lg:relative lg:z-auto',
       layout.sidebarCollapsed ? 'w-16' : 'w-60',
       layout.mobileMenuOpen ? 'translate-x-0' : '-translate-x-full lg:translate-x-0',
     ]"
@@ -108,7 +108,7 @@ async function handleLogout() {
     <!-- Header -->
     <div
       :class="[
-        'flex h-14 items-center border-b',
+        'flex h-14 items-center border-b border-gray-200 dark:border-gray-700',
         layout.sidebarCollapsed
           ? 'justify-between px-3 lg:justify-center lg:px-0'
           : 'justify-between px-3',
@@ -126,7 +126,7 @@ async function handleLogout() {
         </div>
         <span
           v-show="!layout.sidebarCollapsed"
-          class="whitespace-nowrap text-base font-semibold text-gray-900"
+          class="whitespace-nowrap text-base font-semibold text-gray-900 dark:text-white"
         >
           Jump Jump
         </span>
@@ -134,7 +134,7 @@ async function handleLogout() {
 
       <!-- Mobile close -->
       <button
-        class="rounded p-1 text-gray-400 hover:text-gray-600 lg:hidden"
+        class="rounded p-1 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 lg:hidden"
         @click="layout.closeMobileMenu"
       >
         <X class="h-5 w-5" />
@@ -142,7 +142,7 @@ async function handleLogout() {
       <!-- Desktop collapse (only when expanded) -->
       <button
         v-show="!layout.sidebarCollapsed"
-        class="hidden rounded p-1 text-gray-400 hover:text-gray-600 lg:block"
+        class="hidden rounded p-1 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 lg:block"
         @click="layout.toggleSidebar"
       >
         <ChevronLeft class="h-4 w-4 transition-transform" />
@@ -152,7 +152,7 @@ async function handleLogout() {
     <!-- Expand toggle (only when collapsed, desktop) -->
     <div v-if="layout.sidebarCollapsed" class="sidebar-tooltip-wrapper">
       <button
-        class="absolute -right-3 top-4 z-10 hidden h-6 w-6 items-center justify-center rounded-full border border-gray-200 bg-white shadow-sm text-gray-400 hover:text-gray-600 lg:flex"
+        class="absolute -right-3 top-4 z-10 hidden h-6 w-6 items-center justify-center rounded-full border border-gray-200 bg-white shadow-sm text-gray-400 hover:text-gray-600 dark:border-gray-600 dark:bg-gray-800 dark:hover:text-gray-300 lg:flex"
         aria-label="Expand sidebar"
         @click="layout.toggleSidebar"
       >
@@ -162,14 +162,14 @@ async function handleLogout() {
     </div>
 
     <!-- Tenant switcher (hidden on super admin routes) -->
-    <div v-if="!layout.sidebarCollapsed && showTenantSwitcher" class="border-b px-3 py-2">
+    <div v-if="!layout.sidebarCollapsed && showTenantSwitcher" class="border-b border-gray-200 dark:border-gray-700 px-3 py-2">
       <button
-        class="flex w-full items-center justify-between rounded-lg px-2 py-1.5 text-left text-sm hover:bg-gray-100"
+        class="flex w-full items-center justify-between rounded-lg px-2 py-1.5 text-left text-sm hover:bg-gray-100 dark:hover:bg-gray-800"
         @click="tenantDropdownOpen = !tenantDropdownOpen"
       >
         <div class="min-w-0 flex-1">
-          <div class="truncate text-xs text-gray-400">Current tenant</div>
-          <div class="truncate font-medium text-gray-700">
+          <div class="truncate text-xs text-gray-400 dark:text-gray-500">Current tenant</div>
+          <div class="truncate font-medium text-gray-700 dark:text-gray-300">
             {{ auth.currentTenant?.tenantName || (auth.isSuper ? 'Super Admin' : 'Not selected') }}
           </div>
         </div>
@@ -180,16 +180,16 @@ async function handleLogout() {
         <button
           v-for="tenant in auth.tenants"
           :key="tenant.tenantId"
-          class="flex w-full items-center justify-between rounded-md px-2 py-1.5 text-sm hover:bg-gray-100"
-          :class="auth.currentTenantId === tenant.tenantId ? 'bg-blue-50 text-blue-700' : 'text-gray-600'"
+          class="flex w-full items-center justify-between rounded-md px-2 py-1.5 text-sm hover:bg-gray-100 dark:hover:bg-gray-800"
+          :class="auth.currentTenantId === tenant.tenantId ? 'bg-blue-50 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400' : 'text-gray-600 dark:text-gray-400'"
           @click="handleTenantSwitch(tenant.tenantId)"
         >
           <span class="truncate">{{ tenant.tenantName }}</span>
-          <span class="text-xs text-gray-400">{{ tenant.role }}</span>
+          <span class="text-xs text-gray-400 dark:text-gray-500">{{ tenant.role }}</span>
         </button>
         <router-link
           :to="{ name: 'select-tenant' }"
-          class="flex items-center gap-1 rounded-md px-2 py-1.5 text-xs text-gray-400 hover:bg-gray-50 hover:text-gray-600"
+          class="flex items-center gap-1 rounded-md px-2 py-1.5 text-xs text-gray-400 hover:bg-gray-50 hover:text-gray-600 dark:hover:bg-gray-800 dark:hover:text-gray-300"
           @click="tenantDropdownOpen = false; layout.closeMobileMenu()"
         >
           <ChevronRight class="h-3 w-3" />
@@ -199,10 +199,10 @@ async function handleLogout() {
     </div>
 
     <!-- Super admin toggle -->
-    <div v-if="auth.isSuper" class="sidebar-tooltip-wrapper border-b px-2 py-2">
+    <div v-if="auth.isSuper" class="sidebar-tooltip-wrapper border-b border-gray-200 dark:border-gray-700 px-2 py-2">
       <button
         class="flex w-full items-center gap-2 rounded-lg px-2 py-1.5 text-sm transition-colors"
-        :class="isSuperRoute ? 'bg-indigo-50 text-indigo-700' : 'text-gray-500 hover:bg-gray-100 hover:text-gray-700'"
+        :class="isSuperRoute ? 'bg-indigo-50 text-indigo-700 dark:bg-indigo-900/30 dark:text-indigo-400' : 'text-gray-500 hover:bg-gray-100 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-200'"
         @click="isSuperRoute ? router.push({ name: auth.currentTenantId ? 'dashboard' : 'select-tenant' }) : router.push({ name: 'super-dashboard' })"
       >
         <Shield class="h-4 w-4 shrink-0" />
@@ -221,8 +221,8 @@ async function handleLogout() {
             :class="[
               'flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium transition-colors',
               isActive(item.to)
-                ? 'bg-blue-50 text-blue-700'
-                : 'text-gray-600 hover:bg-gray-100 hover:text-gray-900',
+                ? 'bg-blue-50 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400'
+                : 'text-gray-600 hover:bg-gray-100 hover:text-gray-900 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-white',
             ]"
             @click="layout.closeMobileMenu"
           >
@@ -238,11 +238,11 @@ async function handleLogout() {
     </nav>
 
     <!-- Invitation badge + Logout -->
-    <div class="border-t px-2 py-3">
+    <div class="border-t border-gray-200 dark:border-gray-700 px-2 py-3">
       <div v-if="auth.pendingInvitationCount > 0" class="sidebar-tooltip-wrapper">
         <router-link
           :to="{ name: 'invitations' }"
-          class="mb-1 flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium text-amber-600 transition-colors hover:bg-amber-50"
+          class="mb-1 flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium text-amber-600 transition-colors hover:bg-amber-50 dark:hover:bg-amber-900/20"
           @click="layout.closeMobileMenu"
         >
           <span class="relative">
@@ -257,7 +257,7 @@ async function handleLogout() {
       </div>
       <div class="sidebar-tooltip-wrapper">
         <button
-          class="flex w-full items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium text-gray-600 transition-colors hover:bg-red-50 hover:text-red-600"
+          class="flex w-full items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium text-gray-600 transition-colors hover:bg-red-50 hover:text-red-600 dark:text-gray-400 dark:hover:bg-red-900/20 dark:hover:text-red-400"
           @click="handleLogout"
         >
           <LogOut class="h-5 w-5 shrink-0" />

--- a/web-ui/src/components/AppToast.vue
+++ b/web-ui/src/components/AppToast.vue
@@ -12,10 +12,10 @@ const iconMap = {
 } as const
 
 const styleMap = {
-  success: 'bg-green-50 border-green-200 text-green-800',
-  error: 'bg-red-50 border-red-200 text-red-800',
-  warning: 'bg-amber-50 border-amber-200 text-amber-800',
-  info: 'bg-blue-50 border-blue-200 text-blue-800',
+  success: 'bg-green-50 border-green-200 text-green-800 dark:bg-green-900/20 dark:border-green-800 dark:text-green-300',
+  error: 'bg-red-50 border-red-200 text-red-800 dark:bg-red-900/20 dark:border-red-800 dark:text-red-300',
+  warning: 'bg-amber-50 border-amber-200 text-amber-800 dark:bg-amber-900/20 dark:border-amber-800 dark:text-amber-300',
+  info: 'bg-blue-50 border-blue-200 text-blue-800 dark:bg-blue-900/20 dark:border-blue-800 dark:text-blue-300',
 } as const
 
 const iconStyleMap = {

--- a/web-ui/src/components/AppTopBar.vue
+++ b/web-ui/src/components/AppTopBar.vue
@@ -3,6 +3,7 @@ import { ref, computed, onMounted, onBeforeUnmount } from 'vue'
 import { useRouter } from 'vue-router'
 import { useAuthStore } from '@/stores/auth'
 import { useLayoutStore } from '@/stores/layout'
+import { useTheme } from '@/composables/useTheme'
 import {
   Menu,
   Bell,
@@ -11,14 +12,19 @@ import {
   ChevronDown,
   Clock,
   X,
+  Sun,
+  Moon,
+  Monitor,
 } from 'lucide-vue-next'
 
 const auth = useAuthStore()
 const layout = useLayoutStore()
 const router = useRouter()
+const { theme } = useTheme()
 
 const userDropdownOpen = ref(false)
 const notifDropdownOpen = ref(false)
+const themeDropdownOpen = ref(false)
 
 const pendingInvitations = computed(() =>
   auth.invitations.filter((i) => i.status === 'pending'),
@@ -35,6 +41,7 @@ function closeDropdowns(e: MouseEvent) {
   if (!target.closest('.topbar-dropdown')) {
     userDropdownOpen.value = false
     notifDropdownOpen.value = false
+    themeDropdownOpen.value = false
   }
 }
 
@@ -43,11 +50,11 @@ onBeforeUnmount(() => document.removeEventListener('click', closeDropdowns))
 </script>
 
 <template>
-  <header class="flex h-14 shrink-0 items-center justify-between border-b bg-white px-4">
+  <header class="flex h-14 shrink-0 items-center justify-between border-b border-gray-200 bg-white px-4 dark:border-gray-700 dark:bg-gray-900">
     <div class="flex items-center gap-3">
       <!-- Mobile menu toggle -->
       <button
-        class="rounded p-1.5 text-gray-500 hover:bg-gray-100 lg:hidden"
+        class="rounded p-1.5 text-gray-500 hover:bg-gray-100 dark:hover:bg-gray-800 lg:hidden"
         @click="layout.toggleMobileMenu"
       >
         <Menu class="h-5 w-5" />
@@ -57,10 +64,50 @@ onBeforeUnmount(() => document.removeEventListener('click', closeDropdowns))
     </div>
 
     <div class="flex items-center gap-2">
+      <!-- Theme toggle -->
+      <div class="topbar-dropdown relative">
+        <button
+          class="rounded p-1.5 text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-600 dark:hover:bg-gray-800 dark:hover:text-gray-300"
+          aria-label="Toggle theme"
+          @click.stop="themeDropdownOpen = !themeDropdownOpen"
+        >
+          <Sun v-if="theme === 'light'" class="h-5 w-5" />
+          <Moon v-else-if="theme === 'dark'" class="h-5 w-5" />
+          <Monitor v-else class="h-5 w-5" />
+        </button>
+        <div
+          v-if="themeDropdownOpen"
+          class="absolute right-0 top-full z-50 mt-2 w-36 overflow-hidden rounded-xl border border-gray-200 bg-white shadow-lg dark:border-gray-700 dark:bg-gray-900"
+          @click.stop
+        >
+          <button
+            class="flex w-full items-center gap-2 px-3 py-2 text-sm text-gray-600 hover:bg-gray-50 dark:text-gray-300 dark:hover:bg-gray-800"
+            :class="{ 'bg-gray-50 dark:bg-gray-800': theme === 'light' }"
+            @click="theme = 'light'; themeDropdownOpen = false"
+          >
+            <Sun class="h-4 w-4" /> Light
+          </button>
+          <button
+            class="flex w-full items-center gap-2 px-3 py-2 text-sm text-gray-600 hover:bg-gray-50 dark:text-gray-300 dark:hover:bg-gray-800"
+            :class="{ 'bg-gray-50 dark:bg-gray-800': theme === 'dark' }"
+            @click="theme = 'dark'; themeDropdownOpen = false"
+          >
+            <Moon class="h-4 w-4" /> Dark
+          </button>
+          <button
+            class="flex w-full items-center gap-2 px-3 py-2 text-sm text-gray-600 hover:bg-gray-50 dark:text-gray-300 dark:hover:bg-gray-800"
+            :class="{ 'bg-gray-50 dark:bg-gray-800': theme === 'system' }"
+            @click="theme = 'system'; themeDropdownOpen = false"
+          >
+            <Monitor class="h-4 w-4" /> System
+          </button>
+        </div>
+      </div>
+
       <!-- Notification center -->
       <div class="topbar-dropdown relative">
         <button
-          class="relative rounded p-1.5 text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-600"
+          class="relative rounded p-1.5 text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-600 dark:hover:bg-gray-800 dark:hover:text-gray-300"
           aria-label="Open notifications"
           aria-haspopup="menu"
           :aria-expanded="notifDropdownOpen"
@@ -77,13 +124,13 @@ onBeforeUnmount(() => document.removeEventListener('click', closeDropdowns))
 
         <div
           v-if="notifDropdownOpen"
-          class="absolute right-0 top-full z-50 mt-2 w-80 overflow-hidden rounded-xl border border-gray-200 bg-white shadow-lg"
+          class="absolute right-0 top-full z-50 mt-2 w-80 overflow-hidden rounded-xl border border-gray-200 bg-white shadow-lg dark:border-gray-700 dark:bg-gray-900"
           @click.stop
         >
-          <div class="flex items-center justify-between border-b px-4 py-3">
-            <h3 class="text-sm font-semibold text-gray-900">Notifications</h3>
+          <div class="flex items-center justify-between border-b border-gray-200 dark:border-gray-700 px-4 py-3">
+            <h3 class="text-sm font-semibold text-gray-900 dark:text-white">Notifications</h3>
             <button
-              class="rounded p-1 text-gray-400 hover:bg-gray-100 hover:text-gray-600"
+              class="rounded p-1 text-gray-400 hover:bg-gray-100 hover:text-gray-600 dark:hover:bg-gray-800 dark:hover:text-gray-300"
               aria-label="Close notifications"
               @click="notifDropdownOpen = false"
             >
@@ -96,16 +143,16 @@ onBeforeUnmount(() => document.removeEventListener('click', closeDropdowns))
               <div
                 v-for="inv in pendingInvitations"
                 :key="inv.id"
-                class="flex items-start gap-3 border-b border-gray-50 px-4 py-3 transition-colors hover:bg-gray-50"
+                class="flex items-start gap-3 border-b border-gray-50 dark:border-gray-800 px-4 py-3 transition-colors hover:bg-gray-50 dark:hover:bg-gray-800"
               >
                 <div class="mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-amber-100">
                   <Bell class="h-4 w-4 text-amber-600" />
                 </div>
                 <div class="min-w-0 flex-1">
-                  <p class="text-sm text-gray-700">
+                  <p class="text-sm text-gray-700 dark:text-gray-300">
                     Invited to <span class="font-medium">{{ inv.tenantName }}</span>
                   </p>
-                  <p class="mt-0.5 text-xs text-gray-400">
+                  <p class="mt-0.5 text-xs text-gray-400 dark:text-gray-500">
                     <Clock class="mr-0.5 inline h-3 w-3" />
                     Invited by {{ inv.inviterUsername }}
                   </p>
@@ -113,15 +160,15 @@ onBeforeUnmount(() => document.removeEventListener('click', closeDropdowns))
               </div>
             </template>
             <div v-else class="px-4 py-8 text-center">
-              <Bell class="mx-auto h-8 w-8 text-gray-200" />
-              <p class="mt-2 text-sm text-gray-400">No new notifications</p>
+              <Bell class="mx-auto h-8 w-8 text-gray-200 dark:text-gray-700" />
+              <p class="mt-2 text-sm text-gray-400 dark:text-gray-500">No new notifications</p>
             </div>
           </div>
 
           <router-link
             v-if="pendingInvitations.length > 0"
             :to="{ name: 'invitations' }"
-            class="block border-t px-4 py-2.5 text-center text-sm font-medium text-blue-600 transition-colors hover:bg-gray-50"
+            class="block border-t border-gray-200 dark:border-gray-700 px-4 py-2.5 text-center text-sm font-medium text-blue-600 transition-colors hover:bg-gray-50 dark:hover:bg-gray-800"
             @click="notifDropdownOpen = false"
           >
             View all invitations
@@ -132,7 +179,7 @@ onBeforeUnmount(() => document.removeEventListener('click', closeDropdowns))
       <!-- User avatar dropdown -->
       <div class="topbar-dropdown relative">
         <button
-          class="flex items-center gap-2 rounded-lg px-2 py-1.5 transition-colors hover:bg-gray-100"
+          class="flex items-center gap-2 rounded-lg px-2 py-1.5 transition-colors hover:bg-gray-100 dark:hover:bg-gray-800"
           aria-label="User menu"
           aria-haspopup="menu"
           :aria-expanded="userDropdownOpen"
@@ -143,29 +190,29 @@ onBeforeUnmount(() => document.removeEventListener('click', closeDropdowns))
           >
             {{ auth.username.charAt(0).toUpperCase() }}
           </div>
-          <span class="hidden text-sm font-medium text-gray-700 sm:inline">{{ auth.username }}</span>
+          <span class="hidden text-sm font-medium text-gray-700 dark:text-gray-300 sm:inline">{{ auth.username }}</span>
           <ChevronDown class="hidden h-3.5 w-3.5 text-gray-400 sm:block" :class="{ 'rotate-180': userDropdownOpen }" />
         </button>
 
         <div
           v-if="userDropdownOpen"
-          class="absolute right-0 top-full z-50 mt-2 w-56 overflow-hidden rounded-xl border border-gray-200 bg-white shadow-lg"
+          class="absolute right-0 top-full z-50 mt-2 w-56 overflow-hidden rounded-xl border border-gray-200 bg-white shadow-lg dark:border-gray-700 dark:bg-gray-900"
           @click.stop
         >
-          <div class="border-b px-4 py-3">
-            <p class="text-sm font-medium text-gray-900">{{ auth.username }}</p>
-            <p v-if="auth.currentTenant" class="mt-0.5 text-xs text-gray-400">{{ auth.currentTenant.tenantName }}</p>
+          <div class="border-b border-gray-200 dark:border-gray-700 px-4 py-3">
+            <p class="text-sm font-medium text-gray-900 dark:text-white">{{ auth.username }}</p>
+            <p v-if="auth.currentTenant" class="mt-0.5 text-xs text-gray-400 dark:text-gray-500">{{ auth.currentTenant.tenantName }}</p>
           </div>
           <div class="py-1">
             <button
-              class="flex w-full items-center gap-2.5 px-4 py-2 text-sm text-gray-600 transition-colors hover:bg-gray-50 hover:text-gray-900"
+              class="flex w-full items-center gap-2.5 px-4 py-2 text-sm text-gray-600 transition-colors hover:bg-gray-50 hover:text-gray-900 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-white"
               @click="userDropdownOpen = false; router.push({ name: 'change-password' })"
             >
               <KeyRound class="h-4 w-4 text-gray-400" />
               Change Password
             </button>
             <button
-              class="flex w-full items-center gap-2.5 px-4 py-2 text-sm text-red-600 transition-colors hover:bg-red-50"
+              class="flex w-full items-center gap-2.5 px-4 py-2 text-sm text-red-600 transition-colors hover:bg-red-50 dark:hover:bg-red-900/20"
               @click="handleLogout"
             >
               <LogOut class="h-4 w-4" />

--- a/web-ui/src/components/ConfirmDialog.vue
+++ b/web-ui/src/components/ConfirmDialog.vue
@@ -63,15 +63,15 @@ onBeforeUnmount(() => {
         role="dialog"
         aria-modal="true"
         tabindex="-1"
-        class="mx-4 w-full max-w-sm rounded-lg bg-white p-6 shadow-xl"
+        class="mx-4 w-full max-w-sm rounded-lg bg-white p-6 shadow-xl dark:bg-gray-900"
       >
-        <h3 class="text-lg font-semibold text-gray-900">{{ title }}</h3>
+        <h3 class="text-lg font-semibold text-gray-900 dark:text-white">{{ title }}</h3>
         <slot>
-          <p v-if="message" class="mt-2 text-sm text-gray-600">{{ message }}</p>
+          <p v-if="message" class="mt-2 text-sm text-gray-600 dark:text-gray-400">{{ message }}</p>
         </slot>
         <div class="mt-4 flex justify-end gap-2">
           <button
-            class="rounded-md px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-100"
+            class="rounded-md px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-800"
             @click="emit('cancel')"
           >
             {{ cancelText }}

--- a/web-ui/src/composables/useTheme.ts
+++ b/web-ui/src/composables/useTheme.ts
@@ -1,0 +1,41 @@
+import { ref, watch } from 'vue'
+
+type Theme = 'light' | 'dark' | 'system'
+
+const theme = ref<Theme>(loadTheme())
+const darkMode = ref(false)
+
+function loadTheme(): Theme {
+  return (localStorage.getItem('theme') as Theme) || 'system'
+}
+
+function applyDark(dark: boolean) {
+  darkMode.value = dark
+  document.documentElement.classList.toggle('dark', dark)
+}
+
+function resolveTheme(t: Theme) {
+  if (t === 'system') {
+    return window.matchMedia('(prefers-color-scheme: dark)').matches
+  }
+  return t === 'dark'
+}
+
+function initTheme() {
+  applyDark(resolveTheme(theme.value))
+
+  window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', (e) => {
+    if (theme.value === 'system') {
+      applyDark(e.matches)
+    }
+  })
+}
+
+watch(theme, (val) => {
+  localStorage.setItem('theme', val)
+  applyDark(resolveTheme(val))
+})
+
+export function useTheme() {
+  return { theme, darkMode, initTheme }
+}

--- a/web-ui/src/layouts/DefaultLayout.vue
+++ b/web-ui/src/layouts/DefaultLayout.vue
@@ -5,7 +5,7 @@ import AppBreadcrumb from '@/components/AppBreadcrumb.vue'
 </script>
 
 <template>
-  <div class="flex h-screen overflow-hidden bg-gray-50">
+  <div class="flex h-screen overflow-hidden bg-gray-50 dark:bg-gray-900">
     <AppSidebar />
 
     <div class="flex flex-1 flex-col overflow-hidden">

--- a/web-ui/src/main.ts
+++ b/web-ui/src/main.ts
@@ -2,9 +2,14 @@ import { createApp } from 'vue'
 import { createPinia } from 'pinia'
 import App from './App.vue'
 import router from './router'
+import { useTheme } from './composables/useTheme'
 import './style.css'
 
 const app = createApp(App)
 app.use(createPinia())
 app.use(router)
+
+const { initTheme } = useTheme()
+initTheme()
+
 app.mount('#app')

--- a/web-ui/src/pages/ChangePasswordPage.vue
+++ b/web-ui/src/pages/ChangePasswordPage.vue
@@ -81,25 +81,25 @@ async function handleSubmit() {
 
 <template>
   <div>
-    <h1 class="text-xl font-semibold text-gray-900">Change Password</h1>
-    <p class="mt-1 text-sm text-gray-500">Update your account password.</p>
+    <h1 class="text-xl font-semibold text-gray-900 dark:text-white">Change Password</h1>
+    <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">Update your account password.</p>
 
-    <form class="mt-6 max-w-md rounded-lg border bg-white p-6" @submit.prevent="handleSubmit">
+    <form class="mt-6 max-w-md rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 p-6" @submit.prevent="handleSubmit">
       <div class="space-y-4">
         <div>
-          <label class="mb-1 block text-sm font-medium text-gray-700">Current Password</label>
+          <label class="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300">Current Password</label>
           <div class="relative">
             <input
               v-model="currentPassword"
               :type="showCurrentPassword ? 'text' : 'password'"
               required
-              class="w-full rounded-md border border-gray-300 px-3 py-2 pr-10 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
+              class="w-full rounded-md border border-gray-300 dark:border-gray-600 px-3 py-2 pr-10 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
             />
             <button
               type="button"
               :aria-label="showCurrentPassword ? 'Hide current password' : 'Show current password'"
               :aria-pressed="showCurrentPassword"
-              class="absolute inset-y-0 right-0 flex items-center pr-3 text-gray-400 hover:text-gray-600"
+              class="absolute inset-y-0 right-0 flex items-center pr-3 text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300"
               @click="showCurrentPassword = !showCurrentPassword"
             >
               <Eye v-if="!showCurrentPassword" class="h-4 w-4" />
@@ -108,20 +108,20 @@ async function handleSubmit() {
           </div>
         </div>
         <div>
-          <label class="mb-1 block text-sm font-medium text-gray-700">New Password</label>
+          <label class="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300">New Password</label>
           <div class="relative">
             <input
               v-model="newPassword"
               :type="showNewPassword ? 'text' : 'password'"
               required
               minlength="6"
-              class="w-full rounded-md border border-gray-300 px-3 py-2 pr-10 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
+              class="w-full rounded-md border border-gray-300 dark:border-gray-600 px-3 py-2 pr-10 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
             />
             <button
               type="button"
               :aria-label="showNewPassword ? 'Hide new password' : 'Show new password'"
               :aria-pressed="showNewPassword"
-              class="absolute inset-y-0 right-0 flex items-center pr-3 text-gray-400 hover:text-gray-600"
+              class="absolute inset-y-0 right-0 flex items-center pr-3 text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300"
               @click="showNewPassword = !showNewPassword"
             >
               <Eye v-if="!showNewPassword" class="h-4 w-4" />
@@ -134,30 +134,30 @@ async function handleSubmit() {
                 v-for="i in 5"
                 :key="i"
                 class="h-1.5 flex-1 rounded-full"
-                :class="i <= passwordStrength.score ? passwordStrength.color : 'bg-gray-200'"
+                :class="i <= passwordStrength.score ? passwordStrength.color : 'bg-gray-200 dark:bg-gray-700'"
               />
             </div>
-            <p class="mt-1 text-xs text-gray-500">
+            <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
               Strength: <span class="font-medium">{{ passwordStrength.label }}</span>
             </p>
           </div>
         </div>
         <div>
-          <label class="mb-1 block text-sm font-medium text-gray-700">Confirm New Password</label>
+          <label class="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300">Confirm New Password</label>
           <div class="relative">
             <input
               v-model="confirmPassword"
               :type="showConfirmPassword ? 'text' : 'password'"
               required
               minlength="6"
-              class="w-full rounded-md border border-gray-300 px-3 py-2 pr-10 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
+              class="w-full rounded-md border border-gray-300 dark:border-gray-600 px-3 py-2 pr-10 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
               :class="confirmPassword && newPassword !== confirmPassword ? 'border-red-300' : ''"
             />
             <button
               type="button"
               :aria-label="showConfirmPassword ? 'Hide confirm password' : 'Show confirm password'"
               :aria-pressed="showConfirmPassword"
-              class="absolute inset-y-0 right-0 flex items-center pr-3 text-gray-400 hover:text-gray-600"
+              class="absolute inset-y-0 right-0 flex items-center pr-3 text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300"
               @click="showConfirmPassword = !showConfirmPassword"
             >
               <Eye v-if="!showConfirmPassword" class="h-4 w-4" />

--- a/web-ui/src/pages/DashboardPage.vue
+++ b/web-ui/src/pages/DashboardPage.vue
@@ -446,15 +446,15 @@ onMounted(() => fetchDashboardData())
     <!-- Welcome area -->
     <div class="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
       <div>
-        <h1 class="text-xl font-bold text-gray-900 sm:text-2xl">{{ greeting }}, {{ auth.username }}</h1>
-        <p class="mt-1 text-sm text-gray-500">
+        <h1 class="text-xl font-bold text-gray-900 dark:text-white sm:text-2xl">{{ greeting }}, {{ auth.username }}</h1>
+        <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
           Here's an overview of your short links performance.
         </p>
       </div>
       <div class="flex flex-wrap items-center gap-2">
         <button
           :disabled="loading || refreshing"
-          class="inline-flex items-center gap-2 rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm font-medium text-gray-700 shadow-sm transition-colors hover:bg-gray-50 focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:outline-none disabled:opacity-50 sm:px-4 sm:py-2.5"
+          class="inline-flex items-center gap-2 rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 px-3 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 shadow-sm transition-colors hover:bg-gray-50 dark:hover:bg-gray-700 focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:outline-none disabled:opacity-50 sm:px-4 sm:py-2.5"
           aria-label="Refresh dashboard"
           @click="handleRefresh"
         >
@@ -474,14 +474,14 @@ onMounted(() => fetchDashboardData())
     <!-- Stats cards -->
     <div class="grid grid-cols-2 gap-3 sm:gap-4 lg:grid-cols-4">
       <!-- Total Links -->
-      <div class="rounded-xl border border-gray-200 bg-white p-3 shadow-sm sm:p-5">
+      <div class="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 p-3 shadow-sm sm:p-5">
         <div class="flex items-center justify-between">
           <div>
-            <p class="text-xs font-medium text-gray-500 sm:text-sm">Total Links</p>
-            <p class="mt-1 text-xl font-bold text-gray-900 sm:text-2xl">
+            <p class="text-xs font-medium text-gray-500 dark:text-gray-400 sm:text-sm">Total Links</p>
+            <p class="mt-1 text-xl font-bold text-gray-900 dark:text-white sm:text-2xl">
               <span
                 v-if="loading"
-                class="inline-block h-7 w-16 animate-pulse rounded bg-gray-200"
+                class="inline-block h-7 w-16 animate-pulse rounded bg-gray-200 dark:bg-gray-700"
               />
               <template v-else>{{ totalLinks.toLocaleString() }}</template>
             </p>
@@ -493,14 +493,14 @@ onMounted(() => fetchDashboardData())
       </div>
 
       <!-- Active Links -->
-      <div class="rounded-xl border border-gray-200 bg-white p-3 shadow-sm sm:p-5">
+      <div class="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 p-3 shadow-sm sm:p-5">
         <div class="flex items-center justify-between">
           <div>
-            <p class="text-xs font-medium text-gray-500 sm:text-sm">Active Links</p>
-            <p class="mt-1 text-xl font-bold text-gray-900 sm:text-2xl">
+            <p class="text-xs font-medium text-gray-500 dark:text-gray-400 sm:text-sm">Active Links</p>
+            <p class="mt-1 text-xl font-bold text-gray-900 dark:text-white sm:text-2xl">
               <span
                 v-if="loading"
-                class="inline-block h-7 w-16 animate-pulse rounded bg-gray-200"
+                class="inline-block h-7 w-16 animate-pulse rounded bg-gray-200 dark:bg-gray-700"
               />
               <template v-else>{{ activeLinks.toLocaleString() }}</template>
             </p>

--- a/web-ui/src/pages/InvitationsPage.vue
+++ b/web-ui/src/pages/InvitationsPage.vue
@@ -58,15 +58,15 @@ async function handleReject(id: string) {
 <template>
   <div>
     <div class="mb-6 flex items-center gap-3">
-      <button class="rounded p-1 text-gray-400 hover:text-gray-600" @click="router.push({ name: 'dashboard' })">
+      <button class="rounded p-1 text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300" @click="router.push({ name: 'dashboard' })">
         <ArrowLeft class="h-5 w-5" />
       </button>
-      <h1 class="text-xl font-semibold text-gray-900">Invitations</h1>
+      <h1 class="text-xl font-semibold text-gray-900 dark:text-white">Invitations</h1>
     </div>
 
-    <div v-if="loading" class="py-12 text-center text-gray-400">Loading...</div>
+    <div v-if="loading" class="py-12 text-center text-gray-400 dark:text-gray-500">Loading...</div>
 
-    <div v-else-if="invitations.length === 0" class="py-12 text-center text-gray-400">
+    <div v-else-if="invitations.length === 0" class="py-12 text-center text-gray-400 dark:text-gray-500">
       No pending invitations.
     </div>
 
@@ -74,11 +74,11 @@ async function handleReject(id: string) {
       <div
         v-for="inv in invitations"
         :key="inv.id"
-        class="flex items-center justify-between rounded-lg border bg-white p-4 shadow-sm"
+        class="flex items-center justify-between rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 p-4 shadow-sm"
       >
         <div>
-          <div class="font-medium text-gray-900">{{ inv.tenantName }}</div>
-          <div class="text-sm text-gray-500">
+          <div class="font-medium text-gray-900 dark:text-white">{{ inv.tenantName }}</div>
+          <div class="text-sm text-gray-500 dark:text-gray-400">
             Invited by {{ inv.inviterUsername }} &middot; {{ formatTime(inv.createdAt) }}
           </div>
         </div>
@@ -94,7 +94,7 @@ async function handleReject(id: string) {
             </button>
             <button
               :disabled="actionLoading[inv.id]"
-              class="flex items-center gap-1 rounded-md border px-3 py-1.5 text-sm font-medium text-gray-600 hover:bg-gray-50 disabled:opacity-50"
+              class="flex items-center gap-1 rounded-md border border-gray-200 dark:border-gray-700 px-3 py-1.5 text-sm font-medium text-gray-600 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 disabled:opacity-50"
               @click="handleReject(inv.id)"
             >
               <X class="h-4 w-4" />
@@ -104,7 +104,7 @@ async function handleReject(id: string) {
           <span
             v-else
             class="rounded-full px-2.5 py-0.5 text-xs font-medium"
-            :class="inv.status === 'accepted' ? 'bg-green-50 text-green-700' : 'bg-gray-100 text-gray-500'"
+            :class="inv.status === 'accepted' ? 'bg-green-50 text-green-700' : 'bg-gray-100 dark:bg-gray-800 text-gray-500 dark:text-gray-400'"
           >
             {{ inv.status === 'accepted' ? 'Accepted' : 'Rejected' }}
           </span>

--- a/web-ui/src/pages/LoginPage.vue
+++ b/web-ui/src/pages/LoginPage.vue
@@ -36,40 +36,40 @@ async function handleLogin() {
 </script>
 
 <template>
-  <div class="flex min-h-screen items-center justify-center bg-gray-50">
+  <div class="flex min-h-screen items-center justify-center bg-gray-50 dark:bg-gray-800/50">
     <div class="w-full max-w-sm">
       <div class="mb-8 text-center">
         <div class="mx-auto mb-3 flex h-12 w-12 items-center justify-center rounded-xl bg-blue-600">
           <Link2 class="h-7 w-7 text-white" />
         </div>
-        <h1 class="text-2xl font-bold text-gray-900">Jump Jump</h1>
-        <p class="mt-1 text-sm text-gray-500">Short URL Management Platform</p>
+        <h1 class="text-2xl font-bold text-gray-900 dark:text-white">Jump Jump</h1>
+        <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">Short URL Management Platform</p>
       </div>
-      <form class="rounded-lg border bg-white p-6 shadow-sm" @submit.prevent="handleLogin">
+      <form class="rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 p-6 shadow-sm" @submit.prevent="handleLogin">
         <div class="mb-4">
-          <label class="mb-1 block text-sm font-medium text-gray-700">Username</label>
+          <label class="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300">Username</label>
           <input
             v-model="username"
             type="text"
             required
             autofocus
-            class="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
+            class="w-full rounded-md border border-gray-300 dark:border-gray-600 px-3 py-2 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
           />
         </div>
         <div class="mb-4">
-          <label class="mb-1 block text-sm font-medium text-gray-700">Password</label>
+          <label class="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300">Password</label>
           <div class="relative">
             <input
               v-model="password"
               :type="showPassword ? 'text' : 'password'"
               required
-              class="w-full rounded-md border border-gray-300 px-3 py-2 pr-10 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
+              class="w-full rounded-md border border-gray-300 dark:border-gray-600 px-3 py-2 pr-10 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
             />
             <button
               type="button"
               :aria-label="showPassword ? 'Hide password' : 'Show password'"
               :aria-pressed="showPassword"
-              class="absolute inset-y-0 right-0 flex items-center pr-3 text-gray-400 hover:text-gray-600"
+              class="absolute inset-y-0 right-0 flex items-center pr-3 text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300"
               @click="togglePassword"
             >
               <Eye v-if="!showPassword" class="h-4 w-4" />
@@ -84,7 +84,7 @@ async function handleLogin() {
             type="checkbox"
             class="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
           />
-          <label for="remember-me" class="ml-2 text-sm text-gray-600">Remember me</label>
+          <label for="remember-me" class="ml-2 text-sm text-gray-600 dark:text-gray-300">Remember me</label>
         </div>
         <p v-if="error" class="mb-4 text-sm text-red-600">{{ error }}</p>
         <button

--- a/web-ui/src/pages/MembersPage.vue
+++ b/web-ui/src/pages/MembersPage.vue
@@ -199,21 +199,21 @@ onMounted(fetchMembers)
     <!-- Header -->
     <div class="mb-6 flex items-center justify-between">
       <div class="flex items-center gap-2">
-        <Users class="h-5 w-5 text-gray-500" />
-        <h1 class="text-xl font-semibold text-gray-900">Members</h1>
-        <span v-if="!loading" class="rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-600">
+        <Users class="h-5 w-5 text-gray-500 dark:text-gray-400 dark:text-gray-500" />
+        <h1 class="text-xl font-semibold text-gray-900 dark:text-white">Members</h1>
+        <span v-if="!loading" class="rounded-full bg-gray-100 dark:bg-gray-800 px-2 py-0.5 text-xs font-medium text-gray-600 dark:text-gray-400 dark:text-gray-500">
           {{ members.length }}
         </span>
       </div>
       <div class="flex items-center gap-2">
         <!-- Search -->
         <div class="relative">
-          <Search class="absolute left-2.5 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400" />
+          <Search class="absolute left-2.5 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400 dark:text-gray-500" />
           <input
             v-model="searchQuery"
             type="text"
             placeholder="Search members..."
-            class="w-48 rounded-md border border-gray-300 py-2 pl-8 pr-3 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
+            class="w-48 rounded-md border border-gray-300 dark:border-gray-600 py-2 pl-8 pr-3 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
           />
         </div>
         <button
@@ -229,14 +229,14 @@ onMounted(fetchMembers)
 
     <!-- Loading -->
     <div v-if="loading" class="flex items-center justify-center py-20">
-      <Loader2 class="h-6 w-6 animate-spin text-gray-400" />
+      <Loader2 class="h-6 w-6 animate-spin text-gray-400 dark:text-gray-500" />
     </div>
 
     <!-- Members table -->
-    <div v-else class="overflow-hidden rounded-lg border bg-white">
+    <div v-else class="overflow-hidden rounded-lg border bg-white dark:bg-gray-900 dark:bg-gray-900">
       <table class="w-full text-sm">
         <thead>
-          <tr class="border-b bg-gray-50 text-left text-xs font-medium uppercase tracking-wider text-gray-500">
+          <tr class="border-b bg-gray-50 dark:bg-gray-800/50 text-left text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400 dark:text-gray-500">
             <th class="px-4 py-3">User</th>
             <th class="px-4 py-3">Role</th>
             <th class="hidden px-4 py-3 sm:table-cell">Joined</th>
@@ -244,45 +244,45 @@ onMounted(fetchMembers)
           </tr>
         </thead>
         <tbody class="divide-y">
-          <tr v-for="m in filteredMembers" :key="m.userId" class="transition-colors hover:bg-gray-50">
+          <tr v-for="m in filteredMembers" :key="m.userId" class="transition-colors hover:bg-gray-50 dark:hover:bg-gray-700 dark:bg-gray-800/50">
             <td class="px-4 py-3">
               <div class="flex items-center gap-3">
                 <div
                   class="flex h-8 w-8 shrink-0 items-center justify-center rounded-full text-xs font-bold"
-                  :class="m.role === UserRole.Admin ? 'bg-blue-100 text-blue-700' : 'bg-gray-100 text-gray-600'"
+                  :class="m.role === UserRole.Admin ? 'bg-blue-100 text-blue-700' : 'bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-400 dark:text-gray-500'"
                 >
                   {{ m.username.charAt(0).toUpperCase() }}
                 </div>
                 <div>
-                  <span class="font-medium text-gray-900">{{ m.username }}</span>
-                  <span v-if="m.userId === auth.authUser?.id" class="ml-1 text-xs text-gray-400">(you)</span>
+                  <span class="font-medium text-gray-900 dark:text-white">{{ m.username }}</span>
+                  <span v-if="m.userId === auth.authUser?.id" class="ml-1 text-xs text-gray-400 dark:text-gray-500">(you)</span>
                 </div>
               </div>
             </td>
             <td class="px-4 py-3">
               <span
                 class="inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium"
-                :class="m.role === UserRole.Admin ? 'bg-blue-50 text-blue-700' : 'bg-gray-100 text-gray-600'"
+                :class="m.role === UserRole.Admin ? 'bg-blue-50 text-blue-700' : 'bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-400 dark:text-gray-500'"
               >
                 <Shield v-if="m.role === UserRole.Admin" class="h-3 w-3" />
                 <User v-else class="h-3 w-3" />
                 {{ m.role }}
               </span>
             </td>
-            <td class="hidden whitespace-nowrap px-4 py-3 text-gray-500 sm:table-cell">
+            <td class="hidden whitespace-nowrap px-4 py-3 text-gray-500 dark:text-gray-400 dark:text-gray-500 sm:table-cell">
               {{ formatDate(m.joinedAt) }}
             </td>
             <td v-if="auth.isAdmin" class="px-4 py-3">
               <div v-if="m.userId !== auth.authUser?.id" class="flex items-center justify-end gap-1">
                 <button
-                  class="rounded p-1.5 text-gray-400 transition-colors hover:bg-blue-50 hover:text-blue-600"
+                  class="rounded p-1.5 text-gray-400 dark:text-gray-500 transition-colors hover:bg-blue-50 hover:text-blue-600"
                   title="Change role"
                   @click="requestRoleChange(m)"
                 >
                   <ArrowLeftRight class="h-4 w-4" />
                 </button>
                 <button
-                  class="rounded p-1.5 text-gray-400 transition-colors hover:bg-red-50 hover:text-red-600"
+                  class="rounded p-1.5 text-gray-400 dark:text-gray-500 transition-colors hover:bg-red-50 hover:text-red-600"
                   title="Remove member"
                   @click="requestRemoveMember(m)"
                 >
@@ -294,13 +294,13 @@ onMounted(fetchMembers)
         </tbody>
       </table>
 
-      <div v-if="filteredMembers.length === 0 && members.length > 0" class="py-12 text-center text-sm text-gray-400">
+      <div v-if="filteredMembers.length === 0 && members.length > 0" class="py-12 text-center text-sm text-gray-400 dark:text-gray-500">
         No members match "{{ searchQuery }}".
       </div>
       <div v-else-if="members.length === 0" class="py-12 text-center">
-        <Users class="mx-auto h-10 w-10 text-gray-300" />
-        <p class="mt-3 text-sm font-medium text-gray-500">No members yet</p>
-        <p class="mt-1 text-sm text-gray-400">Invite a member to start collaborating.</p>
+        <Users class="mx-auto h-10 w-10 text-gray-300 dark:text-gray-600" />
+        <p class="mt-3 text-sm font-medium text-gray-500 dark:text-gray-400 dark:text-gray-500">No members yet</p>
+        <p class="mt-1 text-sm text-gray-400 dark:text-gray-500">Invite a member to start collaborating.</p>
         <button
           v-if="auth.isAdmin"
           class="mt-3 inline-flex items-center gap-1.5 rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-blue-700"
@@ -315,7 +315,7 @@ onMounted(fetchMembers)
     <!-- Leave tenant (subtle placement) -->
     <div v-if="!loading" class="mt-6 text-right">
       <button
-        class="text-sm text-gray-400 transition-colors hover:text-gray-600"
+        class="text-sm text-gray-400 dark:text-gray-500 transition-colors hover:text-gray-600 dark:text-gray-400 dark:text-gray-500 dark:hover:text-gray-300 dark:text-gray-600"
         @click="requestLeaveTenant"
       >
         Leave this tenant
@@ -329,26 +329,26 @@ onMounted(fetchMembers)
         class="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
         @click.self="showInvite = false"
       >
-        <div class="mx-4 w-full max-w-sm rounded-lg bg-white p-6 shadow-xl">
+        <div class="mx-4 w-full max-w-sm rounded-lg bg-white dark:bg-gray-900 p-6 shadow-xl">
           <div class="mb-4 flex items-center justify-between">
-            <h3 class="text-lg font-semibold text-gray-900">Invite Member</h3>
-            <button class="rounded p-1 text-gray-400 hover:text-gray-600" @click="showInvite = false">
+            <h3 class="text-lg font-semibold text-gray-900 dark:text-white">Invite Member</h3>
+            <button class="rounded p-1 text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:text-gray-400 dark:text-gray-500 dark:hover:text-gray-300 dark:text-gray-600" @click="showInvite = false">
               <X class="h-4 w-4" />
             </button>
           </div>
 
           <form @submit.prevent="handleInvite">
             <div class="mb-3">
-              <label for="invite-username-input" class="mb-1 block text-sm font-medium text-gray-700">Username</label>
+              <label for="invite-username-input" class="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300 dark:text-gray-600">Username</label>
               <input
                 id="invite-username-input"
                 v-model="inviteUsername"
                 type="text"
                 required
                 placeholder="Enter username to invite"
-                class="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
+                class="w-full rounded-md border border-gray-300 dark:border-gray-600 px-3 py-2 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
               />
-              <p class="mt-1 text-xs text-gray-400">The user will receive an invitation to join this tenant.</p>
+              <p class="mt-1 text-xs text-gray-400 dark:text-gray-500">The user will receive an invitation to join this tenant.</p>
             </div>
 
             <p v-if="inviteError" class="mb-3 text-sm text-red-600">{{ inviteError }}</p>
@@ -356,7 +356,7 @@ onMounted(fetchMembers)
             <div class="flex justify-end gap-2">
               <button
                 type="button"
-                class="rounded-md border px-3 py-1.5 text-sm text-gray-600 hover:bg-gray-50"
+                class="rounded-md border px-3 py-1.5 text-sm text-gray-600 dark:text-gray-400 dark:text-gray-500 hover:bg-gray-50 dark:hover:bg-gray-700 dark:bg-gray-800/50"
                 @click="showInvite = false"
               >
                 Cancel
@@ -383,22 +383,22 @@ onMounted(fetchMembers)
       @confirm="executeRoleChange"
       @cancel="confirmRoleChange = null"
     >
-      <p class="mt-2 text-sm text-gray-600">
-        Change <span class="font-medium text-gray-900">{{ confirmRoleChange?.username }}</span>'s role from
+      <p class="mt-2 text-sm text-gray-600 dark:text-gray-400 dark:text-gray-500">
+        Change <span class="font-medium text-gray-900 dark:text-white">{{ confirmRoleChange?.username }}</span>'s role from
         <span class="font-mono font-medium">{{ confirmRoleChange?.currentRole }}</span> to
         <span class="font-mono font-medium">{{ confirmRoleChange?.newRole }}</span>?
       </p>
-      <div class="mt-3 rounded-lg border bg-gray-50 p-3 text-xs text-gray-600">
-        <p class="font-medium text-gray-700">
+      <div class="mt-3 rounded-lg border bg-gray-50 dark:bg-gray-800/50 p-3 text-xs text-gray-600 dark:text-gray-400 dark:text-gray-500">
+        <p class="font-medium text-gray-700 dark:text-gray-300 dark:text-gray-600">
           {{ confirmRoleChange?.newRole === UserRole.Admin ? 'Admin' : 'Member' }} permissions:
         </p>
-        <ul v-if="confirmRoleChange?.newRole === UserRole.Admin" class="mt-1 list-inside list-disc space-y-0.5 text-gray-500">
+        <ul v-if="confirmRoleChange?.newRole === UserRole.Admin" class="mt-1 list-inside list-disc space-y-0.5 text-gray-500 dark:text-gray-400 dark:text-gray-500">
           <li>Manage tenant settings and domains</li>
           <li>Invite and remove members</li>
           <li>Change member roles</li>
           <li>Create, edit, and delete short links</li>
         </ul>
-        <ul v-else class="mt-1 list-inside list-disc space-y-0.5 text-gray-500">
+        <ul v-else class="mt-1 list-inside list-disc space-y-0.5 text-gray-500 dark:text-gray-400 dark:text-gray-500">
           <li>Create, edit, and delete short links</li>
           <li>View member list</li>
         </ul>
@@ -416,9 +416,9 @@ onMounted(fetchMembers)
       @confirm="executeRemoveMember"
       @cancel="confirmRemove = null"
     >
-      <p class="mt-2 text-sm text-gray-600">
+      <p class="mt-2 text-sm text-gray-600 dark:text-gray-400 dark:text-gray-500">
         Are you sure you want to remove
-        <span class="font-medium text-gray-900">{{ confirmRemove?.username }}</span> from this tenant?
+        <span class="font-medium text-gray-900 dark:text-white">{{ confirmRemove?.username }}</span> from this tenant?
         This action cannot be undone.
       </p>
       <p v-if="removeError" class="mt-2 text-sm text-red-600">{{ removeError }}</p>
@@ -434,8 +434,8 @@ onMounted(fetchMembers)
       @confirm="executeLeaveTenant"
       @cancel="confirmLeave = false"
     >
-      <p class="mt-2 text-sm text-gray-600">
-        Are you sure you want to leave <span class="font-medium text-gray-900">{{ auth.currentTenant?.tenantName }}</span>?
+      <p class="mt-2 text-sm text-gray-600 dark:text-gray-400 dark:text-gray-500">
+        Are you sure you want to leave <span class="font-medium text-gray-900 dark:text-white">{{ auth.currentTenant?.tenantName }}</span>?
         You will need to be re-invited to join again.
       </p>
       <p v-if="leaveError" class="mt-2 text-sm text-red-600">{{ leaveError }}</p>

--- a/web-ui/src/pages/NotFoundPage.vue
+++ b/web-ui/src/pages/NotFoundPage.vue
@@ -7,9 +7,9 @@ const router = useRouter()
 
 <template>
   <div class="flex min-h-[60vh] flex-col items-center justify-center text-center">
-    <h1 class="text-7xl font-bold text-gray-200">404</h1>
-    <p class="mt-4 text-lg text-gray-500">Page not found</p>
-    <p class="mt-1 text-sm text-gray-400">
+    <h1 class="text-7xl font-bold text-gray-200 dark:text-gray-700">404</h1>
+    <p class="mt-4 text-lg text-gray-500 dark:text-gray-400">Page not found</p>
+    <p class="mt-1 text-sm text-gray-400 dark:text-gray-500">
       The page you are looking for does not exist or has been moved.
     </p>
     <button

--- a/web-ui/src/pages/PreferencesPage.vue
+++ b/web-ui/src/pages/PreferencesPage.vue
@@ -4,10 +4,10 @@ defineOptions({ name: 'PreferencesPage' })
 
 <template>
   <div>
-    <h1 class="text-xl font-semibold text-gray-900">User Preferences</h1>
-    <p class="mt-1 text-sm text-gray-500">Manage your account preferences.</p>
-    <div class="mt-6 rounded-lg border bg-white p-6">
-      <p class="text-sm text-gray-400">Preferences settings will be available here.</p>
+    <h1 class="text-xl font-semibold text-gray-900 dark:text-white">User Preferences</h1>
+    <p class="mt-1 text-sm text-gray-500 dark:text-gray-400 dark:text-gray-500">Manage your account preferences.</p>
+    <div class="mt-6 rounded-lg border bg-white dark:bg-gray-900 p-6">
+      <p class="text-sm text-gray-400 dark:text-gray-500">Preferences settings will be available here.</p>
     </div>
   </div>
 </template>

--- a/web-ui/src/pages/SelectTenantPage.vue
+++ b/web-ui/src/pages/SelectTenantPage.vue
@@ -92,17 +92,17 @@ async function handleLogout() {
 </script>
 
 <template>
-  <div class="flex min-h-screen items-center justify-center bg-gray-50">
+  <div class="flex min-h-screen items-center justify-center bg-gray-50 dark:bg-gray-800/50">
     <div class="w-full max-w-md">
       <template v-if="loading">
         <div class="flex flex-col items-center gap-3">
           <Loader2 class="h-8 w-8 animate-spin text-blue-600" />
-          <p class="text-sm text-gray-500">Loading...</p>
+          <p class="text-sm text-gray-500 dark:text-gray-400">Loading...</p>
         </div>
       </template>
       <template v-else>
-        <h1 class="mb-2 text-center text-2xl font-bold">Select Tenant</h1>
-        <p class="mb-6 text-center text-sm text-gray-500">
+        <h1 class="mb-2 text-center text-2xl font-bold dark:text-white">Select Tenant</h1>
+        <p class="mb-6 text-center text-sm text-gray-500 dark:text-gray-400">
           Welcome, {{ auth.authUser?.username }}. Choose a tenant to continue.
         </p>
 
@@ -110,7 +110,7 @@ async function handleLogout() {
           <button
             v-for="tenant in auth.tenants"
             :key="tenant.tenantId"
-            class="flex w-full items-center justify-between rounded-lg border bg-white p-4 text-left shadow-sm transition hover:border-blue-300 hover:shadow"
+            class="flex w-full items-center justify-between rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 p-4 text-left shadow-sm transition hover:border-blue-300 hover:shadow"
             @click="selectTenant(tenant.tenantId)"
           >
             <div class="flex items-center gap-3">
@@ -118,16 +118,16 @@ async function handleLogout() {
                 <Building2 class="h-5 w-5 text-blue-600" />
               </div>
               <div>
-                <div class="font-medium text-gray-900">{{ tenant.tenantName }}</div>
+                <div class="font-medium text-gray-900 dark:text-white">{{ tenant.tenantName }}</div>
                 <span
                   class="inline-block rounded-full px-2 py-0.5 text-xs font-medium"
-                  :class="tenant.role === 'admin' ? 'bg-red-50 text-red-700' : 'bg-gray-100 text-gray-600'"
+                  :class="tenant.role === 'admin' ? 'bg-red-50 text-red-700' : 'bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-300'"
                 >
                   {{ tenant.role }}
                 </span>
               </div>
             </div>
-            <ArrowRight class="h-4 w-4 text-gray-400" />
+            <ArrowRight class="h-4 w-4 text-gray-400 dark:text-gray-500" />
           </button>
         </div>
 
@@ -144,7 +144,7 @@ async function handleLogout() {
         </button>
 
         <button
-          class="mt-4 flex w-full items-center justify-center gap-2 rounded-lg border border-dashed border-gray-300 bg-white p-3 text-sm font-medium text-gray-600 transition hover:border-gray-400 hover:text-gray-800"
+          class="mt-4 flex w-full items-center justify-center gap-2 rounded-lg border border-dashed border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 p-3 text-sm font-medium text-gray-600 dark:text-gray-300 transition hover:border-gray-400 hover:text-gray-800 dark:hover:text-white"
           @click="openCreateDialog"
         >
           <Plus class="h-4 w-4" />
@@ -152,7 +152,7 @@ async function handleLogout() {
         </button>
 
         <div class="mt-6 text-center">
-          <button class="text-sm text-gray-400 hover:text-gray-600" @click="handleLogout">
+          <button class="text-sm text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300" @click="handleLogout">
             Sign out
           </button>
         </div>
@@ -163,36 +163,36 @@ async function handleLogout() {
           class="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
           @click.self="showCreateDialog = false"
         >
-          <div class="w-full max-w-sm rounded-lg border bg-white p-6 shadow-lg">
-            <h2 class="mb-4 text-lg font-semibold">Create Tenant</h2>
+          <div class="w-full max-w-sm rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 p-6 shadow-lg">
+            <h2 class="mb-4 text-lg font-semibold dark:text-white">Create Tenant</h2>
             <form @submit.prevent="handleCreateTenant">
               <div class="mb-3">
-                <label class="mb-1 block text-sm font-medium text-gray-700">Name</label>
+                <label class="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300">Name</label>
                 <input
                   v-model="createForm.name"
                   type="text"
                   required
                   autofocus
-                  class="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
+                  class="w-full rounded-md border border-gray-300 dark:border-gray-600 px-3 py-2 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
                 />
               </div>
               <div class="mb-3">
-                <label class="mb-1 block text-sm font-medium text-gray-700">Slug</label>
+                <label class="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300">Slug</label>
                 <input
                   v-model="createForm.slug"
                   type="text"
                   required
                   pattern="[a-z0-9-]+"
-                  class="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
+                  class="w-full rounded-md border border-gray-300 dark:border-gray-600 px-3 py-2 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
                   @input="slugManuallyEdited = true"
                 />
-                <p class="mt-1 text-xs text-gray-400">Auto-generated from name. Edit to customize.</p>
+                <p class="mt-1 text-xs text-gray-400 dark:text-gray-500">Auto-generated from name. Edit to customize.</p>
               </div>
               <p v-if="createError" class="mb-3 text-sm text-red-600">{{ createError }}</p>
               <div class="flex justify-end gap-2">
                 <button
                   type="button"
-                  class="rounded-md border px-3 py-1.5 text-sm text-gray-600 hover:bg-gray-50"
+                  class="rounded-md border border-gray-200 dark:border-gray-700 px-3 py-1.5 text-sm text-gray-600 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700"
                   @click="showCreateDialog = false"
                 >
                   Cancel

--- a/web-ui/src/pages/SettingsPage.vue
+++ b/web-ui/src/pages/SettingsPage.vue
@@ -324,16 +324,16 @@ onMounted(fetchAll)
   <div class="space-y-4 sm:space-y-6">
     <!-- Header -->
     <div>
-      <h1 class="flex items-center gap-2 text-xl font-semibold text-gray-900">
-        <Settings class="h-5 w-5 text-gray-500" />
+      <h1 class="flex items-center gap-2 text-xl font-semibold text-gray-900 dark:text-white">
+        <Settings class="h-5 w-5 text-gray-500 dark:text-gray-400 dark:text-gray-500" />
         Settings
       </h1>
-      <p class="mt-1 text-sm text-gray-500">Manage tenant settings, domains, and system configuration.</p>
+      <p class="mt-1 text-sm text-gray-500 dark:text-gray-400 dark:text-gray-500">Manage tenant settings, domains, and system configuration.</p>
     </div>
 
     <!-- Loading -->
     <div v-if="loading" class="flex items-center justify-center py-20">
-      <Loader2 class="h-6 w-6 animate-spin text-gray-400" />
+      <Loader2 class="h-6 w-6 animate-spin text-gray-400 dark:text-gray-500" />
     </div>
 
     <div v-else-if="pageError" class="rounded-lg border border-red-200 bg-red-50 p-4">
@@ -342,30 +342,30 @@ onMounted(fetchAll)
 
     <template v-else>
       <!-- Tenant Basic Info (admin only) -->
-      <div v-if="isAdmin && tenant" class="rounded-xl border border-gray-200 bg-white shadow-sm">
-        <div class="flex items-center gap-2 border-b border-gray-100 px-4 py-3 sm:px-5 sm:py-4">
+      <div v-if="isAdmin && tenant" class="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 shadow-sm">
+        <div class="flex items-center gap-2 border-b border-gray-100 dark:border-gray-800 px-4 py-3 sm:px-5 sm:py-4">
           <Building2 class="h-4 w-4 text-blue-600" />
-          <h2 class="text-base font-semibold text-gray-900">Tenant Information</h2>
+          <h2 class="text-base font-semibold text-gray-900 dark:text-white">Tenant Information</h2>
         </div>
         <div class="p-4 sm:p-5">
           <div class="space-y-4">
             <div>
-              <label class="mb-1 block text-sm font-medium text-gray-700">Name</label>
+              <label class="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300 dark:text-gray-600">Name</label>
               <input
                 v-model="editName"
                 type="text"
-                class="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
+                class="w-full rounded-md border border-gray-300 dark:border-gray-600 px-3 py-2 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
               />
             </div>
             <div>
-              <label class="mb-1 block text-sm font-medium text-gray-700">Slug</label>
+              <label class="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300 dark:text-gray-600">Slug</label>
               <input
                 v-model="editSlug"
                 type="text"
                 pattern="[a-z0-9-]+"
-                class="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
+                class="w-full rounded-md border border-gray-300 dark:border-gray-600 px-3 py-2 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
               />
-              <p class="mt-1 text-xs text-gray-400">Lowercase letters, numbers, and hyphens</p>
+              <p class="mt-1 text-xs text-gray-400 dark:text-gray-500">Lowercase letters, numbers, and hyphens</p>
             </div>
             <p v-if="tenantError" class="text-xs text-red-600">{{ tenantError }}</p>
           </div>
@@ -384,31 +384,31 @@ onMounted(fetchAll)
       </div>
 
       <!-- Domain Management (admin only) -->
-      <div v-if="isAdmin" class="rounded-xl border border-gray-200 bg-white shadow-sm">
-        <div class="flex items-center gap-2 border-b border-gray-100 px-4 py-3 sm:px-5 sm:py-4">
+      <div v-if="isAdmin" class="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 shadow-sm">
+        <div class="flex items-center gap-2 border-b border-gray-100 dark:border-gray-800 px-4 py-3 sm:px-5 sm:py-4">
           <Globe class="h-4 w-4 text-green-600" />
-          <h2 class="text-base font-semibold text-gray-900">Domains</h2>
-          <span class="rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-600">
+          <h2 class="text-base font-semibold text-gray-900 dark:text-white">Domains</h2>
+          <span class="rounded-full bg-gray-100 dark:bg-gray-800 px-2 py-0.5 text-xs font-medium text-gray-600 dark:text-gray-400 dark:text-gray-500">
             {{ domains.length }}
           </span>
         </div>
         <div class="p-4 sm:p-5">
           <!-- Add domain form -->
-          <div class="rounded-lg border bg-gray-50 p-4">
+          <div class="rounded-lg border bg-gray-50 dark:bg-gray-800/50 p-4">
             <div class="flex flex-col gap-3 sm:flex-row sm:items-end">
               <div class="flex-1">
-                <label class="mb-1 block text-sm font-medium text-gray-700">Domain</label>
+                <label class="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300 dark:text-gray-600">Domain</label>
                 <input
                   v-model="newDomain"
                   type="text"
                   placeholder="example.com"
-                  class="w-full rounded-md border border-gray-300 px-3 py-2 font-mono text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
+                  class="w-full rounded-md border border-gray-300 dark:border-gray-600 px-3 py-2 font-mono text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
                   @keydown.enter.prevent="handleAddDomain"
                 />
               </div>
               <div class="flex items-center gap-3">
-                <label class="flex items-center gap-2 text-sm text-gray-700">
-                  <input v-model="newDomainIsDefault" type="checkbox" class="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500" />
+                <label class="flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300 dark:text-gray-600">
+                  <input v-model="newDomainIsDefault" type="checkbox" class="h-4 w-4 rounded border-gray-300 dark:border-gray-600 text-blue-600 focus:ring-blue-500" />
                   Default
                 </label>
                 <button
@@ -426,7 +426,7 @@ onMounted(fetchAll)
 
           <!-- Domain list -->
           <div v-if="domainsLoading" class="mt-4 flex items-center justify-center py-8">
-            <Loader2 class="h-5 w-5 animate-spin text-gray-400" />
+            <Loader2 class="h-5 w-5 animate-spin text-gray-400 dark:text-gray-500" />
           </div>
           <div v-else-if="domains.length > 0" class="mt-4 overflow-hidden rounded-lg border">
             <!-- Mobile cards -->
@@ -438,15 +438,15 @@ onMounted(fetchAll)
               >
                 <div class="min-w-0 flex-1">
                   <div class="flex items-center gap-2">
-                    <Globe class="h-4 w-4 text-gray-400" />
-                    <span class="font-mono text-sm text-gray-900">{{ d.domain }}</span>
+                    <Globe class="h-4 w-4 text-gray-400 dark:text-gray-500" />
+                    <span class="font-mono text-sm text-gray-900 dark:text-white">{{ d.domain }}</span>
                   </div>
                   <div class="mt-1 flex items-center gap-2 pl-6">
                     <span v-if="d.isDefault" class="inline-flex items-center gap-1 text-xs font-medium text-yellow-600">
                       <Star class="h-3 w-3 fill-yellow-500 text-yellow-500" />
                       Default
                     </span>
-                    <span class="text-xs text-gray-400">{{ formatDate(d.createdAt) }}</span>
+                    <span class="text-xs text-gray-400 dark:text-gray-500">{{ formatDate(d.createdAt) }}</span>
                   </div>
                 </div>
                 <div class="flex items-center gap-1">
@@ -454,14 +454,14 @@ onMounted(fetchAll)
                     :href="'https://' + d.domain"
                     target="_blank"
                     rel="noopener noreferrer"
-                    class="rounded p-1.5 text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-600"
+                    class="rounded p-1.5 text-gray-400 dark:text-gray-500 transition-colors hover:bg-gray-100 dark:hover:bg-gray-800 dark:bg-gray-800 hover:text-gray-600 dark:text-gray-400 dark:text-gray-500 dark:hover:text-gray-300 dark:text-gray-600"
                     title="Open domain"
                     aria-label="Open domain"
                   >
                     <ExternalLink class="h-4 w-4" />
                   </a>
                   <button
-                    class="rounded p-1.5 text-gray-400 transition-colors hover:bg-red-50 hover:text-red-600"
+                    class="rounded p-1.5 text-gray-400 dark:text-gray-500 transition-colors hover:bg-red-50 hover:text-red-600"
                     title="Delete domain"
                     aria-label="Delete domain"
                     @click="confirmDeleteDomain = d.domain"
@@ -474,7 +474,7 @@ onMounted(fetchAll)
             <!-- Desktop table -->
             <table class="hidden w-full text-sm lg:table">
               <thead>
-                <tr class="border-b bg-gray-50 text-left text-xs font-medium uppercase tracking-wider text-gray-500">
+                <tr class="border-b bg-gray-50 dark:bg-gray-800/50 text-left text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400 dark:text-gray-500">
                   <th class="px-4 py-3">Domain</th>
                   <th class="px-4 py-3">Default</th>
                   <th class="hidden px-4 py-3 lg:table-cell">Created</th>
@@ -482,11 +482,11 @@ onMounted(fetchAll)
                 </tr>
               </thead>
               <tbody class="divide-y">
-                <tr v-for="d in domains" :key="d.id" class="transition-colors hover:bg-gray-50">
+                <tr v-for="d in domains" :key="d.id" class="transition-colors hover:bg-gray-50 dark:hover:bg-gray-700 dark:bg-gray-800/50">
                   <td class="px-4 py-3">
                     <div class="flex items-center gap-2">
-                      <Globe class="h-4 w-4 text-gray-400" />
-                      <span class="font-mono text-sm text-gray-900">{{ d.domain }}</span>
+                      <Globe class="h-4 w-4 text-gray-400 dark:text-gray-500" />
+                      <span class="font-mono text-sm text-gray-900 dark:text-white">{{ d.domain }}</span>
                     </div>
                   </td>
                   <td class="px-4 py-3">
@@ -494,21 +494,21 @@ onMounted(fetchAll)
                       <Star class="h-3.5 w-3.5 fill-yellow-500 text-yellow-500" />
                       Default
                     </span>
-                    <span v-else class="text-xs text-gray-400">&mdash;</span>
+                    <span v-else class="text-xs text-gray-400 dark:text-gray-500">&mdash;</span>
                   </td>
-                  <td class="hidden whitespace-nowrap px-4 py-3 text-gray-500 lg:table-cell">{{ formatDate(d.createdAt) }}</td>
+                  <td class="hidden whitespace-nowrap px-4 py-3 text-gray-500 dark:text-gray-400 dark:text-gray-500 lg:table-cell">{{ formatDate(d.createdAt) }}</td>
                   <td class="px-4 py-3">
                     <div class="flex items-center justify-end gap-1">
                       <a
                         :href="'https://' + d.domain"
                         target="_blank"
                         rel="noopener noreferrer"
-                        class="rounded p-1.5 text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-600"
+                        class="rounded p-1.5 text-gray-400 dark:text-gray-500 transition-colors hover:bg-gray-100 dark:hover:bg-gray-800 dark:bg-gray-800 hover:text-gray-600 dark:text-gray-400 dark:text-gray-500 dark:hover:text-gray-300 dark:text-gray-600"
                       >
                         <ExternalLink class="h-4 w-4" />
                       </a>
                       <button
-                        class="rounded p-1.5 text-gray-400 transition-colors hover:bg-red-50 hover:text-red-600"
+                        class="rounded p-1.5 text-gray-400 dark:text-gray-500 transition-colors hover:bg-red-50 hover:text-red-600"
                         @click="confirmDeleteDomain = d.domain"
                       >
                         <Trash2 class="h-4 w-4" />
@@ -519,52 +519,52 @@ onMounted(fetchAll)
               </tbody>
             </table>
           </div>
-          <div v-else class="mt-4 py-6 text-center text-sm text-gray-400">
+          <div v-else class="mt-4 py-6 text-center text-sm text-gray-400 dark:text-gray-500">
             No domains configured for this tenant.
           </div>
         </div>
       </div>
 
       <!-- ID Length Config (admin only) -->
-      <div v-if="isAdmin" class="rounded-xl border border-gray-200 bg-white shadow-sm">
-        <div class="flex items-center gap-2 border-b border-gray-100 px-4 py-3 sm:px-5 sm:py-4">
+      <div v-if="isAdmin" class="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 shadow-sm">
+        <div class="flex items-center gap-2 border-b border-gray-100 dark:border-gray-800 px-4 py-3 sm:px-5 sm:py-4">
           <Hash class="h-4 w-4 text-blue-600" />
-          <h2 class="text-base font-semibold text-gray-900">ID Length Configuration</h2>
+          <h2 class="text-base font-semibold text-gray-900 dark:text-white">ID Length Configuration</h2>
         </div>
         <div class="p-4 sm:p-5">
           <div class="max-w-md space-y-4">
             <div>
-              <label class="mb-1 block text-sm font-medium text-gray-700">Default ID Length</label>
+              <label class="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300 dark:text-gray-600">Default ID Length</label>
               <input
                 v-model.number="idLength"
                 type="number"
                 step="1"
                 :min="idMinimumLength + 1"
                 :max="idMaximumLength - 1"
-                class="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
+                class="w-full rounded-md border border-gray-300 dark:border-gray-600 px-3 py-2 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
               />
             </div>
             <div class="grid grid-cols-2 gap-4">
               <div>
-                <label class="mb-1 block text-sm font-medium text-gray-700">Minimum Length</label>
+                <label class="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300 dark:text-gray-600">Minimum Length</label>
                 <input
                   v-model.number="idMinimumLength"
                   type="number"
                   step="1"
                   :min="2"
                   :max="idLength - 1"
-                  class="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
+                  class="w-full rounded-md border border-gray-300 dark:border-gray-600 px-3 py-2 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
                 />
               </div>
               <div>
-                <label class="mb-1 block text-sm font-medium text-gray-700">Maximum Length</label>
+                <label class="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300 dark:text-gray-600">Maximum Length</label>
                 <input
                   v-model.number="idMaximumLength"
                   type="number"
                   step="1"
                   :min="idLength + 1"
                   :max="10"
-                  class="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
+                  class="w-full rounded-md border border-gray-300 dark:border-gray-600 px-3 py-2 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
                 />
               </div>
             </div>
@@ -586,20 +586,20 @@ onMounted(fetchAll)
       </div>
 
       <!-- 404 Config (admin only) -->
-      <div v-if="isAdmin" class="rounded-xl border border-gray-200 bg-white shadow-sm">
-        <div class="flex items-center gap-2 border-b border-gray-100 px-4 py-3 sm:px-5 sm:py-4">
+      <div v-if="isAdmin" class="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 shadow-sm">
+        <div class="flex items-center gap-2 border-b border-gray-100 dark:border-gray-800 px-4 py-3 sm:px-5 sm:py-4">
           <AlertTriangle class="h-4 w-4 text-orange-500" />
-          <h2 class="text-base font-semibold text-gray-900">404 Handling Configuration</h2>
+          <h2 class="text-base font-semibold text-gray-900 dark:text-white">404 Handling Configuration</h2>
         </div>
         <div class="p-4 sm:p-5">
           <div class="max-w-md space-y-4">
             <div>
-              <label id="mode-label" class="mb-1 block text-sm font-medium text-gray-700">Handling Mode</label>
-              <div role="radiogroup" aria-labelledby="mode-label" class="flex rounded-lg border border-gray-200 p-0.5">
+              <label id="mode-label" class="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300 dark:text-gray-600">Handling Mode</label>
+              <div role="radiogroup" aria-labelledby="mode-label" class="flex rounded-lg border border-gray-200 dark:border-gray-700 p-0.5">
                 <button
                   role="radio"
                   :aria-checked="notFoundMode === 'content'"
-                  :class="['flex-1 rounded-md px-4 py-2 text-sm font-medium transition-colors', notFoundMode === 'content' ? 'bg-blue-600 text-white' : 'text-gray-500 hover:text-gray-700']"
+                  :class="['flex-1 rounded-md px-4 py-2 text-sm font-medium transition-colors', notFoundMode === 'content' ? 'bg-blue-600 text-white' : 'text-gray-500 dark:text-gray-400 dark:text-gray-500 hover:text-gray-700 dark:hover:text-gray-200 dark:text-gray-300 dark:text-gray-600']"
                   @click="notFoundMode = 'content'"
                 >
                   Display Content
@@ -607,7 +607,7 @@ onMounted(fetchAll)
                 <button
                   role="radio"
                   :aria-checked="notFoundMode === 'redirect'"
-                  :class="['flex-1 rounded-md px-4 py-2 text-sm font-medium transition-colors', notFoundMode === 'redirect' ? 'bg-blue-600 text-white' : 'text-gray-500 hover:text-gray-700']"
+                  :class="['flex-1 rounded-md px-4 py-2 text-sm font-medium transition-colors', notFoundMode === 'redirect' ? 'bg-blue-600 text-white' : 'text-gray-500 dark:text-gray-400 dark:text-gray-500 hover:text-gray-700 dark:hover:text-gray-200 dark:text-gray-300 dark:text-gray-600']"
                   @click="notFoundMode = 'redirect'"
                 >
                   Redirect
@@ -615,21 +615,21 @@ onMounted(fetchAll)
               </div>
             </div>
             <div v-if="notFoundMode === 'content'">
-              <label class="mb-1 block text-sm font-medium text-gray-700">Content Text</label>
+              <label class="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300 dark:text-gray-600">Content Text</label>
               <textarea
                 v-model="notFoundValue"
                 rows="4"
                 placeholder="The page content to display when a short link is not found..."
-                class="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
+                class="w-full rounded-md border border-gray-300 dark:border-gray-600 px-3 py-2 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
               />
             </div>
             <div v-else>
-              <label class="mb-1 block text-sm font-medium text-gray-700">Redirect URL</label>
+              <label class="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300 dark:text-gray-600">Redirect URL</label>
               <input
                 v-model="notFoundValue"
                 type="url"
                 placeholder="https://example.com/404"
-                class="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
+                class="w-full rounded-md border border-gray-300 dark:border-gray-600 px-3 py-2 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
               />
             </div>
             <p v-if="notFoundValidationError" class="text-xs text-red-600">{{ notFoundValidationError }}</p>
@@ -650,54 +650,54 @@ onMounted(fetchAll)
       </div>
 
       <!-- Config Preview (admin only) -->
-      <div v-if="isAdmin" class="rounded-xl border border-gray-200 bg-white shadow-sm">
-        <div class="flex items-center gap-2 border-b border-gray-100 px-4 py-3 sm:px-5 sm:py-4">
+      <div v-if="isAdmin" class="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 shadow-sm">
+        <div class="flex items-center gap-2 border-b border-gray-100 dark:border-gray-800 px-4 py-3 sm:px-5 sm:py-4">
           <Eye class="h-4 w-4 text-purple-600" />
-          <h2 class="text-base font-semibold text-gray-900">Configuration Preview</h2>
+          <h2 class="text-base font-semibold text-gray-900 dark:text-white">Configuration Preview</h2>
         </div>
         <div class="p-4 sm:p-5">
           <div class="grid grid-cols-1 gap-4 sm:grid-cols-2">
-            <div class="rounded-lg border border-gray-100 bg-gray-50 p-4">
+            <div class="rounded-lg border border-gray-100 dark:border-gray-800 bg-gray-50 dark:bg-gray-800/50 p-4">
               <div class="mb-3 flex items-center justify-between">
-                <p class="text-xs font-medium uppercase tracking-wider text-gray-500">ID Length Examples</p>
-                <button v-if="sampleIds" class="rounded p-1 text-gray-400 transition-colors hover:bg-gray-200 hover:text-gray-600" @click="refreshSampleIds">
+                <p class="text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400 dark:text-gray-500">ID Length Examples</p>
+                <button v-if="sampleIds" class="rounded p-1 text-gray-400 dark:text-gray-500 transition-colors hover:bg-gray-200 dark:bg-gray-700 hover:text-gray-600 dark:text-gray-400 dark:text-gray-500 dark:hover:text-gray-300 dark:text-gray-600" @click="refreshSampleIds">
                   <Loader2 class="h-3.5 w-3.5" />
                 </button>
               </div>
               <template v-if="sampleIds">
                 <div class="space-y-2">
                   <div class="flex items-center gap-3">
-                    <span class="w-16 text-xs text-gray-400">Min ({{ normalizedIdLengths.min }})</span>
-                    <span class="font-mono text-sm font-semibold text-gray-600">{{ sampleIds.min }}</span>
+                    <span class="w-16 text-xs text-gray-400 dark:text-gray-500">Min ({{ normalizedIdLengths.min }})</span>
+                    <span class="font-mono text-sm font-semibold text-gray-600 dark:text-gray-400 dark:text-gray-500">{{ sampleIds.min }}</span>
                   </div>
                   <div class="flex items-center gap-3">
                     <span class="w-16 text-xs font-medium text-blue-600">Default ({{ normalizedIdLengths.default }})</span>
                     <span class="font-mono text-sm font-bold text-blue-600">{{ sampleIds.default }}</span>
                   </div>
                   <div class="flex items-center gap-3">
-                    <span class="w-16 text-xs text-gray-400">Max ({{ normalizedIdLengths.max }})</span>
-                    <span class="font-mono text-sm font-semibold text-gray-600">{{ sampleIds.max }}</span>
+                    <span class="w-16 text-xs text-gray-400 dark:text-gray-500">Max ({{ normalizedIdLengths.max }})</span>
+                    <span class="font-mono text-sm font-semibold text-gray-600 dark:text-gray-400 dark:text-gray-500">{{ sampleIds.max }}</span>
                   </div>
                 </div>
               </template>
-              <p v-else class="text-xs text-gray-400">Fix validation errors to see examples.</p>
+              <p v-else class="text-xs text-gray-400 dark:text-gray-500">Fix validation errors to see examples.</p>
             </div>
-            <div class="rounded-lg border border-gray-100 bg-gray-50 p-4">
-              <p class="mb-2 text-xs font-medium uppercase tracking-wider text-gray-500">404 Handling</p>
+            <div class="rounded-lg border border-gray-100 dark:border-gray-800 bg-gray-50 dark:bg-gray-800/50 p-4">
+              <p class="mb-2 text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400 dark:text-gray-500">404 Handling</p>
               <span
                 class="inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium"
                 :class="notFoundMode === 'content' ? 'bg-blue-50 text-blue-700' : 'bg-orange-50 text-orange-700'"
               >
                 {{ notFoundMode === 'content' ? 'Display Content' : 'Redirect' }}
               </span>
-              <p class="mt-2 line-clamp-3 text-xs text-gray-600">{{ previewText }}</p>
+              <p class="mt-2 line-clamp-3 text-xs text-gray-600 dark:text-gray-400 dark:text-gray-500">{{ previewText }}</p>
             </div>
           </div>
         </div>
       </div>
 
       <!-- Non-admin message -->
-      <div v-if="!isAdmin" class="rounded-lg border bg-white p-8 text-center text-sm text-gray-400">
+      <div v-if="!isAdmin" class="rounded-lg border bg-white dark:bg-gray-900 p-8 text-center text-sm text-gray-400 dark:text-gray-500">
         Only admins can manage tenant settings.
       </div>
     </template>
@@ -712,9 +712,9 @@ onMounted(fetchAll)
       @confirm="handleDeleteDomain(confirmDeleteDomain!)"
       @cancel="confirmDeleteDomain = null"
     >
-      <p class="mt-2 text-sm text-gray-500">
+      <p class="mt-2 text-sm text-gray-500 dark:text-gray-400 dark:text-gray-500">
         Are you sure you want to remove
-        <span class="font-mono font-medium text-gray-700">{{ confirmDeleteDomain }}</span>?
+        <span class="font-mono font-medium text-gray-700 dark:text-gray-300 dark:text-gray-600">{{ confirmDeleteDomain }}</span>?
       </p>
     </ConfirmDialog>
 

--- a/web-ui/src/pages/ShortLinkCreatePage.vue
+++ b/web-ui/src/pages/ShortLinkCreatePage.vue
@@ -129,14 +129,14 @@ function goToLinks() {
   <div>
     <div class="flex items-center gap-3">
       <button
-        class="rounded p-1.5 text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-600"
+        class="rounded p-1.5 text-gray-400 dark:text-gray-500 transition-colors hover:bg-gray-100 dark:hover:bg-gray-800 dark:bg-gray-800 hover:text-gray-600 dark:text-gray-400 dark:text-gray-500 dark:hover:text-gray-300 dark:text-gray-600"
         @click="router.push({ name: 'short-links' })"
       >
         <ArrowLeft class="h-5 w-5" />
       </button>
       <div>
-        <h1 class="text-xl font-semibold text-gray-900">Create Short Link</h1>
-        <p class="mt-0.5 text-sm text-gray-500">Generate a new short link for your URL.</p>
+        <h1 class="text-xl font-semibold text-gray-900 dark:text-white">Create Short Link</h1>
+        <p class="mt-0.5 text-sm text-gray-500 dark:text-gray-400 dark:text-gray-500">Generate a new short link for your URL.</p>
       </div>
     </div>
 
@@ -147,11 +147,11 @@ function goToLinks() {
     >
       <h2 class="text-lg font-semibold text-green-800">Short Link Created!</h2>
       <div class="mt-3 flex items-center gap-2 rounded-md bg-white p-3 shadow-sm">
-        <span class="font-mono text-sm font-medium text-gray-900">
+        <span class="font-mono text-sm font-medium text-gray-900 dark:text-white">
           {{ getShortLinkUrl(createdLink.id) }}
         </span>
         <button
-          class="rounded p-1 text-gray-400 transition-colors hover:text-green-600"
+          class="rounded p-1 text-gray-400 dark:text-gray-500 transition-colors hover:text-green-600"
           title="Copy short link"
           @click="copyCreatedLink"
         >
@@ -162,13 +162,13 @@ function goToLinks() {
           :href="getShortLinkUrl(createdLink.id)"
           target="_blank"
           rel="noopener noreferrer"
-          class="rounded p-1 text-gray-400 transition-colors hover:text-blue-600"
+          class="rounded p-1 text-gray-400 dark:text-gray-500 transition-colors hover:text-blue-600"
           title="Open short link"
         >
           <ExternalLink class="h-4 w-4" />
         </a>
       </div>
-      <p class="mt-2 text-sm text-gray-600">
+      <p class="mt-2 text-sm text-gray-600 dark:text-gray-400 dark:text-gray-500">
         Destination:
         <a
           :href="createdLink.url"
@@ -187,7 +187,7 @@ function goToLinks() {
           Create Another
         </button>
         <button
-          class="rounded-md px-4 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-100"
+          class="rounded-md px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 dark:text-gray-600 transition-colors hover:bg-gray-100 dark:hover:bg-gray-800 dark:bg-gray-800"
           @click="goToLinks"
         >
           View All Links
@@ -196,10 +196,10 @@ function goToLinks() {
     </div>
 
     <!-- Create form -->
-    <form v-else class="mt-6 max-w-lg rounded-lg border bg-white p-6" @submit.prevent="handleSubmit">
+    <form v-else class="mt-6 max-w-lg rounded-lg border bg-white dark:bg-gray-900 p-6" @submit.prevent="handleSubmit">
       <div class="space-y-5">
         <div>
-          <label class="mb-1 block text-sm font-medium text-gray-700">
+          <label class="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300 dark:text-gray-600">
             Target URL <span class="text-red-500">*</span>
           </label>
           <input
@@ -207,55 +207,55 @@ function goToLinks() {
             type="text"
             required
             placeholder="example.com/long-url or https://example.com"
-            class="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
+            class="w-full rounded-md border border-gray-300 dark:border-gray-600 px-3 py-2 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
             :class="urlError ? 'border-red-300 focus:border-red-500 focus:ring-red-500' : ''"
           />
           <p v-if="urlError" class="mt-1 text-xs text-red-600">{{ urlError }}</p>
-          <p v-else class="mt-1 text-xs text-gray-400">
+          <p v-else class="mt-1 text-xs text-gray-400 dark:text-gray-500">
             https:// will be added automatically if omitted.
           </p>
         </div>
 
         <div v-if="isAdmin">
-          <label class="mb-1 block text-sm font-medium text-gray-700">
+          <label class="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300 dark:text-gray-600">
             Custom ID
-            <span class="text-xs font-normal text-gray-400">(optional)</span>
+            <span class="text-xs font-normal text-gray-400 dark:text-gray-500">(optional)</span>
           </label>
           <input
             v-model="customId"
             type="text"
             placeholder="my-custom-id"
             maxlength="64"
-            class="w-full rounded-md border border-gray-300 px-3 py-2 font-mono text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
+            class="w-full rounded-md border border-gray-300 dark:border-gray-600 px-3 py-2 font-mono text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
             :class="customIdError ? 'border-red-300 focus:border-red-500 focus:ring-red-500' : ''"
           />
           <p v-if="customIdError" class="mt-1 text-xs text-red-600">{{ customIdError }}</p>
-          <p v-else class="mt-1 text-xs text-gray-400">
+          <p v-else class="mt-1 text-xs text-gray-400 dark:text-gray-500">
             Letters, numbers, hyphens, underscores. 2–64 characters. Leave empty to auto-generate.
           </p>
         </div>
 
         <div>
-          <label class="mb-1 block text-sm font-medium text-gray-700">
+          <label class="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300 dark:text-gray-600">
             Description
-            <span class="text-xs font-normal text-gray-400">(optional)</span>
+            <span class="text-xs font-normal text-gray-400 dark:text-gray-500">(optional)</span>
           </label>
           <textarea
             v-model="description"
             rows="3"
             placeholder="Describe where this link points to..."
-            class="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
+            class="w-full rounded-md border border-gray-300 dark:border-gray-600 px-3 py-2 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
           />
         </div>
 
         <div class="flex items-center gap-3">
-          <label class="text-sm font-medium text-gray-700">Enabled</label>
+          <label class="text-sm font-medium text-gray-700 dark:text-gray-300 dark:text-gray-600">Enabled</label>
           <button
             type="button"
             role="switch"
             :aria-checked="isEnable"
             class="relative inline-flex h-6 w-11 shrink-0 rounded-full border-2 border-transparent transition-colors"
-            :class="isEnable ? 'bg-blue-600' : 'bg-gray-200'"
+            :class="isEnable ? 'bg-blue-600' : 'bg-gray-200 dark:bg-gray-700'"
             @click="isEnable = !isEnable"
           >
             <span
@@ -278,7 +278,7 @@ function goToLinks() {
         </button>
         <button
           type="button"
-          class="rounded-md px-4 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-100"
+          class="rounded-md px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 dark:text-gray-600 transition-colors hover:bg-gray-100 dark:hover:bg-gray-800 dark:bg-gray-800"
           @click="router.push({ name: 'short-links' })"
         >
           Cancel

--- a/web-ui/src/pages/ShortLinkDetailPage.vue
+++ b/web-ui/src/pages/ShortLinkDetailPage.vue
@@ -354,14 +354,14 @@ onMounted(() => {
   <div>
     <div class="flex items-center gap-3">
       <button
-        class="rounded p-1.5 text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-600"
+        class="rounded p-1.5 text-gray-400 dark:text-gray-500 transition-colors hover:bg-gray-100 dark:hover:bg-gray-800 dark:bg-gray-800 hover:text-gray-600 dark:text-gray-400 dark:text-gray-500 dark:hover:text-gray-300 dark:text-gray-600"
         @click="router.push({ name: 'short-links' })"
       >
         <ArrowLeft class="h-5 w-5" />
       </button>
       <div class="flex-1">
-        <h1 class="text-xl font-semibold text-gray-900">Short Link Detail</h1>
-        <p v-if="link" class="mt-0.5 text-sm text-gray-500">
+        <h1 class="text-xl font-semibold text-gray-900 dark:text-white">Short Link Detail</h1>
+        <p v-if="link" class="mt-0.5 text-sm text-gray-500 dark:text-gray-400 dark:text-gray-500">
           <span class="font-mono font-medium text-blue-600">{{ shortLinkUrl }}</span>
         </p>
       </div>
@@ -375,9 +375,9 @@ onMounted(() => {
       </button>
     </div>
 
-    <div v-if="loading" class="mt-6 text-center text-gray-400">Loading...</div>
+    <div v-if="loading" class="mt-6 text-center text-gray-400 dark:text-gray-500">Loading...</div>
 
-    <div v-else-if="notFound" class="mt-6 text-center text-gray-400">
+    <div v-else-if="notFound" class="mt-6 text-center text-gray-400 dark:text-gray-500">
       Short link not found.
       <button
         class="ml-2 text-blue-600 hover:underline"
@@ -389,10 +389,10 @@ onMounted(() => {
 
     <template v-else-if="link">
       <!-- Basic info card -->
-      <div class="mt-4 rounded-lg border bg-white p-5">
+      <div class="mt-4 rounded-lg border bg-white dark:bg-gray-900 p-5">
         <div class="grid gap-4 sm:grid-cols-2">
           <div>
-            <label class="text-xs font-medium uppercase text-gray-400">Short Link</label>
+            <label class="text-xs font-medium uppercase text-gray-400 dark:text-gray-500">Short Link</label>
             <div class="mt-1 flex items-center gap-2">
               <a
                 :href="shortLinkUrl"
@@ -403,7 +403,7 @@ onMounted(() => {
                 {{ shortLinkUrl }}
               </a>
               <button
-                class="rounded p-0.5 text-gray-400 transition-colors hover:text-blue-600"
+                class="rounded p-0.5 text-gray-400 dark:text-gray-500 transition-colors hover:text-blue-600"
                 @click="copyLink"
               >
                 <Copy v-if="!copied" class="h-3.5 w-3.5" />
@@ -412,7 +412,7 @@ onMounted(() => {
             </div>
           </div>
           <div>
-            <label class="text-xs font-medium uppercase text-gray-400">Target URL</label>
+            <label class="text-xs font-medium uppercase text-gray-400 dark:text-gray-500">Target URL</label>
             <a
               :href="link.url"
               target="_blank"
@@ -424,14 +424,14 @@ onMounted(() => {
             </a>
           </div>
           <div>
-            <label class="text-xs font-medium uppercase text-gray-400">Description</label>
-            <p class="mt-1 text-sm text-gray-700">{{ link.description || '—' }}</p>
+            <label class="text-xs font-medium uppercase text-gray-400 dark:text-gray-500">Description</label>
+            <p class="mt-1 text-sm text-gray-700 dark:text-gray-300 dark:text-gray-600">{{ link.description || '—' }}</p>
           </div>
           <div>
-            <label class="text-xs font-medium uppercase text-gray-400">Status</label>
+            <label class="text-xs font-medium uppercase text-gray-400 dark:text-gray-500">Status</label>
             <span
               class="mt-1 inline-flex items-center gap-1.5 rounded-full px-2.5 py-0.5 text-xs font-medium"
-              :class="link.isEnable ? 'bg-green-50 text-green-700' : 'bg-gray-100 text-gray-500'"
+              :class="link.isEnable ? 'bg-green-50 text-green-700' : 'bg-gray-100 dark:bg-gray-800 text-gray-500 dark:text-gray-400 dark:text-gray-500'"
             >
               <span
                 class="h-1.5 w-1.5 rounded-full"
@@ -441,12 +441,12 @@ onMounted(() => {
             </span>
           </div>
           <div>
-            <label class="text-xs font-medium uppercase text-gray-400">Created By</label>
-            <p class="mt-1 text-sm text-gray-700">{{ link.createdBy }}</p>
+            <label class="text-xs font-medium uppercase text-gray-400 dark:text-gray-500">Created By</label>
+            <p class="mt-1 text-sm text-gray-700 dark:text-gray-300 dark:text-gray-600">{{ link.createdBy }}</p>
           </div>
           <div>
-            <label class="text-xs font-medium uppercase text-gray-400">Created</label>
-            <p class="mt-1 text-sm text-gray-700">{{ formatDate(link.createTime) }}</p>
+            <label class="text-xs font-medium uppercase text-gray-400 dark:text-gray-500">Created</label>
+            <p class="mt-1 text-sm text-gray-700 dark:text-gray-300 dark:text-gray-600">{{ formatDate(link.createTime) }}</p>
           </div>
         </div>
       </div>
@@ -454,14 +454,14 @@ onMounted(() => {
       <!-- Analytics section -->
       <div class="mt-6">
         <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-          <h2 class="text-lg font-semibold text-gray-900">Access Analytics</h2>
+          <h2 class="text-lg font-semibold text-gray-900 dark:text-white">Access Analytics</h2>
           <div class="flex items-center gap-2">
-            <div class="flex items-center gap-1 rounded-lg border bg-white p-1">
+            <div class="flex items-center gap-1 rounded-lg border bg-white dark:bg-gray-900 p-1">
               <button
                 v-for="d in [7, 14, 30]"
                 :key="d"
                 class="rounded-md px-3 py-1 text-xs font-medium transition-colors"
-                :class="daysAgo === d ? 'bg-blue-600 text-white' : 'text-gray-600 hover:bg-gray-100'"
+                :class="daysAgo === d ? 'bg-blue-600 text-white' : 'text-gray-600 dark:text-gray-400 dark:text-gray-500 hover:bg-gray-100 dark:hover:bg-gray-800 dark:bg-gray-800'"
                 @click="setDateRange(d)"
               >
                 {{ d }}d
@@ -472,43 +472,43 @@ onMounted(() => {
 
         <!-- Stats cards -->
         <div class="mt-4 grid grid-cols-2 gap-3 sm:grid-cols-4">
-          <div class="rounded-lg border bg-white p-4">
-            <div class="flex items-center gap-2 text-gray-400">
+          <div class="rounded-lg border bg-white dark:bg-gray-900 p-4">
+            <div class="flex items-center gap-2 text-gray-400 dark:text-gray-500">
               <Calendar class="h-4 w-4" />
               <span class="text-xs font-medium uppercase">Total Visits</span>
             </div>
-            <p class="mt-2 text-2xl font-bold text-gray-900">{{ totalVisits }}</p>
+            <p class="mt-2 text-2xl font-bold text-gray-900 dark:text-white">{{ totalVisits }}</p>
           </div>
-          <div class="rounded-lg border bg-white p-4">
-            <div class="flex items-center gap-2 text-gray-400">
+          <div class="rounded-lg border bg-white dark:bg-gray-900 p-4">
+            <div class="flex items-center gap-2 text-gray-400 dark:text-gray-500">
               <Globe class="h-4 w-4" />
               <span class="text-xs font-medium uppercase">Unique IPs</span>
             </div>
-            <p class="mt-2 text-2xl font-bold text-gray-900">{{ uniqueIps }}</p>
+            <p class="mt-2 text-2xl font-bold text-gray-900 dark:text-white">{{ uniqueIps }}</p>
           </div>
-          <div class="rounded-lg border bg-white p-4">
-            <div class="flex items-center gap-2 text-gray-400">
+          <div class="rounded-lg border bg-white dark:bg-gray-900 p-4">
+            <div class="flex items-center gap-2 text-gray-400 dark:text-gray-500">
               <Monitor class="h-4 w-4" />
               <span class="text-xs font-medium uppercase">Platforms</span>
             </div>
-            <p class="mt-2 text-2xl font-bold text-gray-900">{{ osDistribution.length }}</p>
+            <p class="mt-2 text-2xl font-bold text-gray-900 dark:text-white">{{ osDistribution.length }}</p>
           </div>
-          <div class="rounded-lg border bg-white p-4">
-            <div class="flex items-center gap-2 text-gray-400">
+          <div class="rounded-lg border bg-white dark:bg-gray-900 p-4">
+            <div class="flex items-center gap-2 text-gray-400 dark:text-gray-500">
               <Calendar class="h-4 w-4" />
               <span class="text-xs font-medium uppercase">Avg/Day</span>
             </div>
-            <p class="mt-2 text-2xl font-bold text-gray-900">
+            <p class="mt-2 text-2xl font-bold text-gray-900 dark:text-white">
               {{ daysAgo > 0 ? (totalVisits / daysAgo).toFixed(1) : 0 }}
             </p>
           </div>
         </div>
 
         <!-- Tab switcher -->
-        <div class="mt-6 flex gap-1 rounded-lg border bg-white p-1 w-fit">
+        <div class="mt-6 flex gap-1 rounded-lg border bg-white dark:bg-gray-900 p-1 w-fit">
           <button
             class="inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 text-xs font-medium transition-colors"
-            :class="activeTab === 'trend' ? 'bg-blue-600 text-white' : 'text-gray-600 hover:bg-gray-100'"
+            :class="activeTab === 'trend' ? 'bg-blue-600 text-white' : 'text-gray-600 dark:text-gray-400 dark:text-gray-500 hover:bg-gray-100 dark:hover:bg-gray-800 dark:bg-gray-800'"
             @click="activeTab = 'trend'"
           >
             <LayoutGrid class="h-3.5 w-3.5" />
@@ -516,7 +516,7 @@ onMounted(() => {
           </button>
           <button
             class="inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 text-xs font-medium transition-colors"
-            :class="activeTab === 'records' ? 'bg-blue-600 text-white' : 'text-gray-600 hover:bg-gray-100'"
+            :class="activeTab === 'records' ? 'bg-blue-600 text-white' : 'text-gray-600 dark:text-gray-400 dark:text-gray-500 hover:bg-gray-100 dark:hover:bg-gray-800 dark:bg-gray-800'"
             @click="activeTab = 'records'"
           >
             <FileText class="h-3.5 w-3.5" />
@@ -527,14 +527,14 @@ onMounted(() => {
         <!-- Charts tab -->
         <template v-if="activeTab === 'trend'">
           <!-- Visit trend chart -->
-          <div class="mt-4 rounded-lg border bg-white p-5">
-            <h3 class="mb-4 text-sm font-semibold text-gray-700">Visit Trend</h3>
+          <div class="mt-4 rounded-lg border bg-white dark:bg-gray-900 p-5">
+            <h3 class="mb-4 text-sm font-semibold text-gray-700 dark:text-gray-300 dark:text-gray-600">Visit Trend</h3>
             <div v-if="chartLoading" class="flex h-56 items-center justify-center">
-              <Loader2 class="h-5 w-5 animate-spin text-gray-400" />
+              <Loader2 class="h-5 w-5 animate-spin text-gray-400 dark:text-gray-500" />
             </div>
             <div
               v-else-if="totalVisits === 0"
-              class="flex h-56 items-center justify-center text-sm text-gray-400"
+              class="flex h-56 items-center justify-center text-sm text-gray-400 dark:text-gray-500"
             >
               No data for this period.
             </div>
@@ -551,14 +551,14 @@ onMounted(() => {
 
           <!-- OS & Browser distribution charts -->
           <div class="mt-4 grid gap-4 lg:grid-cols-2">
-            <div class="rounded-lg border bg-white p-5">
-              <h3 class="mb-4 text-sm font-semibold text-gray-700">OS Distribution</h3>
+            <div class="rounded-lg border bg-white dark:bg-gray-900 p-5">
+              <h3 class="mb-4 text-sm font-semibold text-gray-700 dark:text-gray-300 dark:text-gray-600">OS Distribution</h3>
               <div v-if="chartLoading" class="flex h-56 items-center justify-center">
-                <Loader2 class="h-5 w-5 animate-spin text-gray-400" />
+                <Loader2 class="h-5 w-5 animate-spin text-gray-400 dark:text-gray-500" />
               </div>
               <div
                 v-else-if="osDistribution.length === 0"
-                class="flex h-56 items-center justify-center text-sm text-gray-400"
+                class="flex h-56 items-center justify-center text-sm text-gray-400 dark:text-gray-500"
               >
                 No data for this period.
               </div>
@@ -573,14 +573,14 @@ onMounted(() => {
               </div>
             </div>
 
-            <div class="rounded-lg border bg-white p-5">
-              <h3 class="mb-4 text-sm font-semibold text-gray-700">Browser Distribution</h3>
+            <div class="rounded-lg border bg-white dark:bg-gray-900 p-5">
+              <h3 class="mb-4 text-sm font-semibold text-gray-700 dark:text-gray-300 dark:text-gray-600">Browser Distribution</h3>
               <div v-if="chartLoading" class="flex h-56 items-center justify-center">
-                <Loader2 class="h-5 w-5 animate-spin text-gray-400" />
+                <Loader2 class="h-5 w-5 animate-spin text-gray-400 dark:text-gray-500" />
               </div>
               <div
                 v-else-if="browserDistribution.length === 0"
-                class="flex h-56 items-center justify-center text-sm text-gray-400"
+                class="flex h-56 items-center justify-center text-sm text-gray-400 dark:text-gray-500"
               >
                 No data for this period.
               </div>
@@ -597,14 +597,14 @@ onMounted(() => {
           </div>
 
           <!-- Referer distribution -->
-          <div class="mt-4 rounded-lg border bg-white p-5">
-            <h3 class="mb-4 text-sm font-semibold text-gray-700">Referer Sources</h3>
+          <div class="mt-4 rounded-lg border bg-white dark:bg-gray-900 p-5">
+            <h3 class="mb-4 text-sm font-semibold text-gray-700 dark:text-gray-300 dark:text-gray-600">Referer Sources</h3>
             <div v-if="chartLoading" class="flex h-56 items-center justify-center">
-              <Loader2 class="h-5 w-5 animate-spin text-gray-400" />
+              <Loader2 class="h-5 w-5 animate-spin text-gray-400 dark:text-gray-500" />
             </div>
             <div
               v-else-if="refererDistribution.length === 0"
-              class="flex h-56 items-center justify-center text-sm text-gray-400"
+              class="flex h-56 items-center justify-center text-sm text-gray-400 dark:text-gray-500"
             >
               No data for this period.
             </div>
@@ -620,14 +620,14 @@ onMounted(() => {
           </div>
 
           <!-- IP distribution table -->
-          <div class="mt-4 rounded-lg border bg-white p-5">
-            <h3 class="mb-4 text-sm font-semibold text-gray-700">Top IPs</h3>
-            <div v-if="ipDistribution.length === 0" class="py-8 text-center text-sm text-gray-400">
+          <div class="mt-4 rounded-lg border bg-white dark:bg-gray-900 p-5">
+            <h3 class="mb-4 text-sm font-semibold text-gray-700 dark:text-gray-300 dark:text-gray-600">Top IPs</h3>
+            <div v-if="ipDistribution.length === 0" class="py-8 text-center text-sm text-gray-400 dark:text-gray-500">
               No data for this period.
             </div>
             <table v-else class="w-full text-left text-sm">
               <thead>
-                <tr class="border-b text-xs font-medium uppercase text-gray-400">
+                <tr class="border-b text-xs font-medium uppercase text-gray-400 dark:text-gray-500">
                   <th class="pb-2 pr-4">IP Address</th>
                   <th class="pb-2 pr-4 text-right">Visits</th>
                   <th class="pb-2 text-right">Percentage</th>
@@ -637,14 +637,14 @@ onMounted(() => {
                 <tr
                   v-for="item in ipDistribution"
                   :key="item.ip"
-                  class="border-b border-gray-50 last:border-0"
+                  class="border-b border-gray-50 dark:border-gray-800 last:border-0"
                 >
-                  <td class="py-2 pr-4 font-mono text-gray-700">{{ item.ip }}</td>
-                  <td class="py-2 pr-4 text-right font-medium text-gray-600">{{ item.count }}</td>
+                  <td class="py-2 pr-4 font-mono text-gray-700 dark:text-gray-300 dark:text-gray-600">{{ item.ip }}</td>
+                  <td class="py-2 pr-4 text-right font-medium text-gray-600 dark:text-gray-400 dark:text-gray-500">{{ item.count }}</td>
                   <td class="py-2 text-right">
                     <span class="inline-flex items-center gap-2">
-                      <span class="text-gray-500">{{ item.percent }}%</span>
-                      <span class="inline-block h-1.5 w-16 overflow-hidden rounded-full bg-gray-100">
+                      <span class="text-gray-500 dark:text-gray-400 dark:text-gray-500">{{ item.percent }}%</span>
+                      <span class="inline-block h-1.5 w-16 overflow-hidden rounded-full bg-gray-100 dark:bg-gray-800">
                         <span
                           class="inline-block h-full rounded-full bg-emerald-500"
                           :style="{ width: `${item.percent}%` }"
@@ -660,13 +660,13 @@ onMounted(() => {
 
         <!-- Access records tab -->
         <template v-if="activeTab === 'records'">
-          <div class="mt-4 rounded-lg border bg-white">
+          <div class="mt-4 rounded-lg border bg-white dark:bg-gray-900">
             <div v-if="chartLoading" class="flex h-40 items-center justify-center">
-              <Loader2 class="h-5 w-5 animate-spin text-gray-400" />
+              <Loader2 class="h-5 w-5 animate-spin text-gray-400 dark:text-gray-500" />
             </div>
             <div
               v-else-if="histories.length === 0"
-              class="flex h-40 items-center justify-center text-sm text-gray-400"
+              class="flex h-40 items-center justify-center text-sm text-gray-400 dark:text-gray-500"
             >
               No access records for this period.
             </div>
@@ -674,7 +674,7 @@ onMounted(() => {
               <div class="overflow-x-auto">
                 <table class="w-full text-left text-sm">
                   <thead>
-                    <tr class="border-b bg-gray-50 text-xs font-medium uppercase text-gray-400">
+                    <tr class="border-b bg-gray-50 dark:bg-gray-800/50 text-xs font-medium uppercase text-gray-400 dark:text-gray-500">
                       <th class="px-4 py-3">Time</th>
                       <th class="px-4 py-3">IP</th>
                       <th class="px-4 py-3">Browser</th>
@@ -687,25 +687,25 @@ onMounted(() => {
                     <tr
                       v-for="h in histories"
                       :key="h.id"
-                      class="border-b border-gray-50 hover:bg-gray-50/50"
+                      class="border-b border-gray-50 dark:border-gray-800 hover:bg-gray-50 dark:hover:bg-gray-700 dark:bg-gray-800/50/50"
                     >
-                      <td class="whitespace-nowrap px-4 py-2.5 text-gray-600">
+                      <td class="whitespace-nowrap px-4 py-2.5 text-gray-600 dark:text-gray-400 dark:text-gray-500">
                         {{ formatDate(h.time) }}
                       </td>
-                      <td class="whitespace-nowrap px-4 py-2.5 font-mono text-gray-700">
+                      <td class="whitespace-nowrap px-4 py-2.5 font-mono text-gray-700 dark:text-gray-300 dark:text-gray-600">
                         {{ h.ip }}
                       </td>
-                      <td class="whitespace-nowrap px-4 py-2.5 text-gray-600">
+                      <td class="whitespace-nowrap px-4 py-2.5 text-gray-600 dark:text-gray-400 dark:text-gray-500">
                         {{ h.browser || parseBrowser(h.ua) || '—' }}
                       </td>
-                      <td class="whitespace-nowrap px-4 py-2.5 text-gray-600">
+                      <td class="whitespace-nowrap px-4 py-2.5 text-gray-600 dark:text-gray-400 dark:text-gray-500">
                         {{ parseOS(h.ua) }}
                       </td>
-                      <td class="max-w-[200px] truncate px-4 py-2.5 text-gray-600">
+                      <td class="max-w-[200px] truncate px-4 py-2.5 text-gray-600 dark:text-gray-400 dark:text-gray-500">
                         {{ h.referer ? extractRefererSource(h.referer) : 'Direct' }}
                       </td>
                       <td
-                        class="max-w-[300px] truncate px-4 py-2.5 text-xs text-gray-400"
+                        class="max-w-[300px] truncate px-4 py-2.5 text-xs text-gray-400 dark:text-gray-500"
                         :title="h.ua"
                       >
                         {{ h.ua }}
@@ -714,7 +714,7 @@ onMounted(() => {
                   </tbody>
                 </table>
               </div>
-              <div class="border-t px-4 py-3 text-xs text-gray-400">
+              <div class="border-t px-4 py-3 text-xs text-gray-400 dark:text-gray-500">
                 {{ histories.length }} record{{ histories.length !== 1 ? 's' : '' }}
               </div>
             </template>

--- a/web-ui/src/pages/ShortLinkEditPage.vue
+++ b/web-ui/src/pages/ShortLinkEditPage.vue
@@ -113,45 +113,45 @@ onMounted(fetchData)
   <div>
     <div class="flex items-center gap-3">
       <button
-        class="rounded p-1.5 text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-600"
+        class="rounded p-1.5 text-gray-400 dark:text-gray-500 transition-colors hover:bg-gray-100 dark:hover:bg-gray-800 dark:bg-gray-800 hover:text-gray-600 dark:text-gray-400 dark:text-gray-500 dark:hover:text-gray-300 dark:text-gray-600"
         @click="router.push({ name: 'short-links' })"
       >
         <ArrowLeft class="h-5 w-5" />
       </button>
       <div>
-        <h1 class="text-xl font-semibold text-gray-900">Edit Short Link</h1>
-        <p class="mt-0.5 text-sm text-gray-500">
-          Editing <span class="font-mono font-medium text-gray-700">{{ id }}</span>
+        <h1 class="text-xl font-semibold text-gray-900 dark:text-white">Edit Short Link</h1>
+        <p class="mt-0.5 text-sm text-gray-500 dark:text-gray-400 dark:text-gray-500">
+          Editing <span class="font-mono font-medium text-gray-700 dark:text-gray-300 dark:text-gray-600">{{ id }}</span>
         </p>
       </div>
     </div>
 
     <!-- Skeleton loading -->
-    <div v-if="loading" class="mt-6 max-w-lg rounded-lg border bg-white p-6">
-      <div class="mb-5 rounded-md bg-gray-50 p-3">
+    <div v-if="loading" class="mt-6 max-w-lg rounded-lg border bg-white dark:bg-gray-900 p-6">
+      <div class="mb-5 rounded-md bg-gray-50 dark:bg-gray-800/50 p-3">
         <div class="grid grid-cols-2 gap-2">
-          <div class="h-4 w-32 animate-pulse rounded bg-gray-200" />
-          <div class="h-4 w-28 animate-pulse rounded bg-gray-200" />
-          <div class="col-span-2 h-4 w-48 animate-pulse rounded bg-gray-200" />
+          <div class="h-4 w-32 animate-pulse rounded bg-gray-200 dark:bg-gray-700" />
+          <div class="h-4 w-28 animate-pulse rounded bg-gray-200 dark:bg-gray-700" />
+          <div class="col-span-2 h-4 w-48 animate-pulse rounded bg-gray-200 dark:bg-gray-700" />
         </div>
       </div>
       <div class="space-y-5">
         <div>
-          <div class="mb-1 h-4 w-16 animate-pulse rounded bg-gray-200" />
-          <div class="h-9 w-full animate-pulse rounded-md bg-gray-200" />
+          <div class="mb-1 h-4 w-16 animate-pulse rounded bg-gray-200 dark:bg-gray-700" />
+          <div class="h-9 w-full animate-pulse rounded-md bg-gray-200 dark:bg-gray-700" />
         </div>
         <div>
-          <div class="mb-1 h-4 w-20 animate-pulse rounded bg-gray-200" />
-          <div class="h-20 w-full animate-pulse rounded-md bg-gray-200" />
+          <div class="mb-1 h-4 w-20 animate-pulse rounded bg-gray-200 dark:bg-gray-700" />
+          <div class="h-20 w-full animate-pulse rounded-md bg-gray-200 dark:bg-gray-700" />
         </div>
         <div class="flex items-center gap-3">
-          <div class="h-4 w-14 animate-pulse rounded bg-gray-200" />
-          <div class="h-6 w-11 animate-pulse rounded-full bg-gray-200" />
+          <div class="h-4 w-14 animate-pulse rounded bg-gray-200 dark:bg-gray-700" />
+          <div class="h-6 w-11 animate-pulse rounded-full bg-gray-200 dark:bg-gray-700" />
         </div>
       </div>
     </div>
 
-    <div v-else-if="notFound" class="mt-6 text-center text-gray-400">
+    <div v-else-if="notFound" class="mt-6 text-center text-gray-400 dark:text-gray-500">
       Short link not found.
       <button
         class="ml-2 text-blue-600 hover:underline"
@@ -163,30 +163,30 @@ onMounted(fetchData)
 
     <form
       v-else
-      class="mt-6 max-w-lg rounded-lg border bg-white p-6"
+      class="mt-6 max-w-lg rounded-lg border bg-white dark:bg-gray-900 p-6"
       @submit.prevent="handleSubmit"
     >
       <!-- Read-only info -->
-      <div class="mb-5 rounded-md bg-gray-50 p-3">
+      <div class="mb-5 rounded-md bg-gray-50 dark:bg-gray-800/50 p-3">
         <div class="grid grid-cols-2 gap-2 text-sm">
           <div>
-            <span class="text-gray-500">ID:</span>
-            <span class="ml-1 font-mono font-medium text-gray-900">{{ id }}</span>
+            <span class="text-gray-500 dark:text-gray-400 dark:text-gray-500">ID:</span>
+            <span class="ml-1 font-mono font-medium text-gray-900 dark:text-white">{{ id }}</span>
           </div>
           <div>
-            <span class="text-gray-500">Created by:</span>
-            <span class="ml-1 text-gray-700">{{ createdBy }}</span>
+            <span class="text-gray-500 dark:text-gray-400 dark:text-gray-500">Created by:</span>
+            <span class="ml-1 text-gray-700 dark:text-gray-300 dark:text-gray-600">{{ createdBy }}</span>
           </div>
           <div class="col-span-2">
-            <span class="text-gray-500">Created:</span>
-            <span class="ml-1 text-gray-700">{{ formatDate(createTime) }}</span>
+            <span class="text-gray-500 dark:text-gray-400 dark:text-gray-500">Created:</span>
+            <span class="ml-1 text-gray-700 dark:text-gray-300 dark:text-gray-600">{{ formatDate(createTime) }}</span>
           </div>
         </div>
       </div>
 
       <div class="space-y-5">
         <div>
-          <label class="mb-1 block text-sm font-medium text-gray-700">
+          <label class="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300 dark:text-gray-600">
             Target URL <span class="text-red-500">*</span>
           </label>
           <input
@@ -194,32 +194,32 @@ onMounted(fetchData)
             type="text"
             required
             placeholder="example.com/long-url or https://example.com"
-            class="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
+            class="w-full rounded-md border border-gray-300 dark:border-gray-600 px-3 py-2 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
             :class="urlError ? 'border-red-300 focus:border-red-500 focus:ring-red-500' : ''"
           />
           <p v-if="urlError" class="mt-1 text-xs text-red-600">{{ urlError }}</p>
-          <p v-else class="mt-1 text-xs text-gray-400">
+          <p v-else class="mt-1 text-xs text-gray-400 dark:text-gray-500">
             https:// will be added automatically if omitted.
           </p>
         </div>
 
         <div>
-          <label class="mb-1 block text-sm font-medium text-gray-700">Description</label>
+          <label class="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300 dark:text-gray-600">Description</label>
           <textarea
             v-model="description"
             rows="3"
-            class="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
+            class="w-full rounded-md border border-gray-300 dark:border-gray-600 px-3 py-2 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
           />
         </div>
 
         <div class="flex items-center gap-3">
-          <label class="text-sm font-medium text-gray-700">Enabled</label>
+          <label class="text-sm font-medium text-gray-700 dark:text-gray-300 dark:text-gray-600">Enabled</label>
           <button
             type="button"
             role="switch"
             :aria-checked="isEnable"
             class="relative inline-flex h-6 w-11 shrink-0 rounded-full border-2 border-transparent transition-colors"
-            :class="isEnable ? 'bg-blue-600' : 'bg-gray-200'"
+            :class="isEnable ? 'bg-blue-600' : 'bg-gray-200 dark:bg-gray-700'"
             @click="isEnable = !isEnable"
           >
             <span
@@ -242,7 +242,7 @@ onMounted(fetchData)
         </button>
         <button
           type="button"
-          class="rounded-md px-4 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-100"
+          class="rounded-md px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 dark:text-gray-600 transition-colors hover:bg-gray-100 dark:hover:bg-gray-800 dark:bg-gray-800"
           @click="router.push({ name: 'short-links' })"
         >
           Cancel

--- a/web-ui/src/pages/ShortLinksPage.vue
+++ b/web-ui/src/pages/ShortLinksPage.vue
@@ -286,8 +286,8 @@ onMounted(fetchLinks)
   <div>
     <div class="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
       <div>
-        <h1 class="text-xl font-semibold text-gray-900">Short Links</h1>
-        <p class="mt-1 text-sm text-gray-500">{{ total }} link{{ total !== 1 ? 's' : '' }} total</p>
+        <h1 class="text-xl font-semibold text-gray-900 dark:text-white">Short Links</h1>
+        <p class="mt-1 text-sm text-gray-500 dark:text-gray-400 dark:text-gray-500">{{ total }} link{{ total !== 1 ? 's' : '' }} total</p>
       </div>
       <router-link
         :to="{ name: 'short-link-create' }"
@@ -300,29 +300,29 @@ onMounted(fetchLinks)
 
     <!-- Search & Filters -->
     <div
-      class="mt-4 flex flex-col gap-3 rounded-lg border bg-white p-4 sm:flex-row sm:items-center"
+      class="mt-4 flex flex-col gap-3 rounded-lg border bg-white dark:bg-gray-900 p-4 sm:flex-row sm:items-center"
     >
       <div class="relative flex-1">
-        <Search class="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400" />
+        <Search class="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400 dark:text-gray-500" />
         <input
           v-model="searchId"
           type="text"
           placeholder="Search by ID..."
-          class="w-full rounded-md border border-gray-300 py-2 pl-9 pr-3 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
+          class="w-full rounded-md border border-gray-300 dark:border-gray-600 py-2 pl-9 pr-3 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
         />
       </div>
       <div class="relative flex-1">
-        <Search class="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400" />
+        <Search class="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400 dark:text-gray-500" />
         <input
           v-model="searchUrl"
           type="text"
           placeholder="Search by URL..."
-          class="w-full rounded-md border border-gray-300 py-2 pl-9 pr-3 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
+          class="w-full rounded-md border border-gray-300 dark:border-gray-600 py-2 pl-9 pr-3 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
         />
       </div>
       <select
         v-model="filterEnabled"
-        class="rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none sm:w-auto"
+        class="rounded-md border border-gray-300 dark:border-gray-600 px-3 py-2 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none sm:w-auto"
       >
         <option value="">All Status</option>
         <option value="true">Enabled</option>
@@ -332,7 +332,7 @@ onMounted(fetchLinks)
 
     <!-- Batch actions -->
     <div v-if="selectedIds.size > 0" class="mt-3 flex flex-wrap items-center gap-2">
-      <span class="text-sm text-gray-600">{{ selectedIds.size }} selected</span>
+      <span class="text-sm text-gray-600 dark:text-gray-400 dark:text-gray-500">{{ selectedIds.size }} selected</span>
       <button
         :disabled="batchUpdating"
         class="inline-flex items-center gap-1.5 rounded-md bg-green-50 px-3 py-1.5 text-sm font-medium text-green-600 transition-colors hover:bg-green-100 disabled:opacity-50"
@@ -342,7 +342,7 @@ onMounted(fetchLinks)
       </button>
       <button
         :disabled="batchUpdating"
-        class="inline-flex items-center gap-1.5 rounded-md bg-gray-100 px-3 py-1.5 text-sm font-medium text-gray-600 transition-colors hover:bg-gray-200 disabled:opacity-50"
+        class="inline-flex items-center gap-1.5 rounded-md bg-gray-100 dark:bg-gray-800 px-3 py-1.5 text-sm font-medium text-gray-600 dark:text-gray-400 dark:text-gray-500 transition-colors hover:bg-gray-200 dark:bg-gray-700 disabled:opacity-50"
         @click="handleBatchToggleEnable(false)"
       >
         Disable Selected
@@ -361,22 +361,22 @@ onMounted(fetchLinks)
     <div class="mt-4 space-y-3 md:hidden">
       <!-- Loading skeleton -->
       <template v-if="loading">
-        <div v-for="i in 5" :key="`skel-${i}`" class="rounded-lg border bg-white p-4">
+        <div v-for="i in 5" :key="`skel-${i}`" class="rounded-lg border bg-white dark:bg-gray-900 p-4">
           <div class="flex items-center justify-between">
-            <div class="h-4 w-24 animate-pulse rounded bg-gray-200" />
-            <div class="h-5 w-16 animate-pulse rounded-full bg-gray-200" />
+            <div class="h-4 w-24 animate-pulse rounded bg-gray-200 dark:bg-gray-700" />
+            <div class="h-5 w-16 animate-pulse rounded-full bg-gray-200 dark:bg-gray-700" />
           </div>
-          <div class="mt-2 h-3 w-full animate-pulse rounded bg-gray-100" />
+          <div class="mt-2 h-3 w-full animate-pulse rounded bg-gray-100 dark:bg-gray-800" />
           <div class="mt-2 flex items-center justify-between">
-            <div class="h-3 w-20 animate-pulse rounded bg-gray-100" />
-            <div class="h-6 w-6 animate-pulse rounded bg-gray-100" />
+            <div class="h-3 w-20 animate-pulse rounded bg-gray-100 dark:bg-gray-800" />
+            <div class="h-6 w-6 animate-pulse rounded bg-gray-100 dark:bg-gray-800" />
           </div>
         </div>
       </template>
       <!-- Empty state -->
-      <div v-else-if="filteredLinks.length === 0 && total === 0" class="rounded-lg border bg-white py-12 text-center">
-        <Link class="mx-auto h-10 w-10 text-gray-300" />
-        <p class="mt-3 text-sm font-medium text-gray-500">No short links yet</p>
+      <div v-else-if="filteredLinks.length === 0 && total === 0" class="rounded-lg border bg-white dark:bg-gray-900 py-12 text-center">
+        <Link class="mx-auto h-10 w-10 text-gray-300 dark:text-gray-600" />
+        <p class="mt-3 text-sm font-medium text-gray-500 dark:text-gray-400 dark:text-gray-500">No short links yet</p>
         <router-link
           :to="{ name: 'short-link-create' }"
           class="mt-3 inline-flex items-center gap-1.5 rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700"
@@ -385,14 +385,14 @@ onMounted(fetchLinks)
           Create your first link
         </router-link>
       </div>
-      <div v-else-if="filteredLinks.length === 0" class="rounded-lg border bg-white py-8 text-center text-sm text-gray-400">
+      <div v-else-if="filteredLinks.length === 0" class="rounded-lg border bg-white dark:bg-gray-900 py-8 text-center text-sm text-gray-400 dark:text-gray-500">
         No short links match your search.
       </div>
       <!-- Link cards -->
       <div
         v-for="link in sortedLinks"
         :key="link.id"
-        class="rounded-lg border bg-white transition-colors"
+        class="rounded-lg border bg-white dark:bg-gray-900 transition-colors"
         :class="{ 'border-blue-200 bg-blue-50/30': selectedIds.has(link.id) }"
       >
         <div class="flex items-center justify-between p-4">
@@ -400,12 +400,12 @@ onMounted(fetchLinks)
             <input
               type="checkbox"
               :checked="selectedIds.has(link.id)"
-              class="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+              class="h-4 w-4 rounded border-gray-300 dark:border-gray-600 text-blue-600 focus:ring-blue-500"
               @change="toggleSelect(link.id)"
             />
-            <span class="font-mono text-sm font-medium text-gray-900">{{ link.id }}</span>
+            <span class="font-mono text-sm font-medium text-gray-900 dark:text-white">{{ link.id }}</span>
             <button
-              class="rounded p-0.5 text-gray-400 hover:text-blue-600"
+              class="rounded p-0.5 text-gray-400 dark:text-gray-500 hover:text-blue-600"
               title="Copy short link"
               aria-label="Copy short link"
               @click="copyLink(link.id)"
@@ -417,7 +417,7 @@ onMounted(fetchLinks)
           <button
             :disabled="togglingId === link.id"
             class="inline-flex items-center gap-1.5 rounded-full px-2 py-0.5 text-xs font-medium"
-            :class="link.isEnable ? 'bg-green-50 text-green-700' : 'bg-gray-100 text-gray-500'"
+            :class="link.isEnable ? 'bg-green-50 text-green-700' : 'bg-gray-100 dark:bg-gray-800 text-gray-500 dark:text-gray-400 dark:text-gray-500'"
             @click="handleToggleEnable(link)"
           >
             <Loader2 v-if="togglingId === link.id" class="h-3 w-3 animate-spin" />
@@ -435,13 +435,13 @@ onMounted(fetchLinks)
             <span class="truncate">{{ link.url }}</span>
             <ExternalLink class="h-3 w-3 shrink-0" />
           </a>
-          <p v-if="link.description" class="mt-1 truncate text-xs text-gray-400">{{ link.description }}</p>
+          <p v-if="link.description" class="mt-1 truncate text-xs text-gray-400 dark:text-gray-500">{{ link.description }}</p>
         </div>
         <div class="flex items-center justify-between border-t px-4 py-2">
-          <span class="text-xs text-gray-400">{{ formatDate(link.createTime) }}</span>
+          <span class="text-xs text-gray-400 dark:text-gray-500">{{ formatDate(link.createTime) }}</span>
           <div class="flex items-center gap-1">
             <button
-              class="rounded p-1.5 text-gray-400 hover:bg-gray-100 hover:text-gray-600"
+              class="rounded p-1.5 text-gray-400 dark:text-gray-500 hover:bg-gray-100 dark:hover:bg-gray-800 dark:bg-gray-800 hover:text-gray-600 dark:text-gray-400 dark:text-gray-500 dark:hover:text-gray-300 dark:text-gray-600"
               title="View details"
               aria-label="View details"
               @click="router.push({ name: 'short-link-detail', params: { id: link.id } })"
@@ -449,7 +449,7 @@ onMounted(fetchLinks)
               <Eye class="h-4 w-4" />
             </button>
             <button
-              class="rounded p-1.5 text-gray-400 hover:bg-gray-100 hover:text-gray-600"
+              class="rounded p-1.5 text-gray-400 dark:text-gray-500 hover:bg-gray-100 dark:hover:bg-gray-800 dark:bg-gray-800 hover:text-gray-600 dark:text-gray-400 dark:text-gray-500 dark:hover:text-gray-300 dark:text-gray-600"
               title="Edit"
               aria-label="Edit"
               @click="router.push({ name: 'short-link-edit', params: { id: link.id } })"
@@ -457,7 +457,7 @@ onMounted(fetchLinks)
               <Pencil class="h-4 w-4" />
             </button>
             <button
-              class="rounded p-1.5 text-gray-400 hover:bg-red-50 hover:text-red-600"
+              class="rounded p-1.5 text-gray-400 dark:text-gray-500 hover:bg-red-50 hover:text-red-600"
               title="Delete"
               aria-label="Delete"
               @click="confirmDeleteId = link.id"
@@ -473,22 +473,22 @@ onMounted(fetchLinks)
         v-if="totalPages > 1"
         class="mt-3 flex items-center justify-between"
       >
-        <span class="text-xs text-gray-400">
+        <span class="text-xs text-gray-400 dark:text-gray-500">
           {{ (page - 1) * pageSize + 1 }}–{{ Math.min(page * pageSize, total) }} of {{ total }}
         </span>
         <div class="flex items-center gap-1">
           <button
             :disabled="page <= 1"
-            class="rounded p-1.5 text-gray-400 transition-colors hover:bg-gray-100 disabled:opacity-30"
+            class="rounded p-1.5 text-gray-400 dark:text-gray-500 transition-colors hover:bg-gray-100 dark:hover:bg-gray-800 dark:bg-gray-800 disabled:opacity-30"
             aria-label="Previous page"
             @click="goPage(page - 1)"
           >
             <ChevronLeft class="h-5 w-5" />
           </button>
-          <span class="min-w-[60px] text-center text-sm font-medium text-gray-700">{{ page }} / {{ totalPages }}</span>
+          <span class="min-w-[60px] text-center text-sm font-medium text-gray-700 dark:text-gray-300 dark:text-gray-600">{{ page }} / {{ totalPages }}</span>
           <button
             :disabled="page >= totalPages"
-            class="rounded p-1.5 text-gray-400 transition-colors hover:bg-gray-100 disabled:opacity-30"
+            class="rounded p-1.5 text-gray-400 dark:text-gray-500 transition-colors hover:bg-gray-100 dark:hover:bg-gray-800 dark:bg-gray-800 disabled:opacity-30"
             aria-label="Next page"
             @click="goPage(page + 1)"
           >
@@ -499,18 +499,18 @@ onMounted(fetchLinks)
     </div>
 
     <!-- Desktop table (hidden below md) -->
-    <div class="mt-4 hidden overflow-hidden rounded-lg border bg-white md:block">
+    <div class="mt-4 hidden overflow-hidden rounded-lg border bg-white dark:bg-gray-900 dark:bg-gray-900 md:block">
       <div class="overflow-x-auto">
         <table class="w-full text-sm">
           <thead>
             <tr
-              class="border-b bg-gray-50 text-left text-xs font-medium uppercase tracking-wider text-gray-500"
+              class="border-b bg-gray-50 dark:bg-gray-800/50 text-left text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400 dark:text-gray-500"
             >
               <th class="w-10 px-4 py-3">
                 <input
                   type="checkbox"
                   :checked="allSelected"
-                  class="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+                  class="h-4 w-4 rounded border-gray-300 dark:border-gray-600 text-blue-600 focus:ring-blue-500"
                   @change="toggleSelectAll"
                 />
               </th>
@@ -549,37 +549,37 @@ onMounted(fetchLinks)
             <template v-if="loading">
               <tr v-for="i in 5" :key="`skeleton-${i}`">
                 <td class="px-4 py-3">
-                  <div class="h-4 w-4 animate-pulse rounded bg-gray-200" />
+                  <div class="h-4 w-4 animate-pulse rounded bg-gray-200 dark:bg-gray-700" />
                 </td>
                 <td class="px-4 py-3">
-                  <div class="h-4 w-20 animate-pulse rounded bg-gray-200" />
+                  <div class="h-4 w-20 animate-pulse rounded bg-gray-200 dark:bg-gray-700" />
                 </td>
                 <td class="px-4 py-3">
-                  <div class="h-4 w-40 animate-pulse rounded bg-gray-200" />
+                  <div class="h-4 w-40 animate-pulse rounded bg-gray-200 dark:bg-gray-700" />
                 </td>
                 <td class="hidden px-4 py-3 md:table-cell">
-                  <div class="h-4 w-32 animate-pulse rounded bg-gray-200" />
+                  <div class="h-4 w-32 animate-pulse rounded bg-gray-200 dark:bg-gray-700" />
                 </td>
                 <td class="px-4 py-3">
-                  <div class="h-5 w-16 animate-pulse rounded-full bg-gray-200" />
+                  <div class="h-5 w-16 animate-pulse rounded-full bg-gray-200 dark:bg-gray-700" />
                 </td>
                 <td class="hidden px-4 py-3 lg:table-cell">
-                  <div class="h-4 w-28 animate-pulse rounded bg-gray-200" />
+                  <div class="h-4 w-28 animate-pulse rounded bg-gray-200 dark:bg-gray-700" />
                 </td>
                 <td class="hidden px-4 py-3 lg:table-cell">
-                  <div class="h-4 w-28 animate-pulse rounded bg-gray-200" />
+                  <div class="h-4 w-28 animate-pulse rounded bg-gray-200 dark:bg-gray-700" />
                 </td>
                 <td class="px-4 py-3">
-                  <div class="ml-auto h-4 w-20 animate-pulse rounded bg-gray-200" />
+                  <div class="ml-auto h-4 w-20 animate-pulse rounded bg-gray-200 dark:bg-gray-700" />
                 </td>
               </tr>
             </template>
             <!-- Empty state -->
             <tr v-else-if="filteredLinks.length === 0 && total === 0">
               <td colspan="8" class="px-4 py-12 text-center">
-                <Link class="mx-auto h-10 w-10 text-gray-300" />
-                <p class="mt-3 text-sm font-medium text-gray-500">No short links yet</p>
-                <p class="mt-1 text-sm text-gray-400">
+                <Link class="mx-auto h-10 w-10 text-gray-300 dark:text-gray-600" />
+                <p class="mt-3 text-sm font-medium text-gray-500 dark:text-gray-400 dark:text-gray-500">No short links yet</p>
+                <p class="mt-1 text-sm text-gray-400 dark:text-gray-500">
                   Create your first short link to get started.
                 </p>
                 <router-link
@@ -592,7 +592,7 @@ onMounted(fetchLinks)
               </td>
             </tr>
             <tr v-else-if="filteredLinks.length === 0">
-              <td colspan="8" class="px-4 py-8 text-center text-gray-400">
+              <td colspan="8" class="px-4 py-8 text-center text-gray-400 dark:text-gray-500">
                 No short links match your search.
               </td>
             </tr>
@@ -600,22 +600,22 @@ onMounted(fetchLinks)
             <tr
               v-for="link in sortedLinks"
               :key="link.id"
-              class="transition-colors hover:bg-gray-50"
+              class="transition-colors hover:bg-gray-50 dark:hover:bg-gray-700 dark:bg-gray-800/50"
               :class="{ 'bg-blue-50/50': selectedIds.has(link.id) }"
             >
               <td class="px-4 py-3">
                 <input
                   type="checkbox"
                   :checked="selectedIds.has(link.id)"
-                  class="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+                  class="h-4 w-4 rounded border-gray-300 dark:border-gray-600 text-blue-600 focus:ring-blue-500"
                   @change="toggleSelect(link.id)"
                 />
               </td>
               <td class="px-4 py-3">
                 <div class="flex items-center gap-1.5">
-                  <span class="font-mono text-xs font-medium text-gray-900">{{ link.id }}</span>
+                  <span class="font-mono text-xs font-medium text-gray-900 dark:text-white">{{ link.id }}</span>
                   <button
-                    class="rounded p-0.5 text-gray-400 transition-colors hover:text-blue-600"
+                    class="rounded p-0.5 text-gray-400 dark:text-gray-500 transition-colors hover:text-blue-600"
                     title="Copy short link"
                     @click="copyLink(link.id)"
                   >
@@ -635,7 +635,7 @@ onMounted(fetchLinks)
                   <ExternalLink class="h-3 w-3 shrink-0" />
                 </a>
               </td>
-              <td class="hidden max-w-[180px] truncate px-4 py-3 text-gray-500 md:table-cell">
+              <td class="hidden max-w-[180px] truncate px-4 py-3 text-gray-500 dark:text-gray-400 dark:text-gray-500 md:table-cell">
                 {{ link.description || '—' }}
               </td>
               <td class="px-4 py-3">
@@ -645,7 +645,7 @@ onMounted(fetchLinks)
                   :class="
                     link.isEnable
                       ? 'bg-green-50 text-green-700 hover:bg-green-100'
-                      : 'bg-gray-100 text-gray-500 hover:bg-gray-200'
+                      : 'bg-gray-100 dark:bg-gray-800 text-gray-500 dark:text-gray-400 dark:text-gray-500 hover:bg-gray-200 dark:bg-gray-700'
                   "
                   @click="handleToggleEnable(link)"
                 >
@@ -658,30 +658,30 @@ onMounted(fetchLinks)
                   {{ link.isEnable ? 'Enabled' : 'Disabled' }}
                 </button>
               </td>
-              <td class="hidden whitespace-nowrap px-4 py-3 text-gray-500 lg:table-cell">
+              <td class="hidden whitespace-nowrap px-4 py-3 text-gray-500 dark:text-gray-400 dark:text-gray-500 lg:table-cell">
                 {{ formatDate(link.createTime) }}
               </td>
-              <td class="hidden whitespace-nowrap px-4 py-3 text-gray-500 lg:table-cell">
+              <td class="hidden whitespace-nowrap px-4 py-3 text-gray-500 dark:text-gray-400 dark:text-gray-500 lg:table-cell">
                 {{ formatDate(link.updateTime) }}
               </td>
               <td class="px-4 py-3">
                 <div class="flex items-center justify-end gap-1">
                   <button
-                    class="rounded p-1.5 text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-600"
+                    class="rounded p-1.5 text-gray-400 dark:text-gray-500 transition-colors hover:bg-gray-100 dark:hover:bg-gray-800 dark:bg-gray-800 hover:text-gray-600 dark:text-gray-400 dark:text-gray-500 dark:hover:text-gray-300 dark:text-gray-600"
                     title="View details"
                     @click="router.push({ name: 'short-link-detail', params: { id: link.id } })"
                   >
                     <Eye class="h-4 w-4" />
                   </button>
                   <button
-                    class="rounded p-1.5 text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-600"
+                    class="rounded p-1.5 text-gray-400 dark:text-gray-500 transition-colors hover:bg-gray-100 dark:hover:bg-gray-800 dark:bg-gray-800 hover:text-gray-600 dark:text-gray-400 dark:text-gray-500 dark:hover:text-gray-300 dark:text-gray-600"
                     title="Edit"
                     @click="router.push({ name: 'short-link-edit', params: { id: link.id } })"
                   >
                     <Pencil class="h-4 w-4" />
                   </button>
                   <button
-                    class="rounded p-1.5 text-gray-400 transition-colors hover:bg-red-50 hover:text-red-600"
+                    class="rounded p-1.5 text-gray-400 dark:text-gray-500 transition-colors hover:bg-red-50 hover:text-red-600"
                     title="Delete"
                     @click="confirmDeleteId = link.id"
                   >
@@ -700,38 +700,38 @@ onMounted(fetchLinks)
         class="flex flex-col items-center justify-between gap-3 border-t px-4 py-3 sm:flex-row"
       >
         <div class="flex items-center gap-2">
-          <span class="text-sm text-gray-500">Show</span>
+          <span class="text-sm text-gray-500 dark:text-gray-400 dark:text-gray-500">Show</span>
           <select
             v-model="pageSize"
-            class="rounded-md border border-gray-300 px-2 py-1 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
+            class="rounded-md border border-gray-300 dark:border-gray-600 px-2 py-1 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
             @change="handlePageSizeChange"
           >
             <option v-for="size in pageSizeOptions" :key="size" :value="size">
               {{ size }}
             </option>
           </select>
-          <span class="text-sm text-gray-500">per page</span>
-          <span class="ml-2 text-sm text-gray-400">
+          <span class="text-sm text-gray-500 dark:text-gray-400 dark:text-gray-500">per page</span>
+          <span class="ml-2 text-sm text-gray-400 dark:text-gray-500">
             {{ (page - 1) * pageSize + 1 }}–{{ Math.min(page * pageSize, total) }} of {{ total }}
           </span>
         </div>
         <div v-if="totalPages > 1" class="flex items-center gap-1">
           <button
             :disabled="page <= 1"
-            class="rounded p-1.5 text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-600 disabled:opacity-30"
+            class="rounded p-1.5 text-gray-400 dark:text-gray-500 transition-colors hover:bg-gray-100 dark:hover:bg-gray-800 dark:bg-gray-800 hover:text-gray-600 dark:text-gray-400 dark:text-gray-500 dark:hover:text-gray-300 dark:text-gray-600 disabled:opacity-30"
             @click="goPage(page - 1)"
           >
             <ChevronLeft class="h-5 w-5" />
           </button>
           <template v-for="(p, idx) in pageNumbers" :key="`page-${idx}`">
-            <span v-if="p === '...'" class="px-1 text-sm text-gray-400">...</span>
+            <span v-if="p === '...'" class="px-1 text-sm text-gray-400 dark:text-gray-500">...</span>
             <button
               v-else
               :class="[
                 'min-w-[32px] rounded px-2 py-1 text-sm font-medium transition-colors',
                 p === page
                   ? 'bg-blue-600 text-white'
-                  : 'text-gray-600 hover:bg-gray-100',
+                  : 'text-gray-600 dark:text-gray-400 dark:text-gray-500 hover:bg-gray-100 dark:hover:bg-gray-800 dark:bg-gray-800',
               ]"
               @click="goPage(p as number)"
             >
@@ -740,19 +740,19 @@ onMounted(fetchLinks)
           </template>
           <button
             :disabled="page >= totalPages"
-            class="rounded p-1.5 text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-600 disabled:opacity-30"
+            class="rounded p-1.5 text-gray-400 dark:text-gray-500 transition-colors hover:bg-gray-100 dark:hover:bg-gray-800 dark:bg-gray-800 hover:text-gray-600 dark:text-gray-400 dark:text-gray-500 dark:hover:text-gray-300 dark:text-gray-600 disabled:opacity-30"
             @click="goPage(page + 1)"
           >
             <ChevronRight class="h-5 w-5" />
           </button>
           <div class="ml-2 flex items-center gap-1">
-            <span class="text-sm text-gray-400">Go to</span>
+            <span class="text-sm text-gray-400 dark:text-gray-500">Go to</span>
             <input
               v-model="pageJump"
               type="number"
               :min="1"
               :max="totalPages"
-              class="w-14 rounded-md border border-gray-300 px-2 py-1 text-center text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
+              class="w-14 rounded-md border border-gray-300 dark:border-gray-600 px-2 py-1 text-center text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
               @keyup.enter="handlePageJump"
             />
           </div>
@@ -769,9 +769,9 @@ onMounted(fetchLinks)
       @confirm="handleDelete(confirmDeleteId!)"
       @cancel="confirmDeleteId = null"
     >
-      <p class="mt-2 text-sm text-gray-500">
+      <p class="mt-2 text-sm text-gray-500 dark:text-gray-400 dark:text-gray-500">
         Are you sure you want to delete
-        <span class="font-mono font-medium text-gray-700">{{ confirmDeleteId }}</span
+        <span class="font-mono font-medium text-gray-700 dark:text-gray-300 dark:text-gray-600">{{ confirmDeleteId }}</span
         >? This action cannot be undone.
       </p>
     </ConfirmDialog>

--- a/web-ui/src/pages/TenantCreatePage.vue
+++ b/web-ui/src/pages/TenantCreatePage.vue
@@ -52,21 +52,21 @@ async function handleSubmit() {
   <div>
     <div class="flex items-center gap-3">
       <button
-        class="rounded p-1.5 text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-600"
+        class="rounded p-1.5 text-gray-400 dark:text-gray-500 transition-colors hover:bg-gray-100 dark:hover:bg-gray-800 dark:bg-gray-800 hover:text-gray-600 dark:text-gray-400 dark:text-gray-500 dark:hover:text-gray-300 dark:text-gray-600"
         @click="router.push({ name: 'tenants' })"
       >
         <ArrowLeft class="h-5 w-5" />
       </button>
       <div>
-        <h1 class="text-xl font-semibold text-gray-900">Create Tenant</h1>
-        <p class="mt-0.5 text-sm text-gray-500">Add a new tenant to the system.</p>
+        <h1 class="text-xl font-semibold text-gray-900 dark:text-white">Create Tenant</h1>
+        <p class="mt-0.5 text-sm text-gray-500 dark:text-gray-400 dark:text-gray-500">Add a new tenant to the system.</p>
       </div>
     </div>
 
-    <form class="mt-6 max-w-lg rounded-lg border bg-white p-6" @submit.prevent="handleSubmit">
+    <form class="mt-6 max-w-lg rounded-lg border bg-white dark:bg-gray-900 p-6" @submit.prevent="handleSubmit">
       <div class="space-y-5">
         <div>
-          <label class="mb-1 block text-sm font-medium text-gray-700">
+          <label class="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300 dark:text-gray-600">
             Name <span class="text-red-500">*</span>
           </label>
           <input
@@ -74,12 +74,12 @@ async function handleSubmit() {
             type="text"
             required
             placeholder="My Organization"
-            class="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
+            class="w-full rounded-md border border-gray-300 dark:border-gray-600 px-3 py-2 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
           />
         </div>
 
         <div>
-          <label class="mb-1 block text-sm font-medium text-gray-700">
+          <label class="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300 dark:text-gray-600">
             Slug <span class="text-red-500">*</span>
           </label>
           <input
@@ -87,11 +87,11 @@ async function handleSubmit() {
             type="text"
             required
             placeholder="my-organization"
-            class="w-full rounded-md border border-gray-300 px-3 py-2 font-mono text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
+            class="w-full rounded-md border border-gray-300 dark:border-gray-600 px-3 py-2 font-mono text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
             :class="slugError ? 'border-red-300 focus:border-red-500 focus:ring-red-500' : ''"
           />
           <p v-if="slugError" class="mt-1 text-xs text-red-600">{{ slugError }}</p>
-          <p v-else class="mt-1 text-xs text-gray-400">URL-friendly identifier (auto-generated from name).</p>
+          <p v-else class="mt-1 text-xs text-gray-400 dark:text-gray-500">URL-friendly identifier (auto-generated from name).</p>
         </div>
       </div>
 
@@ -107,7 +107,7 @@ async function handleSubmit() {
         </button>
         <button
           type="button"
-          class="rounded-md px-4 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-100"
+          class="rounded-md px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 dark:text-gray-600 transition-colors hover:bg-gray-100 dark:hover:bg-gray-800 dark:bg-gray-800"
           @click="router.push({ name: 'tenants' })"
         >
           Cancel

--- a/web-ui/src/pages/TenantDetailPage.vue
+++ b/web-ui/src/pages/TenantDetailPage.vue
@@ -134,24 +134,24 @@ onMounted(() => {
   <div>
     <div class="flex items-center gap-3">
       <button
-        class="rounded p-1.5 text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-600"
+        class="rounded p-1.5 text-gray-400 dark:text-gray-500 transition-colors hover:bg-gray-100 dark:hover:bg-gray-800 dark:bg-gray-800 hover:text-gray-600 dark:text-gray-400 dark:text-gray-500 dark:hover:text-gray-300 dark:text-gray-600"
         @click="router.push({ name: 'tenants' })"
       >
         <ArrowLeft class="h-5 w-5" />
       </button>
       <div class="flex-1">
-        <h1 class="text-xl font-semibold text-gray-900">Tenant Detail</h1>
-        <p v-if="tenant" class="mt-0.5 text-sm text-gray-500">
-          <span class="font-mono font-medium text-gray-700">{{ tenant.id }}</span>
+        <h1 class="text-xl font-semibold text-gray-900 dark:text-white">Tenant Detail</h1>
+        <p v-if="tenant" class="mt-0.5 text-sm text-gray-500 dark:text-gray-400 dark:text-gray-500">
+          <span class="font-mono font-medium text-gray-700 dark:text-gray-300 dark:text-gray-600">{{ tenant.id }}</span>
         </p>
       </div>
     </div>
 
-    <div v-if="loading" class="mt-6 text-center text-gray-400">
+    <div v-if="loading" class="mt-6 text-center text-gray-400 dark:text-gray-500">
       <Loader2 class="inline h-5 w-5 animate-spin" />
     </div>
 
-    <div v-else-if="notFound" class="mt-6 text-center text-gray-400">
+    <div v-else-if="notFound" class="mt-6 text-center text-gray-400 dark:text-gray-500">
       Tenant not found.
       <button
         class="ml-2 text-blue-600 hover:underline"
@@ -167,20 +167,20 @@ onMounted(() => {
 
     <template v-else-if="tenant">
       <!-- Basic info card -->
-      <div class="mt-4 rounded-lg border bg-white p-5">
-        <div class="flex items-center gap-3 border-b border-gray-100 pb-4">
+      <div class="mt-4 rounded-lg border bg-white dark:bg-gray-900 p-5">
+        <div class="flex items-center gap-3 border-b border-gray-100 dark:border-gray-800 pb-4">
           <div
             class="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-blue-50 text-sm font-bold text-blue-600"
           >
             {{ tenant.name.charAt(0).toUpperCase() }}
           </div>
           <div>
-            <h2 class="text-lg font-semibold text-gray-900">{{ tenant.name }}</h2>
-            <p class="text-sm text-gray-500">{{ tenant.slug }}</p>
+            <h2 class="text-lg font-semibold text-gray-900 dark:text-white">{{ tenant.name }}</h2>
+            <p class="text-sm text-gray-500 dark:text-gray-400 dark:text-gray-500">{{ tenant.slug }}</p>
           </div>
           <span
             class="ml-auto inline-flex items-center gap-1.5 rounded-full px-2.5 py-0.5 text-xs font-medium"
-            :class="tenant.isActive ? 'bg-green-50 text-green-700' : 'bg-gray-100 text-gray-500'"
+            :class="tenant.isActive ? 'bg-green-50 text-green-700' : 'bg-gray-100 dark:bg-gray-800 text-gray-500 dark:text-gray-400 dark:text-gray-500'"
           >
             <span
               class="h-1.5 w-1.5 rounded-full"
@@ -191,20 +191,20 @@ onMounted(() => {
         </div>
         <div class="mt-4 grid gap-4 sm:grid-cols-2">
           <div>
-            <label class="text-xs font-medium uppercase text-gray-400">Tenant ID</label>
-            <p class="mt-1 font-mono text-sm text-gray-900">{{ tenant.id }}</p>
+            <label class="text-xs font-medium uppercase text-gray-400 dark:text-gray-500">Tenant ID</label>
+            <p class="mt-1 font-mono text-sm text-gray-900 dark:text-white">{{ tenant.id }}</p>
           </div>
           <div>
-            <label class="text-xs font-medium uppercase text-gray-400">Slug</label>
-            <p class="mt-1 font-mono text-sm text-gray-900">{{ tenant.slug }}</p>
+            <label class="text-xs font-medium uppercase text-gray-400 dark:text-gray-500">Slug</label>
+            <p class="mt-1 font-mono text-sm text-gray-900 dark:text-white">{{ tenant.slug }}</p>
           </div>
           <div>
-            <label class="text-xs font-medium uppercase text-gray-400">Created</label>
-            <p class="mt-1 text-sm text-gray-700">{{ formatDate(tenant.createdAt) }}</p>
+            <label class="text-xs font-medium uppercase text-gray-400 dark:text-gray-500">Created</label>
+            <p class="mt-1 text-sm text-gray-700 dark:text-gray-300 dark:text-gray-600">{{ formatDate(tenant.createdAt) }}</p>
           </div>
           <div>
-            <label class="text-xs font-medium uppercase text-gray-400">Updated</label>
-            <p class="mt-1 text-sm text-gray-700">{{ formatDate(tenant.updatedAt) }}</p>
+            <label class="text-xs font-medium uppercase text-gray-400 dark:text-gray-500">Updated</label>
+            <p class="mt-1 text-sm text-gray-700 dark:text-gray-300 dark:text-gray-600">{{ formatDate(tenant.updatedAt) }}</p>
           </div>
         </div>
       </div>
@@ -213,33 +213,33 @@ onMounted(() => {
       <div class="mt-6">
         <div class="flex items-center justify-between">
           <div class="flex items-center gap-2">
-            <Globe class="h-5 w-5 text-gray-500" />
-            <h2 class="text-lg font-semibold text-gray-900">Domains</h2>
-            <span class="rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-600">
+            <Globe class="h-5 w-5 text-gray-500 dark:text-gray-400 dark:text-gray-500" />
+            <h2 class="text-lg font-semibold text-gray-900 dark:text-white">Domains</h2>
+            <span class="rounded-full bg-gray-100 dark:bg-gray-800 px-2 py-0.5 text-xs font-medium text-gray-600 dark:text-gray-400 dark:text-gray-500">
               {{ domains.length }}
             </span>
           </div>
         </div>
 
         <!-- Add domain form -->
-        <div class="mt-4 rounded-lg border bg-white p-4">
+        <div class="mt-4 rounded-lg border bg-white dark:bg-gray-900 p-4">
           <div class="flex flex-col gap-3 sm:flex-row sm:items-end">
             <div class="flex-1">
-              <label class="mb-1 block text-sm font-medium text-gray-700">Domain</label>
+              <label class="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300 dark:text-gray-600">Domain</label>
               <input
                 v-model="newDomain"
                 type="text"
                 placeholder="example.com"
-                class="w-full rounded-md border border-gray-300 px-3 py-2 font-mono text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
+                class="w-full rounded-md border border-gray-300 dark:border-gray-600 px-3 py-2 font-mono text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
                 @keydown.enter.prevent="handleAddDomain"
               />
             </div>
             <div class="flex items-center gap-3">
-              <label class="flex items-center gap-2 text-sm text-gray-700">
+              <label class="flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300 dark:text-gray-600">
                 <input
                   v-model="newDomainIsDefault"
                   type="checkbox"
-                  class="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+                  class="h-4 w-4 rounded border-gray-300 dark:border-gray-600 text-blue-600 focus:ring-blue-500"
                 />
                 Default
               </label>
@@ -257,14 +257,14 @@ onMounted(() => {
         </div>
 
         <!-- Domain list -->
-        <div v-if="domainsLoading" class="mt-4 flex items-center justify-center rounded-lg border bg-white py-8">
-          <Loader2 class="h-5 w-5 animate-spin text-gray-400" />
+        <div v-if="domainsLoading" class="mt-4 flex items-center justify-center rounded-lg border bg-white dark:bg-gray-900 py-8">
+          <Loader2 class="h-5 w-5 animate-spin text-gray-400 dark:text-gray-500" />
         </div>
-        <div v-else-if="domains.length > 0" class="mt-4 overflow-hidden rounded-lg border bg-white">
+        <div v-else-if="domains.length > 0" class="mt-4 overflow-hidden rounded-lg border bg-white dark:bg-gray-900 dark:bg-gray-900">
           <table class="w-full text-sm">
             <thead>
               <tr
-                class="border-b bg-gray-50 text-left text-xs font-medium uppercase tracking-wider text-gray-500"
+                class="border-b bg-gray-50 dark:bg-gray-800/50 text-left text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400 dark:text-gray-500"
               >
                 <th class="px-4 py-3">Domain</th>
                 <th class="px-4 py-3">Default</th>
@@ -276,12 +276,12 @@ onMounted(() => {
               <tr
                 v-for="d in domains"
                 :key="d.id"
-                class="transition-colors hover:bg-gray-50"
+                class="transition-colors hover:bg-gray-50 dark:hover:bg-gray-700 dark:bg-gray-800/50"
               >
                 <td class="px-4 py-3">
                   <div class="flex items-center gap-2">
-                    <Globe class="h-4 w-4 text-gray-400" />
-                    <span class="font-mono text-sm text-gray-900">{{ d.domain }}</span>
+                    <Globe class="h-4 w-4 text-gray-400 dark:text-gray-500" />
+                    <span class="font-mono text-sm text-gray-900 dark:text-white">{{ d.domain }}</span>
                   </div>
                 </td>
                 <td class="px-4 py-3">
@@ -289,9 +289,9 @@ onMounted(() => {
                     <Star class="h-3.5 w-3.5 fill-yellow-500 text-yellow-500" />
                     Default
                   </span>
-                  <span v-else class="text-xs text-gray-400">—</span>
+                  <span v-else class="text-xs text-gray-400 dark:text-gray-500">—</span>
                 </td>
-                <td class="hidden whitespace-nowrap px-4 py-3 text-gray-500 lg:table-cell">
+                <td class="hidden whitespace-nowrap px-4 py-3 text-gray-500 dark:text-gray-400 dark:text-gray-500 lg:table-cell">
                   {{ formatDate(d.createdAt) }}
                 </td>
                 <td class="px-4 py-3">
@@ -300,13 +300,13 @@ onMounted(() => {
                       :href="'https://' + d.domain"
                       target="_blank"
                       rel="noopener noreferrer"
-                      class="rounded p-1.5 text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-600"
+                      class="rounded p-1.5 text-gray-400 dark:text-gray-500 transition-colors hover:bg-gray-100 dark:hover:bg-gray-800 dark:bg-gray-800 hover:text-gray-600 dark:text-gray-400 dark:text-gray-500 dark:hover:text-gray-300 dark:text-gray-600"
                       title="Open domain"
                     >
                       <ExternalLink class="h-4 w-4" />
                     </a>
                     <button
-                      class="rounded p-1.5 text-gray-400 transition-colors hover:bg-red-50 hover:text-red-600"
+                      class="rounded p-1.5 text-gray-400 dark:text-gray-500 transition-colors hover:bg-red-50 hover:text-red-600"
                       title="Remove domain"
                       @click="confirmDeleteDomain = d.domain"
                     >
@@ -318,7 +318,7 @@ onMounted(() => {
             </tbody>
           </table>
         </div>
-        <div v-else class="mt-4 rounded-lg border bg-white py-8 text-center text-sm text-gray-400">
+        <div v-else class="mt-4 rounded-lg border bg-white dark:bg-gray-900 py-8 text-center text-sm text-gray-400 dark:text-gray-500">
           No domains configured for this tenant.
         </div>
       </div>
@@ -337,17 +337,17 @@ onMounted(() => {
           aria-modal="true"
           aria-labelledby="remove-domain-title"
           tabindex="-1"
-          class="mx-4 w-full max-w-sm rounded-lg bg-white p-6 shadow-xl"
+          class="mx-4 w-full max-w-sm rounded-lg bg-white dark:bg-gray-900 p-6 shadow-xl"
         >
-          <h3 id="remove-domain-title" class="text-lg font-semibold text-gray-900">Remove Domain</h3>
-          <p class="mt-2 text-sm text-gray-500">
+          <h3 id="remove-domain-title" class="text-lg font-semibold text-gray-900 dark:text-white">Remove Domain</h3>
+          <p class="mt-2 text-sm text-gray-500 dark:text-gray-400 dark:text-gray-500">
             Are you sure you want to remove
-            <span class="font-mono font-medium text-gray-700">{{ confirmDeleteDomain }}</span
+            <span class="font-mono font-medium text-gray-700 dark:text-gray-300 dark:text-gray-600">{{ confirmDeleteDomain }}</span
             >? This action cannot be undone.
           </p>
           <div class="mt-4 flex justify-end gap-2">
             <button
-              class="rounded-md px-4 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-100"
+              class="rounded-md px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 dark:text-gray-600 transition-colors hover:bg-gray-100 dark:hover:bg-gray-800 dark:bg-gray-800"
               @click="confirmDeleteDomain = null"
             >
               Cancel

--- a/web-ui/src/pages/TenantsPage.vue
+++ b/web-ui/src/pages/TenantsPage.vue
@@ -53,8 +53,8 @@ onMounted(fetchTenants)
   <div>
     <div class="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
       <div>
-        <h1 class="text-xl font-semibold text-gray-900">Tenant Management</h1>
-        <p class="mt-1 text-sm text-gray-500">
+        <h1 class="text-xl font-semibold text-gray-900 dark:text-white">Tenant Management</h1>
+        <p class="mt-1 text-sm text-gray-500 dark:text-gray-400 dark:text-gray-500">
           {{ tenants.length }} tenant{{ tenants.length !== 1 ? 's' : '' }} total
         </p>
       </div>
@@ -68,25 +68,25 @@ onMounted(fetchTenants)
     </div>
 
     <!-- Search -->
-    <div class="mt-4 flex flex-col gap-3 rounded-lg border bg-white p-4 sm:flex-row sm:items-center">
+    <div class="mt-4 flex flex-col gap-3 rounded-lg border bg-white dark:bg-gray-900 p-4 sm:flex-row sm:items-center">
       <div class="relative flex-1">
-        <Search class="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400" />
+        <Search class="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400 dark:text-gray-500" />
         <input
           v-model="search"
           type="text"
           placeholder="Search by name, slug, or ID..."
-          class="w-full rounded-md border border-gray-300 py-2 pl-9 pr-3 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
+          class="w-full rounded-md border border-gray-300 dark:border-gray-600 py-2 pl-9 pr-3 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
         />
       </div>
     </div>
 
     <!-- Table -->
-    <div class="mt-4 overflow-hidden rounded-lg border bg-white">
+    <div class="mt-4 overflow-hidden rounded-lg border bg-white dark:bg-gray-900 dark:bg-gray-900">
       <div class="overflow-x-auto">
         <table class="w-full text-sm">
           <thead>
             <tr
-              class="border-b bg-gray-50 text-left text-xs font-medium uppercase tracking-wider text-gray-500"
+              class="border-b bg-gray-50 dark:bg-gray-800/50 text-left text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400 dark:text-gray-500"
             >
               <th class="px-4 py-3">Name</th>
               <th class="px-4 py-3">Slug</th>
@@ -97,12 +97,12 @@ onMounted(fetchTenants)
           </thead>
           <tbody class="divide-y">
             <tr v-if="loading">
-              <td colspan="5" class="px-4 py-8 text-center text-gray-400">Loading...</td>
+              <td colspan="5" class="px-4 py-8 text-center text-gray-400 dark:text-gray-500">Loading...</td>
             </tr>
             <tr v-else-if="filteredTenants.length === 0">
-              <td colspan="5" class="px-4 py-8 text-center text-gray-400">
+              <td colspan="5" class="px-4 py-8 text-center text-gray-400 dark:text-gray-500">
                 <div class="flex flex-col items-center gap-2">
-                  <Building2 class="h-8 w-8 text-gray-300" />
+                  <Building2 class="h-8 w-8 text-gray-300 dark:text-gray-600" />
                   <span>No tenants found.</span>
                 </div>
               </td>
@@ -110,7 +110,7 @@ onMounted(fetchTenants)
             <tr
               v-for="tenant in filteredTenants"
               :key="tenant.id"
-              class="transition-colors hover:bg-gray-50"
+              class="transition-colors hover:bg-gray-50 dark:hover:bg-gray-700 dark:bg-gray-800/50"
             >
               <td class="px-4 py-3">
                 <div class="flex items-center gap-2">
@@ -120,13 +120,13 @@ onMounted(fetchTenants)
                     {{ tenant.name.charAt(0).toUpperCase() }}
                   </div>
                   <div>
-                    <p class="font-medium text-gray-900">{{ tenant.name }}</p>
-                    <p class="text-xs text-gray-400">{{ tenant.id }}</p>
+                    <p class="font-medium text-gray-900 dark:text-white">{{ tenant.name }}</p>
+                    <p class="text-xs text-gray-400 dark:text-gray-500">{{ tenant.id }}</p>
                   </div>
                 </div>
               </td>
               <td class="px-4 py-3">
-                <span class="font-mono text-sm text-gray-600">{{ tenant.slug }}</span>
+                <span class="font-mono text-sm text-gray-600 dark:text-gray-400 dark:text-gray-500">{{ tenant.slug }}</span>
               </td>
               <td class="px-4 py-3">
                 <span
@@ -134,7 +134,7 @@ onMounted(fetchTenants)
                   :class="
                     tenant.isActive
                       ? 'bg-green-50 text-green-700'
-                      : 'bg-gray-100 text-gray-500'
+                      : 'bg-gray-100 dark:bg-gray-800 text-gray-500 dark:text-gray-400 dark:text-gray-500'
                   "
                 >
                   <span
@@ -144,13 +144,13 @@ onMounted(fetchTenants)
                   {{ tenant.isActive ? 'Active' : 'Inactive' }}
                 </span>
               </td>
-              <td class="hidden whitespace-nowrap px-4 py-3 text-gray-500 lg:table-cell">
+              <td class="hidden whitespace-nowrap px-4 py-3 text-gray-500 dark:text-gray-400 dark:text-gray-500 lg:table-cell">
                 {{ formatDate(tenant.createdAt) }}
               </td>
               <td class="px-4 py-3">
                 <div class="flex items-center justify-end gap-1">
                   <button
-                    class="rounded p-1.5 text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-600"
+                    class="rounded p-1.5 text-gray-400 dark:text-gray-500 transition-colors hover:bg-gray-100 dark:hover:bg-gray-800 dark:bg-gray-800 hover:text-gray-600 dark:text-gray-400 dark:text-gray-500 dark:hover:text-gray-300 dark:text-gray-600"
                     title="View details"
                     @click="router.push({ name: 'tenant-detail', params: { id: tenant.id } })"
                   >

--- a/web-ui/src/pages/super/SuperDashboardPage.vue
+++ b/web-ui/src/pages/super/SuperDashboardPage.vue
@@ -44,17 +44,17 @@ onMounted(fetchDashboardData)
 <template>
   <div class="space-y-6">
     <div>
-      <h1 class="text-2xl font-bold text-gray-900">Super Admin Dashboard</h1>
-      <p class="mt-1 text-sm text-gray-500">Platform overview and statistics.</p>
+      <h1 class="text-2xl font-bold text-gray-900 dark:text-white">Super Admin Dashboard</h1>
+      <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">Platform overview and statistics.</p>
     </div>
 
     <div class="grid grid-cols-1 gap-4 sm:grid-cols-2">
-      <div class="rounded-xl border border-gray-200 bg-white p-5 shadow-sm">
+      <div class="rounded-xl border border-gray-200 bg-white p-5 shadow-sm dark:border-gray-700 dark:bg-gray-900">
         <div class="flex items-center justify-between">
           <div>
-            <p class="text-sm font-medium text-gray-500">Total Tenants</p>
-            <p class="mt-1 text-2xl font-bold text-gray-900">
-              <span v-if="loading" class="inline-block h-7 w-16 animate-pulse rounded bg-gray-200" />
+            <p class="text-sm font-medium text-gray-500 dark:text-gray-400">Total Tenants</p>
+            <p class="mt-1 text-2xl font-bold text-gray-900 dark:text-white">
+              <span v-if="loading" class="inline-block h-7 w-16 animate-pulse rounded bg-gray-200 dark:bg-gray-700" />
               <template v-else>{{ totalTenants.toLocaleString() }}</template>
             </p>
           </div>
@@ -64,12 +64,12 @@ onMounted(fetchDashboardData)
         </div>
       </div>
 
-      <div class="rounded-xl border border-gray-200 bg-white p-5 shadow-sm">
+      <div class="rounded-xl border border-gray-200 bg-white p-5 shadow-sm dark:border-gray-700 dark:bg-gray-900">
         <div class="flex items-center justify-between">
           <div>
-            <p class="text-sm font-medium text-gray-500">Total Users</p>
-            <p class="mt-1 text-2xl font-bold text-gray-900">
-              <span v-if="loading" class="inline-block h-7 w-16 animate-pulse rounded bg-gray-200" />
+            <p class="text-sm font-medium text-gray-500 dark:text-gray-400">Total Users</p>
+            <p class="mt-1 text-2xl font-bold text-gray-900 dark:text-white">
+              <span v-if="loading" class="inline-block h-7 w-16 animate-pulse rounded bg-gray-200 dark:bg-gray-700" />
               <template v-else>{{ totalUsers.toLocaleString() }}</template>
             </p>
           </div>
@@ -80,11 +80,11 @@ onMounted(fetchDashboardData)
       </div>
     </div>
 
-    <div class="rounded-xl border border-gray-200 bg-white shadow-sm">
-      <div class="flex items-center justify-between border-b border-gray-100 px-5 py-4">
+    <div class="rounded-xl border border-gray-200 bg-white shadow-sm dark:border-gray-700 dark:bg-gray-900">
+      <div class="flex items-center justify-between border-b border-gray-100 px-5 py-4 dark:border-gray-800">
         <div class="flex items-center gap-2">
-          <Building2 class="h-4 w-4 text-gray-500" />
-          <h2 class="text-base font-semibold text-gray-900">Tenants</h2>
+          <Building2 class="h-4 w-4 text-gray-500 dark:text-gray-400" />
+          <h2 class="text-base font-semibold text-gray-900 dark:text-white">Tenants</h2>
         </div>
         <router-link
           :to="{ name: 'super-tenants' }"
@@ -97,9 +97,9 @@ onMounted(fetchDashboardData)
         <Loader2 class="h-5 w-5 animate-spin text-gray-400" />
       </div>
       <div v-else-if="recentTenants.length === 0" class="px-5 py-12 text-center">
-        <Building2 class="mx-auto h-10 w-10 text-gray-300" />
-        <p class="mt-3 text-sm font-medium text-gray-500">No tenants yet</p>
-        <p class="mt-1 text-sm text-gray-400">Tenants will appear here once created.</p>
+        <Building2 class="mx-auto h-10 w-10 text-gray-300 dark:text-gray-600" />
+        <p class="mt-3 text-sm font-medium text-gray-500 dark:text-gray-400">No tenants yet</p>
+        <p class="mt-1 text-sm text-gray-400 dark:text-gray-500">Tenants will appear here once created.</p>
         <router-link
           :to="{ name: 'super-tenants' }"
           class="mt-3 inline-flex items-center gap-1.5 rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-blue-700"

--- a/web-ui/src/pages/super/SuperTenantDetailPage.vue
+++ b/web-ui/src/pages/super/SuperTenantDetailPage.vue
@@ -167,37 +167,37 @@ onMounted(fetchTenant)
   <div>
     <div class="flex items-center gap-3">
       <button
-        class="rounded p-1.5 text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-600"
+        class="rounded p-1.5 text-gray-400 dark:text-gray-500 transition-colors hover:bg-gray-100 dark:hover:bg-gray-800 dark:bg-gray-800 hover:text-gray-600 dark:text-gray-400 dark:text-gray-500 dark:hover:text-gray-300 dark:text-gray-600"
         @click="router.push({ name: 'super-tenants' })"
       >
         <ArrowLeft class="h-5 w-5" />
       </button>
       <div class="flex-1">
-        <h1 class="text-xl font-semibold text-gray-900">Tenant Detail</h1>
-        <p v-if="tenant" class="mt-0.5 text-sm text-gray-500">
-          <span class="font-mono font-medium text-gray-700">{{ tenant.id }}</span>
+        <h1 class="text-xl font-semibold text-gray-900 dark:text-white">Tenant Detail</h1>
+        <p v-if="tenant" class="mt-0.5 text-sm text-gray-500 dark:text-gray-400 dark:text-gray-500">
+          <span class="font-mono font-medium text-gray-700 dark:text-gray-300 dark:text-gray-600">{{ tenant.id }}</span>
         </p>
       </div>
     </div>
 
     <div v-if="loading" class="mt-6 space-y-4">
-      <div class="rounded-lg border bg-white p-5">
+      <div class="rounded-lg border bg-white dark:bg-gray-900 p-5">
         <div class="flex items-center gap-3">
-          <div class="h-10 w-10 animate-pulse rounded-lg bg-gray-200" />
+          <div class="h-10 w-10 animate-pulse rounded-lg bg-gray-200 dark:bg-gray-700" />
           <div class="flex-1">
-            <div class="h-5 w-40 animate-pulse rounded bg-gray-200" />
-            <div class="mt-2 h-4 w-24 animate-pulse rounded bg-gray-200" />
+            <div class="h-5 w-40 animate-pulse rounded bg-gray-200 dark:bg-gray-700" />
+            <div class="mt-2 h-4 w-24 animate-pulse rounded bg-gray-200 dark:bg-gray-700" />
           </div>
         </div>
         <div class="mt-4 grid gap-4 sm:grid-cols-3">
-          <div class="h-10 animate-pulse rounded bg-gray-100" />
-          <div class="h-10 animate-pulse rounded bg-gray-100" />
-          <div class="h-10 animate-pulse rounded bg-gray-100" />
+          <div class="h-10 animate-pulse rounded bg-gray-100 dark:bg-gray-800" />
+          <div class="h-10 animate-pulse rounded bg-gray-100 dark:bg-gray-800" />
+          <div class="h-10 animate-pulse rounded bg-gray-100 dark:bg-gray-800" />
         </div>
       </div>
     </div>
 
-    <div v-else-if="notFound" class="mt-6 text-center text-gray-400">
+    <div v-else-if="notFound" class="mt-6 text-center text-gray-400 dark:text-gray-500">
       Tenant not found.
       <button class="ml-2 text-blue-600 hover:underline" @click="router.push({ name: 'super-tenants' })">
         Back to list
@@ -210,7 +210,7 @@ onMounted(fetchTenant)
 
     <template v-else-if="tenant">
       <!-- Tenant header card -->
-      <div class="mt-4 rounded-lg border bg-white p-5">
+      <div class="mt-4 rounded-lg border bg-white dark:bg-gray-900 p-5">
         <div class="flex items-center gap-3">
           <div
             class="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-blue-50 text-sm font-bold text-blue-600"
@@ -218,12 +218,12 @@ onMounted(fetchTenant)
             {{ tenant.name.charAt(0).toUpperCase() }}
           </div>
           <div>
-            <h2 class="text-lg font-semibold text-gray-900">{{ tenant.name }}</h2>
-            <p class="text-sm text-gray-500">{{ tenant.slug }}</p>
+            <h2 class="text-lg font-semibold text-gray-900 dark:text-white">{{ tenant.name }}</h2>
+            <p class="text-sm text-gray-500 dark:text-gray-400 dark:text-gray-500">{{ tenant.slug }}</p>
           </div>
           <span
             class="ml-auto inline-flex items-center gap-1.5 rounded-full px-2.5 py-0.5 text-xs font-medium"
-            :class="tenant.isActive ? 'bg-green-50 text-green-700' : 'bg-gray-100 text-gray-500'"
+            :class="tenant.isActive ? 'bg-green-50 text-green-700' : 'bg-gray-100 dark:bg-gray-800 text-gray-500 dark:text-gray-400 dark:text-gray-500'"
           >
             <span class="h-1.5 w-1.5 rounded-full" :class="tenant.isActive ? 'bg-green-500' : 'bg-gray-400'" />
             {{ tenant.isActive ? 'Active' : 'Inactive' }}
@@ -242,16 +242,16 @@ onMounted(fetchTenant)
         </div>
         <div class="mt-4 grid gap-4 sm:grid-cols-3">
           <div>
-            <label class="text-xs font-medium uppercase text-gray-400">Tenant ID</label>
-            <p class="mt-1 font-mono text-sm text-gray-900">{{ tenant.id }}</p>
+            <label class="text-xs font-medium uppercase text-gray-400 dark:text-gray-500">Tenant ID</label>
+            <p class="mt-1 font-mono text-sm text-gray-900 dark:text-white">{{ tenant.id }}</p>
           </div>
           <div>
-            <label class="text-xs font-medium uppercase text-gray-400">Created</label>
-            <p class="mt-1 text-sm text-gray-700">{{ formatDate(tenant.createdAt) }}</p>
+            <label class="text-xs font-medium uppercase text-gray-400 dark:text-gray-500">Created</label>
+            <p class="mt-1 text-sm text-gray-700 dark:text-gray-300 dark:text-gray-600">{{ formatDate(tenant.createdAt) }}</p>
           </div>
           <div>
-            <label class="text-xs font-medium uppercase text-gray-400">Updated</label>
-            <p class="mt-1 text-sm text-gray-700">{{ formatDate(tenant.updatedAt) }}</p>
+            <label class="text-xs font-medium uppercase text-gray-400 dark:text-gray-500">Updated</label>
+            <p class="mt-1 text-sm text-gray-700 dark:text-gray-300 dark:text-gray-600">{{ formatDate(tenant.updatedAt) }}</p>
           </div>
         </div>
       </div>
@@ -265,7 +265,7 @@ onMounted(fetchTenant)
             class="whitespace-nowrap border-b-2 pb-3 pt-2 text-sm font-medium transition-colors"
             :class="activeTab === tab
               ? 'border-blue-600 text-blue-600'
-              : 'border-transparent text-gray-500 hover:text-gray-700'"
+              : 'border-transparent text-gray-500 dark:text-gray-400 dark:text-gray-500 hover:text-gray-700 dark:hover:text-gray-200 dark:text-gray-300 dark:text-gray-600'"
             @click="onTabChange(tab)"
           >
             {{ tab === 'short-links' ? 'Short Links' : tab.charAt(0).toUpperCase() + tab.slice(1) }}
@@ -276,28 +276,28 @@ onMounted(fetchTenant)
       <!-- Tab content -->
       <div class="mt-4">
         <!-- Info tab -->
-        <div v-if="activeTab === 'info'" class="rounded-lg border bg-white p-5">
+        <div v-if="activeTab === 'info'" class="rounded-lg border bg-white dark:bg-gray-900 p-5">
           <div class="grid gap-4 sm:grid-cols-2">
             <div>
-              <label class="text-xs font-medium uppercase text-gray-400">Name</label>
-              <p class="mt-1 text-sm text-gray-900">{{ tenant.name }}</p>
+              <label class="text-xs font-medium uppercase text-gray-400 dark:text-gray-500">Name</label>
+              <p class="mt-1 text-sm text-gray-900 dark:text-white">{{ tenant.name }}</p>
             </div>
             <div>
-              <label class="text-xs font-medium uppercase text-gray-400">Slug</label>
-              <p class="mt-1 font-mono text-sm text-gray-900">{{ tenant.slug }}</p>
+              <label class="text-xs font-medium uppercase text-gray-400 dark:text-gray-500">Slug</label>
+              <p class="mt-1 font-mono text-sm text-gray-900 dark:text-white">{{ tenant.slug }}</p>
             </div>
           </div>
         </div>
 
         <!-- Members tab -->
         <div v-if="activeTab === 'members'">
-          <div v-if="membersLoading" class="flex items-center justify-center rounded-lg border bg-white py-8">
-            <Loader2 class="h-5 w-5 animate-spin text-gray-400" />
+          <div v-if="membersLoading" class="flex items-center justify-center rounded-lg border bg-white dark:bg-gray-900 py-8">
+            <Loader2 class="h-5 w-5 animate-spin text-gray-400 dark:text-gray-500" />
           </div>
-          <div v-else class="overflow-hidden rounded-lg border bg-white">
+          <div v-else class="overflow-hidden rounded-lg border bg-white dark:bg-gray-900 dark:bg-gray-900">
             <table class="w-full text-sm">
               <thead>
-                <tr class="border-b bg-gray-50 text-left text-xs font-medium uppercase tracking-wider text-gray-500">
+                <tr class="border-b bg-gray-50 dark:bg-gray-800/50 text-left text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400 dark:text-gray-500">
                   <th class="px-4 py-3">Username</th>
                   <th class="px-4 py-3">Role</th>
                   <th class="hidden px-4 py-3 lg:table-cell">Joined</th>
@@ -305,26 +305,26 @@ onMounted(fetchTenant)
               </thead>
               <tbody class="divide-y">
                 <tr v-if="members.length === 0">
-                  <td colspan="3" class="px-4 py-8 text-center text-gray-400">No members in this tenant.</td>
+                  <td colspan="3" class="px-4 py-8 text-center text-gray-400 dark:text-gray-500">No members in this tenant.</td>
                 </tr>
-                <tr v-for="m in members" :key="m.userId" class="transition-colors hover:bg-gray-50">
+                <tr v-for="m in members" :key="m.userId" class="transition-colors hover:bg-gray-50 dark:hover:bg-gray-700 dark:bg-gray-800/50">
                   <td class="px-4 py-3">
                     <div class="flex items-center gap-2">
-                      <div class="flex h-7 w-7 items-center justify-center rounded-full bg-gray-100 text-xs font-bold text-gray-600">
+                      <div class="flex h-7 w-7 items-center justify-center rounded-full bg-gray-100 dark:bg-gray-800 text-xs font-bold text-gray-600 dark:text-gray-400 dark:text-gray-500">
                         {{ m.username.charAt(0).toUpperCase() }}
                       </div>
-                      <span class="font-medium text-gray-900">{{ m.username }}</span>
+                      <span class="font-medium text-gray-900 dark:text-white">{{ m.username }}</span>
                     </div>
                   </td>
                   <td class="px-4 py-3">
                     <span
                       class="inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium"
-                      :class="m.role === 'admin' ? 'bg-blue-50 text-blue-700' : 'bg-gray-100 text-gray-600'"
+                      :class="m.role === 'admin' ? 'bg-blue-50 text-blue-700' : 'bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-400 dark:text-gray-500'"
                     >
                       {{ m.role }}
                     </span>
                   </td>
-                  <td class="hidden whitespace-nowrap px-4 py-3 text-gray-500 lg:table-cell">
+                  <td class="hidden whitespace-nowrap px-4 py-3 text-gray-500 dark:text-gray-400 dark:text-gray-500 lg:table-cell">
                     {{ formatDate(m.joinedAt) }}
                   </td>
                 </tr>
@@ -335,13 +335,13 @@ onMounted(fetchTenant)
 
         <!-- Short Links tab -->
         <div v-if="activeTab === 'short-links'">
-          <div v-if="shortLinksLoading" class="flex items-center justify-center rounded-lg border bg-white py-8">
-            <Loader2 class="h-5 w-5 animate-spin text-gray-400" />
+          <div v-if="shortLinksLoading" class="flex items-center justify-center rounded-lg border bg-white dark:bg-gray-900 py-8">
+            <Loader2 class="h-5 w-5 animate-spin text-gray-400 dark:text-gray-500" />
           </div>
-          <div v-else class="overflow-hidden rounded-lg border bg-white">
+          <div v-else class="overflow-hidden rounded-lg border bg-white dark:bg-gray-900 dark:bg-gray-900">
             <table class="w-full text-sm">
               <thead>
-                <tr class="border-b bg-gray-50 text-left text-xs font-medium uppercase tracking-wider text-gray-500">
+                <tr class="border-b bg-gray-50 dark:bg-gray-800/50 text-left text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400 dark:text-gray-500">
                   <th class="px-4 py-3">ID</th>
                   <th class="hidden px-4 py-3 md:table-cell">URL</th>
                   <th class="px-4 py-3">Status</th>
@@ -351,26 +351,26 @@ onMounted(fetchTenant)
               </thead>
               <tbody class="divide-y">
                 <tr v-if="shortLinks.length === 0">
-                  <td colspan="5" class="px-4 py-8 text-center text-gray-400">No short links in this tenant.</td>
+                  <td colspan="5" class="px-4 py-8 text-center text-gray-400 dark:text-gray-500">No short links in this tenant.</td>
                 </tr>
-                <tr v-for="sl in shortLinks" :key="sl.id" class="transition-colors hover:bg-gray-50">
-                  <td class="px-4 py-3 font-mono text-sm font-medium text-gray-900">{{ sl.id }}</td>
-                  <td class="hidden max-w-[240px] truncate px-4 py-3 text-gray-500 md:table-cell">{{ sl.url }}</td>
+                <tr v-for="sl in shortLinks" :key="sl.id" class="transition-colors hover:bg-gray-50 dark:hover:bg-gray-700 dark:bg-gray-800/50">
+                  <td class="px-4 py-3 font-mono text-sm font-medium text-gray-900 dark:text-white">{{ sl.id }}</td>
+                  <td class="hidden max-w-[240px] truncate px-4 py-3 text-gray-500 dark:text-gray-400 dark:text-gray-500 md:table-cell">{{ sl.url }}</td>
                   <td class="px-4 py-3">
                     <span
                       class="inline-flex items-center gap-1.5 rounded-full px-2 py-0.5 text-xs font-medium"
-                      :class="sl.isEnable ? 'bg-green-50 text-green-700' : 'bg-gray-100 text-gray-500'"
+                      :class="sl.isEnable ? 'bg-green-50 text-green-700' : 'bg-gray-100 dark:bg-gray-800 text-gray-500 dark:text-gray-400 dark:text-gray-500'"
                     >
                       <span class="h-1.5 w-1.5 rounded-full" :class="sl.isEnable ? 'bg-green-500' : 'bg-gray-400'" />
                       {{ sl.isEnable ? 'Active' : 'Inactive' }}
                     </span>
                   </td>
-                  <td class="hidden px-4 py-3 text-gray-500 lg:table-cell">{{ sl.createdBy }}</td>
-                  <td class="hidden whitespace-nowrap px-4 py-3 text-gray-500 lg:table-cell">{{ formatDate(sl.createTime) }}</td>
+                  <td class="hidden px-4 py-3 text-gray-500 dark:text-gray-400 dark:text-gray-500 lg:table-cell">{{ sl.createdBy }}</td>
+                  <td class="hidden whitespace-nowrap px-4 py-3 text-gray-500 dark:text-gray-400 dark:text-gray-500 lg:table-cell">{{ formatDate(sl.createTime) }}</td>
                 </tr>
               </tbody>
             </table>
-            <div v-if="shortLinksTotal > 20" class="border-t px-4 py-3 text-center text-xs text-gray-400">
+            <div v-if="shortLinksTotal > 20" class="border-t px-4 py-3 text-center text-xs text-gray-400 dark:text-gray-500">
               Showing 20 of {{ shortLinksTotal }}
             </div>
           </div>
@@ -379,15 +379,15 @@ onMounted(fetchTenant)
         <!-- Domains tab -->
         <div v-if="activeTab === 'domains'">
           <!-- Add domain -->
-          <div class="mb-4 rounded-lg border bg-white p-4">
+          <div class="mb-4 rounded-lg border bg-white dark:bg-gray-900 p-4">
             <div class="flex flex-col gap-3 sm:flex-row sm:items-end">
               <div class="flex-1">
-                <label class="mb-1 block text-sm font-medium text-gray-700">Domain</label>
+                <label class="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300 dark:text-gray-600">Domain</label>
                 <input
                   v-model="newDomain"
                   type="text"
                   placeholder="example.com"
-                  class="w-full rounded-md border border-gray-300 px-3 py-2 font-mono text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
+                  class="w-full rounded-md border border-gray-300 dark:border-gray-600 px-3 py-2 font-mono text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
                   @keydown.enter.prevent="handleAddDomain"
                 />
               </div>
@@ -403,13 +403,13 @@ onMounted(fetchTenant)
             </div>
           </div>
 
-          <div v-if="domainsLoading" class="flex items-center justify-center rounded-lg border bg-white py-8">
-            <Loader2 class="h-5 w-5 animate-spin text-gray-400" />
+          <div v-if="domainsLoading" class="flex items-center justify-center rounded-lg border bg-white dark:bg-gray-900 py-8">
+            <Loader2 class="h-5 w-5 animate-spin text-gray-400 dark:text-gray-500" />
           </div>
-          <div v-else-if="domains.length > 0" class="overflow-hidden rounded-lg border bg-white">
+          <div v-else-if="domains.length > 0" class="overflow-hidden rounded-lg border bg-white dark:bg-gray-900 dark:bg-gray-900">
             <table class="w-full text-sm">
               <thead>
-                <tr class="border-b bg-gray-50 text-left text-xs font-medium uppercase tracking-wider text-gray-500">
+                <tr class="border-b bg-gray-50 dark:bg-gray-800/50 text-left text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400 dark:text-gray-500">
                   <th class="px-4 py-3">Domain</th>
                   <th class="px-4 py-3">Default</th>
                   <th class="hidden px-4 py-3 lg:table-cell">Created</th>
@@ -417,11 +417,11 @@ onMounted(fetchTenant)
                 </tr>
               </thead>
               <tbody class="divide-y">
-                <tr v-for="d in domains" :key="d.id" class="transition-colors hover:bg-gray-50">
+                <tr v-for="d in domains" :key="d.id" class="transition-colors hover:bg-gray-50 dark:hover:bg-gray-700 dark:bg-gray-800/50">
                   <td class="px-4 py-3">
                     <div class="flex items-center gap-2">
-                      <Globe class="h-4 w-4 text-gray-400" />
-                      <span class="font-mono text-sm text-gray-900">{{ d.domain }}</span>
+                      <Globe class="h-4 w-4 text-gray-400 dark:text-gray-500" />
+                      <span class="font-mono text-sm text-gray-900 dark:text-white">{{ d.domain }}</span>
                     </div>
                   </td>
                   <td class="px-4 py-3">
@@ -429,21 +429,21 @@ onMounted(fetchTenant)
                       <Star class="h-3.5 w-3.5 fill-yellow-500 text-yellow-500" />
                       Default
                     </span>
-                    <span v-else class="text-xs text-gray-400">-</span>
+                    <span v-else class="text-xs text-gray-400 dark:text-gray-500">-</span>
                   </td>
-                  <td class="hidden whitespace-nowrap px-4 py-3 text-gray-500 lg:table-cell">{{ formatDate(d.createdAt) }}</td>
+                  <td class="hidden whitespace-nowrap px-4 py-3 text-gray-500 dark:text-gray-400 dark:text-gray-500 lg:table-cell">{{ formatDate(d.createdAt) }}</td>
                   <td class="px-4 py-3">
                     <div class="flex items-center justify-end gap-1">
                       <a
                         :href="'https://' + d.domain"
                         target="_blank"
                         rel="noopener noreferrer"
-                        class="rounded p-1.5 text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-600"
+                        class="rounded p-1.5 text-gray-400 dark:text-gray-500 transition-colors hover:bg-gray-100 dark:hover:bg-gray-800 dark:bg-gray-800 hover:text-gray-600 dark:text-gray-400 dark:text-gray-500 dark:hover:text-gray-300 dark:text-gray-600"
                       >
                         <ExternalLink class="h-4 w-4" />
                       </a>
                       <button
-                        class="rounded p-1.5 text-gray-400 transition-colors hover:bg-red-50 hover:text-red-600"
+                        class="rounded p-1.5 text-gray-400 dark:text-gray-500 transition-colors hover:bg-red-50 hover:text-red-600"
                         @click="confirmDeleteDomain = d.domain"
                       >
                         <Trash2 class="h-4 w-4" />
@@ -454,7 +454,7 @@ onMounted(fetchTenant)
               </tbody>
             </table>
           </div>
-          <div v-else class="rounded-lg border bg-white py-8 text-center text-sm text-gray-400">
+          <div v-else class="rounded-lg border bg-white dark:bg-gray-900 py-8 text-center text-sm text-gray-400 dark:text-gray-500">
             No domains configured for this tenant.
           </div>
         </div>
@@ -468,15 +468,15 @@ onMounted(fetchTenant)
         class="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
         @click.self="confirmDeleteDomain = null"
       >
-        <div class="mx-4 w-full max-w-sm rounded-lg bg-white p-6 shadow-xl">
-          <h3 class="text-lg font-semibold text-gray-900">Remove Domain</h3>
-          <p class="mt-2 text-sm text-gray-500">
+        <div class="mx-4 w-full max-w-sm rounded-lg bg-white dark:bg-gray-900 p-6 shadow-xl">
+          <h3 class="text-lg font-semibold text-gray-900 dark:text-white">Remove Domain</h3>
+          <p class="mt-2 text-sm text-gray-500 dark:text-gray-400 dark:text-gray-500">
             Are you sure you want to remove
-            <span class="font-mono font-medium text-gray-700">{{ confirmDeleteDomain }}</span>?
+            <span class="font-mono font-medium text-gray-700 dark:text-gray-300 dark:text-gray-600">{{ confirmDeleteDomain }}</span>?
           </p>
           <div class="mt-4 flex justify-end gap-2">
             <button
-              class="rounded-md px-4 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-100"
+              class="rounded-md px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 dark:text-gray-600 transition-colors hover:bg-gray-100 dark:hover:bg-gray-800 dark:bg-gray-800"
               @click="confirmDeleteDomain = null"
             >
               Cancel

--- a/web-ui/src/pages/super/SuperTenantsPage.vue
+++ b/web-ui/src/pages/super/SuperTenantsPage.vue
@@ -109,16 +109,16 @@ onMounted(fetchTenants)
 <template>
   <div>
     <div>
-      <h1 class="text-xl font-semibold text-gray-900">Tenant Management</h1>
-      <p class="mt-1 text-sm text-gray-500">{{ total }} tenant{{ total !== 1 ? 's' : '' }} total</p>
+      <h1 class="text-xl font-semibold text-gray-900 dark:text-white">Tenant Management</h1>
+      <p class="mt-1 text-sm text-gray-500 dark:text-gray-400 dark:text-gray-500">{{ total }} tenant{{ total !== 1 ? 's' : '' }} total</p>
     </div>
 
     <!-- Table -->
-    <div class="mt-4 overflow-hidden rounded-lg border bg-white">
+    <div class="mt-4 overflow-hidden rounded-lg border bg-white dark:bg-gray-900 dark:bg-gray-900">
       <div class="overflow-x-auto">
         <table class="w-full text-sm">
           <thead>
-            <tr class="border-b bg-gray-50 text-left text-xs font-medium uppercase tracking-wider text-gray-500">
+            <tr class="border-b bg-gray-50 dark:bg-gray-800/50 text-left text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400 dark:text-gray-500">
               <th
                 class="px-4 py-3"
                 :aria-sort="sortField === 'name' ? (sortDirection === 'asc' ? 'ascending' : 'descending') : 'none'"
@@ -152,21 +152,21 @@ onMounted(fetchTenants)
           </thead>
           <tbody class="divide-y">
             <tr v-if="loading">
-              <td colspan="5" class="px-4 py-8 text-center text-gray-400">
+              <td colspan="5" class="px-4 py-8 text-center text-gray-400 dark:text-gray-500">
                 <Loader2 class="inline h-5 w-5 animate-spin" />
               </td>
             </tr>
             <tr v-else-if="tenants.length === 0">
               <td colspan="5" class="px-4 py-12 text-center">
-                <Building2 class="mx-auto h-10 w-10 text-gray-300" />
-                <p class="mt-3 text-sm font-medium text-gray-500">No tenants yet</p>
-                <p class="mt-1 text-sm text-gray-400">Tenants will appear here once created by users.</p>
+                <Building2 class="mx-auto h-10 w-10 text-gray-300 dark:text-gray-600" />
+                <p class="mt-3 text-sm font-medium text-gray-500 dark:text-gray-400 dark:text-gray-500">No tenants yet</p>
+                <p class="mt-1 text-sm text-gray-400 dark:text-gray-500">Tenants will appear here once created by users.</p>
               </td>
             </tr>
             <tr
               v-for="tenant in sortedTenants"
               :key="tenant.id"
-              class="transition-colors hover:bg-gray-50"
+              class="transition-colors hover:bg-gray-50 dark:hover:bg-gray-700 dark:bg-gray-800/50"
             >
               <td class="px-4 py-3">
                 <div class="flex items-center gap-2">
@@ -176,20 +176,20 @@ onMounted(fetchTenants)
                     {{ tenant.name.charAt(0).toUpperCase() }}
                   </div>
                   <div>
-                    <p class="font-medium text-gray-900">{{ tenant.name }}</p>
-                    <p class="text-xs text-gray-400">{{ tenant.id }}</p>
+                    <p class="font-medium text-gray-900 dark:text-white">{{ tenant.name }}</p>
+                    <p class="text-xs text-gray-400 dark:text-gray-500">{{ tenant.id }}</p>
                   </div>
                 </div>
               </td>
               <td class="px-4 py-3">
-                <span class="font-mono text-sm text-gray-600">{{ tenant.slug }}</span>
+                <span class="font-mono text-sm text-gray-600 dark:text-gray-400 dark:text-gray-500">{{ tenant.slug }}</span>
               </td>
               <td class="px-4 py-3">
                 <button
                   :disabled="toggleLoading === tenant.id"
                   class="inline-flex items-center gap-1.5 rounded-full px-2.5 py-0.5 text-xs font-medium transition-colors"
                   :class="[
-                    tenant.isActive ? 'bg-green-50 text-green-700 hover:bg-green-100' : 'bg-gray-100 text-gray-500 hover:bg-gray-200',
+                    tenant.isActive ? 'bg-green-50 text-green-700 hover:bg-green-100' : 'bg-gray-100 dark:bg-gray-800 text-gray-500 dark:text-gray-400 dark:text-gray-500 hover:bg-gray-200 dark:bg-gray-700',
                     toggleLoading === tenant.id ? 'opacity-50' : 'cursor-pointer',
                   ]"
                   @click="handleToggleStatus(tenant)"
@@ -199,13 +199,13 @@ onMounted(fetchTenants)
                   {{ tenant.isActive ? 'Active' : 'Inactive' }}
                 </button>
               </td>
-              <td class="hidden whitespace-nowrap px-4 py-3 text-gray-500 lg:table-cell">
+              <td class="hidden whitespace-nowrap px-4 py-3 text-gray-500 dark:text-gray-400 dark:text-gray-500 lg:table-cell">
                 {{ formatDate(tenant.createdAt) }}
               </td>
               <td class="px-4 py-3">
                 <div class="flex items-center justify-end gap-1">
                   <button
-                    class="rounded p-1.5 text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-600"
+                    class="rounded p-1.5 text-gray-400 dark:text-gray-500 transition-colors hover:bg-gray-100 dark:hover:bg-gray-800 dark:bg-gray-800 hover:text-gray-600 dark:text-gray-400 dark:text-gray-500 dark:hover:text-gray-300 dark:text-gray-600"
                     title="View details"
                     @click="router.push({ name: 'super-tenant-detail', params: { id: tenant.id } })"
                   >
@@ -220,20 +220,20 @@ onMounted(fetchTenants)
 
       <!-- Pagination -->
       <div v-if="total > pageSize" class="flex items-center justify-between border-t px-4 py-3">
-        <p class="text-xs text-gray-500">
+        <p class="text-xs text-gray-500 dark:text-gray-400 dark:text-gray-500">
           Page {{ page }} of {{ Math.ceil(total / pageSize) }} ({{ total }} total)
         </p>
         <div class="flex items-center gap-1">
           <button
             :disabled="page <= 1"
-            class="rounded p-1.5 text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-600 disabled:opacity-50"
+            class="rounded p-1.5 text-gray-400 dark:text-gray-500 transition-colors hover:bg-gray-100 dark:hover:bg-gray-800 dark:bg-gray-800 hover:text-gray-600 dark:text-gray-400 dark:text-gray-500 dark:hover:text-gray-300 dark:text-gray-600 disabled:opacity-50"
             @click="goToPage(page - 1)"
           >
             <ChevronLeft class="h-4 w-4" />
           </button>
           <button
             :disabled="page >= Math.ceil(total / pageSize)"
-            class="rounded p-1.5 text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-600 disabled:opacity-50"
+            class="rounded p-1.5 text-gray-400 dark:text-gray-500 transition-colors hover:bg-gray-100 dark:hover:bg-gray-800 dark:bg-gray-800 hover:text-gray-600 dark:text-gray-400 dark:text-gray-500 dark:hover:text-gray-300 dark:text-gray-600 disabled:opacity-50"
             @click="goToPage(page + 1)"
           >
             <ChevronRight class="h-4 w-4" />

--- a/web-ui/src/pages/super/SuperUsersPage.vue
+++ b/web-ui/src/pages/super/SuperUsersPage.vue
@@ -155,8 +155,8 @@ onMounted(fetchUsers)
   <div>
     <div class="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
       <div>
-        <h1 class="text-xl font-semibold text-gray-900">User Management</h1>
-        <p class="mt-1 text-sm text-gray-500">{{ total }} user{{ total !== 1 ? 's' : '' }} total</p>
+        <h1 class="text-xl font-semibold text-gray-900 dark:text-white">User Management</h1>
+        <p class="mt-1 text-sm text-gray-500 dark:text-gray-400 dark:text-gray-500">{{ total }} user{{ total !== 1 ? 's' : '' }} total</p>
       </div>
       <button
         class="inline-flex items-center gap-2 rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-blue-700"
@@ -168,19 +168,19 @@ onMounted(fetchUsers)
     </div>
 
     <!-- Search -->
-    <div class="mt-4 flex flex-col gap-3 rounded-lg border bg-white p-4 sm:flex-row sm:items-center">
+    <div class="mt-4 flex flex-col gap-3 rounded-lg border bg-white dark:bg-gray-900 p-4 sm:flex-row sm:items-center">
       <div class="relative flex-1">
-        <Search class="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400" />
+        <Search class="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400 dark:text-gray-500" />
         <input
           v-model="search"
           type="text"
           placeholder="Search by username..."
-          class="w-full rounded-md border border-gray-300 py-2 pl-9 pr-3 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
+          class="w-full rounded-md border border-gray-300 dark:border-gray-600 py-2 pl-9 pr-3 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
           @keydown.enter="handleSearch"
         />
       </div>
       <button
-        class="rounded-md bg-gray-100 px-4 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-200"
+        class="rounded-md bg-gray-100 dark:bg-gray-800 px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 dark:text-gray-600 transition-colors hover:bg-gray-200 dark:bg-gray-700"
         @click="handleSearch"
       >
         Search
@@ -188,11 +188,11 @@ onMounted(fetchUsers)
     </div>
 
     <!-- Table -->
-    <div class="mt-4 overflow-hidden rounded-lg border bg-white">
+    <div class="mt-4 overflow-hidden rounded-lg border bg-white dark:bg-gray-900 dark:bg-gray-900">
       <div class="overflow-x-auto">
         <table class="w-full text-sm">
           <thead>
-            <tr class="border-b bg-gray-50 text-left text-xs font-medium uppercase tracking-wider text-gray-500">
+            <tr class="border-b bg-gray-50 dark:bg-gray-800/50 text-left text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400 dark:text-gray-500">
               <th class="px-4 py-3">Username</th>
               <th class="px-4 py-3">Status</th>
               <th class="hidden px-4 py-3 md:table-cell">Super Admin</th>
@@ -202,15 +202,15 @@ onMounted(fetchUsers)
           </thead>
           <tbody class="divide-y">
             <tr v-if="loading">
-              <td colspan="5" class="px-4 py-8 text-center text-gray-400">
+              <td colspan="5" class="px-4 py-8 text-center text-gray-400 dark:text-gray-500">
                 <Loader2 class="inline h-5 w-5 animate-spin" />
               </td>
             </tr>
             <tr v-else-if="users.length === 0">
               <td colspan="5" class="px-4 py-12 text-center">
-                <Users class="mx-auto h-10 w-10 text-gray-300" />
-                <p class="mt-3 text-sm font-medium text-gray-500">No users yet</p>
-                <p class="mt-1 text-sm text-gray-400">Create a new user to get started.</p>
+                <Users class="mx-auto h-10 w-10 text-gray-300 dark:text-gray-600" />
+                <p class="mt-3 text-sm font-medium text-gray-500 dark:text-gray-400 dark:text-gray-500">No users yet</p>
+                <p class="mt-1 text-sm text-gray-400 dark:text-gray-500">Create a new user to get started.</p>
                 <button
                   class="mt-3 inline-flex items-center gap-1.5 rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-blue-700"
                   @click="showCreateModal = true"
@@ -223,16 +223,16 @@ onMounted(fetchUsers)
             <tr
               v-for="user in users"
               :key="user.id"
-              class="transition-colors hover:bg-gray-50"
+              class="transition-colors hover:bg-gray-50 dark:hover:bg-gray-700 dark:bg-gray-800/50"
             >
               <td class="px-4 py-3">
                 <div class="flex items-center gap-2">
-                  <div class="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-gray-100 text-xs font-bold text-gray-600">
+                  <div class="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-gray-100 dark:bg-gray-800 text-xs font-bold text-gray-600 dark:text-gray-400 dark:text-gray-500">
                     {{ user.username.charAt(0).toUpperCase() }}
                   </div>
                   <div>
-                    <p class="font-medium text-gray-900">{{ user.username }}</p>
-                    <p class="text-xs text-gray-400">{{ user.id }}</p>
+                    <p class="font-medium text-gray-900 dark:text-white">{{ user.username }}</p>
+                    <p class="text-xs text-gray-400 dark:text-gray-500">{{ user.id }}</p>
                   </div>
                 </div>
               </td>
@@ -241,7 +241,7 @@ onMounted(fetchUsers)
                   :disabled="toggleLoading === user.id || user.isSuper"
                   class="inline-flex items-center gap-1.5 rounded-full px-2.5 py-0.5 text-xs font-medium transition-colors"
                   :class="[
-                    user.isActive ? 'bg-green-50 text-green-700 hover:bg-green-100' : 'bg-gray-100 text-gray-500 hover:bg-gray-200',
+                    user.isActive ? 'bg-green-50 text-green-700 hover:bg-green-100' : 'bg-gray-100 dark:bg-gray-800 text-gray-500 dark:text-gray-400 dark:text-gray-500 hover:bg-gray-200 dark:bg-gray-700',
                     (user.isSuper || toggleLoading === user.id) ? 'cursor-not-allowed opacity-50' : 'cursor-pointer',
                   ]"
                   @click="handleToggleStatus(user)"
@@ -256,22 +256,22 @@ onMounted(fetchUsers)
                   <Shield class="h-3.5 w-3.5" />
                   Super
                 </span>
-                <span v-else class="text-xs text-gray-400">-</span>
+                <span v-else class="text-xs text-gray-400 dark:text-gray-500">-</span>
               </td>
-              <td class="hidden whitespace-nowrap px-4 py-3 text-gray-500 lg:table-cell">
+              <td class="hidden whitespace-nowrap px-4 py-3 text-gray-500 dark:text-gray-400 dark:text-gray-500 lg:table-cell">
                 {{ formatDate(user.createdAt) }}
               </td>
               <td class="px-4 py-3">
                 <div class="flex items-center justify-end gap-1">
                   <button
-                    class="rounded p-1.5 text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-600"
+                    class="rounded p-1.5 text-gray-400 dark:text-gray-500 transition-colors hover:bg-gray-100 dark:hover:bg-gray-800 dark:bg-gray-800 hover:text-gray-600 dark:text-gray-400 dark:text-gray-500 dark:hover:text-gray-300 dark:text-gray-600"
                     title="View details"
                     @click="openDetailModal(user)"
                   >
                     <Eye class="h-4 w-4" />
                   </button>
                   <button
-                    class="rounded p-1.5 text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-600"
+                    class="rounded p-1.5 text-gray-400 dark:text-gray-500 transition-colors hover:bg-gray-100 dark:hover:bg-gray-800 dark:bg-gray-800 hover:text-gray-600 dark:text-gray-400 dark:text-gray-500 dark:hover:text-gray-300 dark:text-gray-600"
                     title="Reset password"
                     @click="openResetModal(user)"
                   >
@@ -286,20 +286,20 @@ onMounted(fetchUsers)
 
       <!-- Pagination -->
       <div v-if="total > pageSize" class="flex items-center justify-between border-t px-4 py-3">
-        <p class="text-xs text-gray-500">
+        <p class="text-xs text-gray-500 dark:text-gray-400 dark:text-gray-500">
           Page {{ page }} of {{ Math.ceil(total / pageSize) }} ({{ total }} total)
         </p>
         <div class="flex items-center gap-1">
           <button
             :disabled="page <= 1"
-            class="rounded p-1.5 text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-600 disabled:opacity-50"
+            class="rounded p-1.5 text-gray-400 dark:text-gray-500 transition-colors hover:bg-gray-100 dark:hover:bg-gray-800 dark:bg-gray-800 hover:text-gray-600 dark:text-gray-400 dark:text-gray-500 dark:hover:text-gray-300 dark:text-gray-600 disabled:opacity-50"
             @click="goToPage(page - 1)"
           >
             <ChevronLeft class="h-4 w-4" />
           </button>
           <button
             :disabled="page >= Math.ceil(total / pageSize)"
-            class="rounded p-1.5 text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-600 disabled:opacity-50"
+            class="rounded p-1.5 text-gray-400 dark:text-gray-500 transition-colors hover:bg-gray-100 dark:hover:bg-gray-800 dark:bg-gray-800 hover:text-gray-600 dark:text-gray-400 dark:text-gray-500 dark:hover:text-gray-300 dark:text-gray-600 disabled:opacity-50"
             @click="goToPage(page + 1)"
           >
             <ChevronRight class="h-4 w-4" />
@@ -315,29 +315,29 @@ onMounted(fetchUsers)
         class="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
         @click.self="showCreateModal = false"
       >
-        <div class="mx-4 w-full max-w-md rounded-lg bg-white p-6 shadow-xl">
+        <div class="mx-4 w-full max-w-md rounded-lg bg-white dark:bg-gray-900 p-6 shadow-xl">
           <div class="flex items-center justify-between">
-            <h3 class="text-lg font-semibold text-gray-900">Create User</h3>
-            <button class="rounded p-1 text-gray-400 hover:text-gray-600" @click="showCreateModal = false">
+            <h3 class="text-lg font-semibold text-gray-900 dark:text-white">Create User</h3>
+            <button class="rounded p-1 text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:text-gray-400 dark:text-gray-500 dark:hover:text-gray-300 dark:text-gray-600" @click="showCreateModal = false">
               <X class="h-5 w-5" />
             </button>
           </div>
           <div class="mt-4 space-y-4">
             <div>
-              <label class="mb-1 block text-sm font-medium text-gray-700">Username</label>
+              <label class="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300 dark:text-gray-600">Username</label>
               <input
                 v-model="newUsername"
                 type="text"
-                class="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
+                class="w-full rounded-md border border-gray-300 dark:border-gray-600 px-3 py-2 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
                 @keydown.enter="handleCreate"
               />
             </div>
             <div>
-              <label class="mb-1 block text-sm font-medium text-gray-700">Password</label>
+              <label class="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300 dark:text-gray-600">Password</label>
               <input
                 v-model="newPassword"
                 type="password"
-                class="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
+                class="w-full rounded-md border border-gray-300 dark:border-gray-600 px-3 py-2 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
                 @keydown.enter="handleCreate"
               />
             </div>
@@ -345,7 +345,7 @@ onMounted(fetchUsers)
           </div>
           <div class="mt-5 flex justify-end gap-2">
             <button
-              class="rounded-md px-4 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-100"
+              class="rounded-md px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 dark:text-gray-600 transition-colors hover:bg-gray-100 dark:hover:bg-gray-800 dark:bg-gray-800"
               @click="showCreateModal = false"
             >
               Cancel
@@ -370,29 +370,29 @@ onMounted(fetchUsers)
         class="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
         @click.self="showResetModal = false"
       >
-        <div class="mx-4 w-full max-w-md rounded-lg bg-white p-6 shadow-xl">
+        <div class="mx-4 w-full max-w-md rounded-lg bg-white dark:bg-gray-900 p-6 shadow-xl">
           <div class="flex items-center justify-between">
-            <h3 class="text-lg font-semibold text-gray-900">Reset Password</h3>
-            <button class="rounded p-1 text-gray-400 hover:text-gray-600" @click="showResetModal = false">
+            <h3 class="text-lg font-semibold text-gray-900 dark:text-white">Reset Password</h3>
+            <button class="rounded p-1 text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:text-gray-400 dark:text-gray-500 dark:hover:text-gray-300 dark:text-gray-600" @click="showResetModal = false">
               <X class="h-5 w-5" />
             </button>
           </div>
-          <p class="mt-2 text-sm text-gray-500">
-            Reset password for <span class="font-medium text-gray-700">{{ resetUsername }}</span>
+          <p class="mt-2 text-sm text-gray-500 dark:text-gray-400 dark:text-gray-500">
+            Reset password for <span class="font-medium text-gray-700 dark:text-gray-300 dark:text-gray-600">{{ resetUsername }}</span>
           </p>
           <div class="mt-4">
-            <label class="mb-1 block text-sm font-medium text-gray-700">New Password</label>
+            <label class="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300 dark:text-gray-600">New Password</label>
             <input
               v-model="resetNewPassword"
               type="password"
-              class="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
+              class="w-full rounded-md border border-gray-300 dark:border-gray-600 px-3 py-2 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
               @keydown.enter="handleReset"
             />
             <p v-if="resetError" class="mt-2 text-sm text-red-600">{{ resetError }}</p>
           </div>
           <div class="mt-5 flex justify-end gap-2">
             <button
-              class="rounded-md px-4 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-100"
+              class="rounded-md px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 dark:text-gray-600 transition-colors hover:bg-gray-100 dark:hover:bg-gray-800 dark:bg-gray-800"
               @click="showResetModal = false"
             >
               Cancel
@@ -417,55 +417,55 @@ onMounted(fetchUsers)
         class="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
         @click.self="showDetailModal = false"
       >
-        <div class="mx-4 w-full max-w-lg rounded-lg bg-white p-6 shadow-xl">
+        <div class="mx-4 w-full max-w-lg rounded-lg bg-white dark:bg-gray-900 p-6 shadow-xl">
           <div class="flex items-center justify-between">
-            <h3 class="text-lg font-semibold text-gray-900">User Details</h3>
-            <button class="rounded p-1 text-gray-400 hover:text-gray-600" @click="showDetailModal = false">
+            <h3 class="text-lg font-semibold text-gray-900 dark:text-white">User Details</h3>
+            <button class="rounded p-1 text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:text-gray-400 dark:text-gray-500 dark:hover:text-gray-300 dark:text-gray-600" @click="showDetailModal = false">
               <X class="h-5 w-5" />
             </button>
           </div>
 
           <div v-if="detailLoading" class="mt-4 flex justify-center py-8">
-            <Loader2 class="h-5 w-5 animate-spin text-gray-400" />
+            <Loader2 class="h-5 w-5 animate-spin text-gray-400 dark:text-gray-500" />
           </div>
 
           <template v-else-if="userDetail">
             <div class="mt-4 space-y-3">
               <div class="flex items-center gap-3">
-                <div class="flex h-10 w-10 items-center justify-center rounded-full bg-gray-100 text-sm font-bold text-gray-600">
+                <div class="flex h-10 w-10 items-center justify-center rounded-full bg-gray-100 dark:bg-gray-800 text-sm font-bold text-gray-600 dark:text-gray-400 dark:text-gray-500">
                   {{ userDetail.username.charAt(0).toUpperCase() }}
                 </div>
                 <div>
-                  <p class="font-medium text-gray-900">{{ userDetail.username }}</p>
-                  <p class="text-xs text-gray-400 font-mono">{{ userDetail.id }}</p>
+                  <p class="font-medium text-gray-900 dark:text-white">{{ userDetail.username }}</p>
+                  <p class="text-xs text-gray-400 dark:text-gray-500 font-mono">{{ userDetail.id }}</p>
                 </div>
                 <span
                   class="ml-auto inline-flex items-center gap-1.5 rounded-full px-2.5 py-0.5 text-xs font-medium"
-                  :class="userDetail.isActive ? 'bg-green-50 text-green-700' : 'bg-gray-100 text-gray-500'"
+                  :class="userDetail.isActive ? 'bg-green-50 text-green-700' : 'bg-gray-100 dark:bg-gray-800 text-gray-500 dark:text-gray-400 dark:text-gray-500'"
                 >
                   <span class="h-1.5 w-1.5 rounded-full" :class="userDetail.isActive ? 'bg-green-500' : 'bg-gray-400'" />
                   {{ userDetail.isActive ? 'Active' : 'Disabled' }}
                 </span>
               </div>
 
-              <div class="rounded-lg border bg-gray-50 p-3 text-sm">
+              <div class="rounded-lg border bg-gray-50 dark:bg-gray-800/50 p-3 text-sm">
                 <div class="grid gap-2 sm:grid-cols-2">
                   <div>
-                    <span class="text-xs text-gray-400">Super Admin</span>
-                    <p class="font-medium" :class="userDetail.isSuper ? 'text-indigo-600' : 'text-gray-600'">
+                    <span class="text-xs text-gray-400 dark:text-gray-500">Super Admin</span>
+                    <p class="font-medium" :class="userDetail.isSuper ? 'text-indigo-600' : 'text-gray-600 dark:text-gray-400 dark:text-gray-500'">
                       {{ userDetail.isSuper ? 'Yes' : 'No' }}
                     </p>
                   </div>
                   <div>
-                    <span class="text-xs text-gray-400">Created</span>
-                    <p class="font-medium text-gray-600">{{ formatDate(userDetail.createdAt) }}</p>
+                    <span class="text-xs text-gray-400 dark:text-gray-500">Created</span>
+                    <p class="font-medium text-gray-600 dark:text-gray-400 dark:text-gray-500">{{ formatDate(userDetail.createdAt) }}</p>
                   </div>
                 </div>
               </div>
 
               <div>
-                <h4 class="mb-2 text-sm font-medium text-gray-700">Tenant Memberships</h4>
-                <div v-if="userDetail.tenants.length === 0" class="text-sm text-gray-400">
+                <h4 class="mb-2 text-sm font-medium text-gray-700 dark:text-gray-300 dark:text-gray-600">Tenant Memberships</h4>
+                <div v-if="userDetail.tenants.length === 0" class="text-sm text-gray-400 dark:text-gray-500">
                   No tenant memberships.
                 </div>
                 <div v-else class="space-y-1.5">
@@ -474,10 +474,10 @@ onMounted(fetchUsers)
                     :key="t.tenantId"
                     class="flex items-center justify-between rounded-md border bg-white px-3 py-2"
                   >
-                    <span class="font-mono text-sm text-gray-700">{{ t.tenantId }}</span>
+                    <span class="font-mono text-sm text-gray-700 dark:text-gray-300 dark:text-gray-600">{{ t.tenantId }}</span>
                     <span
                       class="inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium"
-                      :class="t.role === 'admin' ? 'bg-blue-50 text-blue-700' : 'bg-gray-100 text-gray-600'"
+                      :class="t.role === 'admin' ? 'bg-blue-50 text-blue-700' : 'bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-400 dark:text-gray-500'"
                     >
                       {{ t.role }}
                     </span>

--- a/web-ui/src/style.css
+++ b/web-ui/src/style.css
@@ -1,4 +1,5 @@
 @import 'tailwindcss';
+@custom-variant dark (&:where(.dark, .dark *));
 
 button,
 [type="button"],


### PR DESCRIPTION
## Summary
- Add `useTheme` composable supporting light/dark/system modes with localStorage persistence
- Configure Tailwind CSS v4 `@custom-variant dark` for class-based dark mode toggling
- Add theme toggle dropdown in TopBar (Sun/Moon/Monitor icons)
- Respect system `prefers-color-scheme` when set to "system" mode
- Apply `dark:` variants across all components and pages (29 files)

## Test plan
- [ ] Click theme toggle in TopBar → verify Light/Dark/System options work
- [ ] In Dark mode, verify backgrounds are dark gray, text is light, borders are dark
- [ ] In System mode, verify it follows OS dark/light preference
- [ ] Verify theme persists after page refresh (localStorage)
- [ ] Verify all pages render correctly in both modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)