### PR TITLE
feat(web-ui): keyboard shortcuts

### DIFF
--- a/web-ui/src/components/ShortcutHelp.vue
+++ b/web-ui/src/components/ShortcutHelp.vue
@@ -1,0 +1,82 @@
+<script setup lang="ts">
+import { useKeyboardShortcuts } from '@/composables/useKeyboardShortcuts'
+import { X, Keyboard } from 'lucide-vue-next'
+
+const { showHelp } = useKeyboardShortcuts()
+
+function close() {
+  showHelp.value = false
+}
+
+function handleKeydown(e: KeyboardEvent) {
+  if (e.key === 'Escape') {
+    close()
+  }
+}
+</script>
+
+<template>
+  <Teleport to="body">
+    <div
+      v-if="showHelp"
+      class="fixed inset-0 z-[70] flex items-center justify-center"
+    >
+      <div class="fixed inset-0 bg-black/50" @click="close" />
+      <div
+        class="relative w-full max-w-md overflow-hidden rounded-xl border border-gray-200 bg-white shadow-2xl"
+        @keydown="handleKeydown"
+      >
+        <div class="flex items-center justify-between border-b px-5 py-4">
+          <div class="flex items-center gap-2">
+            <Keyboard class="h-5 w-5 text-gray-500" />
+            <h3 class="text-base font-semibold text-gray-900">Keyboard Shortcuts</h3>
+          </div>
+          <button
+            class="rounded p-1 text-gray-400 hover:bg-gray-100 hover:text-gray-600"
+            @click="close"
+          >
+            <X class="h-4 w-4" />
+          </button>
+        </div>
+
+        <div class="space-y-1 px-5 py-4">
+          <div class="flex items-center justify-between py-2">
+            <span class="text-sm text-gray-600">Open global search</span>
+            <div class="flex items-center gap-1">
+              <kbd class="rounded border border-gray-200 bg-gray-50 px-2 py-0.5 text-xs font-medium text-gray-500">Ctrl</kbd>
+              <kbd class="rounded border border-gray-200 bg-gray-50 px-2 py-0.5 text-xs font-medium text-gray-500">K</kbd>
+            </div>
+          </div>
+
+          <div class="border-t border-gray-100" />
+
+          <div class="flex items-center justify-between py-2">
+            <span class="text-sm text-gray-600">Show this help panel</span>
+            <kbd class="rounded border border-gray-200 bg-gray-50 px-2 py-0.5 text-xs font-medium text-gray-500">?</kbd>
+          </div>
+
+          <div class="border-t border-gray-100" />
+
+          <p class="pt-2 text-xs font-medium uppercase text-gray-400">Short Links Page</p>
+
+          <div class="flex items-center justify-between py-2">
+            <span class="text-sm text-gray-600">Create new short link</span>
+            <kbd class="rounded border border-gray-200 bg-gray-50 px-2 py-0.5 text-xs font-medium text-gray-500">N</kbd>
+          </div>
+
+          <div class="flex items-center justify-between py-2">
+            <span class="text-sm text-gray-600">Focus search</span>
+            <kbd class="rounded border border-gray-200 bg-gray-50 px-2 py-0.5 text-xs font-medium text-gray-500">/</kbd>
+          </div>
+
+          <div class="border-t border-gray-100" />
+
+          <div class="flex items-center justify-between py-2">
+            <span class="text-sm text-gray-600">Close panels / Cancel</span>
+            <kbd class="rounded border border-gray-200 bg-gray-50 px-2 py-0.5 text-xs font-medium text-gray-500">Esc</kbd>
+          </div>
+        </div>
+      </div>
+    </div>
+  </Teleport>
+</template>

--- a/web-ui/src/composables/useKeyboardShortcuts.ts
+++ b/web-ui/src/composables/useKeyboardShortcuts.ts
@@ -1,0 +1,106 @@
+import { onMounted, onBeforeUnmount } from 'vue'
+import { useRouter, useRoute } from 'vue-router'
+
+interface ShortcutDef {
+  key: string
+  ctrl?: boolean
+  description: string
+  action: () => void
+  page?: string
+}
+
+const showHelp = ref(false)
+
+import { ref } from 'vue'
+
+export function useKeyboardShortcuts() {
+  const router = useRouter()
+  const route = useRoute()
+
+  const shortcuts: ShortcutDef[] = [
+    {
+      key: 'k',
+      ctrl: true,
+      description: 'Open global search',
+      action: () => {
+        document.dispatchEvent(new CustomEvent('open-global-search'))
+      },
+    },
+    {
+      key: '?',
+      description: 'Show keyboard shortcuts',
+      action: () => {
+        showHelp.value = !showHelp.value
+      },
+    },
+    {
+      key: 'n',
+      description: 'Create new short link',
+      page: 'short-links',
+      action: () => {
+        if (route.name === 'short-links') {
+          router.push({ name: 'short-link-create' })
+        }
+      },
+    },
+    {
+      key: '/',
+      description: 'Focus search on current page',
+      page: 'short-links',
+      action: () => {
+        const searchInput = document.querySelector<HTMLInputElement>(
+          '[data-shortcut-search]',
+        )
+        if (searchInput) {
+          searchInput.focus()
+        }
+      },
+    },
+    {
+      key: 'Escape',
+      description: 'Close panels / Cancel search',
+      action: () => {
+        showHelp.value = false
+        const searchInput = document.querySelector<HTMLInputElement>(
+          '[data-shortcut-search]',
+        )
+        if (searchInput && document.activeElement === searchInput) {
+          searchInput.blur()
+        }
+      },
+    },
+  ]
+
+  function handleKeydown(e: KeyboardEvent) {
+    const target = e.target as HTMLElement
+    const isInput = target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable
+
+    for (const shortcut of shortcuts) {
+      if (shortcut.page && route.name !== shortcut.page) continue
+
+      if (shortcut.key === 'Escape') {
+        if (shortcut.key === e.key) {
+          shortcut.action()
+          return
+        }
+        continue
+      }
+
+      if (isInput) continue
+
+      const keyMatch = shortcut.key.toLowerCase() === e.key.toLowerCase()
+      const ctrlMatch = shortcut.ctrl ? (e.ctrlKey || e.metaKey) : !(e.ctrlKey || e.metaKey)
+
+      if (keyMatch && ctrlMatch) {
+        e.preventDefault()
+        shortcut.action()
+        return
+      }
+    }
+  }
+
+  onMounted(() => document.addEventListener('keydown', handleKeydown))
+  onBeforeUnmount(() => document.removeEventListener('keydown', handleKeydown))
+
+  return { showHelp, shortcuts }
+}

--- a/web-ui/src/layouts/DefaultLayout.vue
+++ b/web-ui/src/layouts/DefaultLayout.vue
@@ -2,6 +2,10 @@
 import AppSidebar from '@/components/AppSidebar.vue'
 import AppTopBar from '@/components/AppTopBar.vue'
 import AppBreadcrumb from '@/components/AppBreadcrumb.vue'
+import ShortcutHelp from '@/components/ShortcutHelp.vue'
+import { useKeyboardShortcuts } from '@/composables/useKeyboardShortcuts'
+
+useKeyboardShortcuts()
 </script>
 
 <template>
@@ -23,6 +27,8 @@ import AppBreadcrumb from '@/components/AppBreadcrumb.vue'
         </router-view>
       </main>
     </div>
+
+    <ShortcutHelp />
   </div>
 </template>
 

--- a/web-ui/src/pages/ShortLinksPage.vue
+++ b/web-ui/src/pages/ShortLinksPage.vue
@@ -307,6 +307,7 @@ onMounted(fetchLinks)
         <input
           v-model="searchId"
           type="text"
+          data-shortcut-search
           placeholder="Search by ID..."
           class="w-full rounded-md border border-gray-300 py-2 pl-9 pr-3 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
         />


### PR DESCRIPTION
## Summary
- Add keyboard shortcuts composable (`useKeyboardShortcuts`) with support for page-scoped and global shortcuts
- Shortcuts: `Ctrl+K` open global search, `?` toggle help panel, `N` create new short link, `/` focus search, `Esc` close panels
- Add `ShortcutHelp` modal component listing all available shortcuts
- Add `data-shortcut-search` attribute to ShortLinksPage search input for `/` shortcut targeting

## Test plan
- [ ] Press `?` to verify help panel opens/closes
- [ ] On short links page, press `N` to navigate to create page
- [ ] On short links page, press `/` to focus the search input
- [ ] Press `Esc` to close help panel and blur search input
- [ ] Verify shortcuts don't fire when typing in input fields (except Esc)

🤖 Generated with [Claude Code](https://claude.com/claude-code)