### PR TITLE
fix(web-ui): complete dark mode adaptation across all pages and components

### DIFF
--- a/web-ui/src/components/GlobalSearch.vue
+++ b/web-ui/src/components/GlobalSearch.vue
@@ -55,12 +55,12 @@ onBeforeUnmount(() => {
 <template>
   <!-- Search trigger button -->
   <button
-    class="flex items-center gap-2 rounded-lg border border-gray-200 bg-white px-3 py-1.5 text-sm text-gray-400 transition-colors hover:border-gray-300 hover:text-gray-500"
+    class="flex items-center gap-2 rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 px-3 py-1.5 text-sm text-gray-400 dark:text-gray-500 transition-colors hover:border-gray-300 dark:hover:border-gray-600 hover:text-gray-500"
     @click="openSearch"
   >
     <Search class="h-4 w-4" />
     <span class="hidden sm:inline">Search...</span>
-    <kbd class="hidden rounded border border-gray-200 bg-gray-50 px-1.5 py-0.5 text-[10px] font-medium text-gray-400 sm:inline">Ctrl+K</kbd>
+    <kbd class="hidden rounded border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 px-1.5 py-0.5 text-[10px] font-medium text-gray-400 dark:text-gray-500 sm:inline">Ctrl+K</kbd>
   </button>
 
   <!-- Search modal -->
@@ -74,27 +74,27 @@ onBeforeUnmount(() => {
         @click="closeSearch"
       />
       <div
-        class="relative w-full max-w-lg overflow-hidden rounded-xl border border-gray-200 bg-white shadow-2xl"
+        class="relative w-full max-w-lg overflow-hidden rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 shadow-2xl"
         @keydown="handleKeydown"
       >
         <!-- Search input -->
-        <div class="flex items-center gap-3 border-b border-gray-100 px-4 py-3">
+        <div class="flex items-center gap-3 border-b border-gray-100 dark:border-gray-800 px-4 py-3">
           <Search class="h-5 w-5 shrink-0 text-gray-400" />
           <input
             ref="inputRef"
             v-model="query"
             type="text"
             placeholder="Search short links, members..."
-            class="flex-1 bg-transparent text-sm text-gray-900 placeholder-gray-400 focus:outline-none"
+            class="flex-1 bg-transparent text-sm text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none"
           />
           <Loader2 v-if="loading" class="h-4 w-4 animate-spin text-gray-400" />
-          <kbd v-else class="rounded border border-gray-200 bg-gray-50 px-1.5 py-0.5 text-[10px] font-medium text-gray-400">ESC</kbd>
+          <kbd v-else class="rounded border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 px-1.5 py-0.5 text-[10px] font-medium text-gray-400 dark:text-gray-500">ESC</kbd>
         </div>
 
         <!-- Results -->
         <div v-if="query.trim()" class="max-h-72 overflow-y-auto">
           <div v-if="!loading && !hasResults" class="px-4 py-8 text-center">
-            <p class="text-sm text-gray-400">No results found for "{{ query }}"</p>
+            <p class="text-sm text-gray-400 dark:text-gray-500">No results found for "{{ query }}"</p>
           </div>
           <ul v-else-if="hasResults">
             <li
@@ -102,19 +102,19 @@ onBeforeUnmount(() => {
               :key="result.type + result.id"
               :class="[
                 'flex cursor-pointer items-center gap-3 px-4 py-2.5 transition-colors',
-                index === activeIndex ? 'bg-blue-50' : 'hover:bg-gray-50',
+                index === activeIndex ? 'bg-blue-50 dark:bg-blue-900/20' : 'hover:bg-gray-50 dark:hover:bg-gray-800',
               ]"
               @click="selectResult(result)"
               @mouseenter="activeIndex = index"
             >
-              <div class="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-gray-100">
-                <component :is="getResultIcon(result.type)" class="h-4 w-4 text-gray-500" />
+              <div class="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-gray-100 dark:bg-gray-800">
+                <component :is="getResultIcon(result.type)" class="h-4 w-4 text-gray-500 dark:text-gray-400" />
               </div>
               <div class="min-w-0 flex-1">
-                <p class="text-sm font-medium text-gray-900">{{ result.label }}</p>
+                <p class="text-sm font-medium text-gray-900 dark:text-white">{{ result.label }}</p>
                 <p class="truncate text-xs text-gray-400">{{ result.subtitle }}</p>
               </div>
-              <span class="shrink-0 rounded-full bg-gray-100 px-2 py-0.5 text-[10px] font-medium text-gray-500">
+              <span class="shrink-0 rounded-full bg-gray-100 dark:bg-gray-800 px-2 py-0.5 text-[10px] font-medium text-gray-500 dark:text-gray-400">
                 {{ result.type === 'short-link' ? 'Link' : 'Member' }}
               </span>
             </li>
@@ -123,7 +123,7 @@ onBeforeUnmount(() => {
 
         <!-- Empty state -->
         <div v-else class="px-4 py-6 text-center">
-          <p class="text-sm text-gray-400">Start typing to search...</p>
+          <p class="text-sm text-gray-400 dark:text-gray-500">Start typing to search...</p>
         </div>
       </div>
     </div>

--- a/web-ui/src/components/ShortcutHelp.vue
+++ b/web-ui/src/components/ShortcutHelp.vue
@@ -21,16 +21,16 @@ function handleKeydown(e: KeyboardEvent) {
     >
       <div class="fixed inset-0 bg-black/50" @click="close" />
       <div
-        class="relative w-full max-w-md overflow-hidden rounded-xl border border-gray-200 bg-white shadow-2xl"
+        class="relative w-full max-w-md overflow-hidden rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 shadow-2xl"
         @keydown="handleKeydown"
       >
-        <div class="flex items-center justify-between border-b px-5 py-4">
+        <div class="flex items-center justify-between border-b dark:border-gray-700 px-5 py-4">
           <div class="flex items-center gap-2">
-            <Keyboard class="h-5 w-5 text-gray-500" />
-            <h3 class="text-base font-semibold text-gray-900">Keyboard Shortcuts</h3>
+            <Keyboard class="h-5 w-5 text-gray-500 dark:text-gray-400" />
+            <h3 class="text-base font-semibold text-gray-900 dark:text-white">Keyboard Shortcuts</h3>
           </div>
           <button
-            class="rounded p-1 text-gray-400 hover:bg-gray-100 hover:text-gray-600"
+            class="rounded p-1 text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800 hover:text-gray-600 dark:hover:text-gray-300"
             @click="close"
           >
             <X class="h-4 w-4" />
@@ -39,39 +39,39 @@ function handleKeydown(e: KeyboardEvent) {
 
         <div class="space-y-1 px-5 py-4">
           <div class="flex items-center justify-between py-2">
-            <span class="text-sm text-gray-600">Open global search</span>
+            <span class="text-sm text-gray-600 dark:text-gray-400">Open global search</span>
             <div class="flex items-center gap-1">
-              <kbd class="rounded border border-gray-200 bg-gray-50 px-2 py-0.5 text-xs font-medium text-gray-500">Ctrl</kbd>
-              <kbd class="rounded border border-gray-200 bg-gray-50 px-2 py-0.5 text-xs font-medium text-gray-500">K</kbd>
+              <kbd class="rounded border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 px-2 py-0.5 text-xs font-medium text-gray-500 dark:text-gray-400">Ctrl</kbd>
+              <kbd class="rounded border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 px-2 py-0.5 text-xs font-medium text-gray-500 dark:text-gray-400">K</kbd>
             </div>
           </div>
 
-          <div class="border-t border-gray-100" />
+          <div class="border-t border-gray-100 dark:border-gray-800" />
 
           <div class="flex items-center justify-between py-2">
-            <span class="text-sm text-gray-600">Show this help panel</span>
-            <kbd class="rounded border border-gray-200 bg-gray-50 px-2 py-0.5 text-xs font-medium text-gray-500">?</kbd>
+            <span class="text-sm text-gray-600 dark:text-gray-400">Show this help panel</span>
+            <kbd class="rounded border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 px-2 py-0.5 text-xs font-medium text-gray-500 dark:text-gray-400">?</kbd>
           </div>
 
-          <div class="border-t border-gray-100" />
+          <div class="border-t border-gray-100 dark:border-gray-800" />
 
-          <p class="pt-2 text-xs font-medium uppercase text-gray-400">Short Links Page</p>
+          <p class="pt-2 text-xs font-medium uppercase text-gray-400 dark:text-gray-500">Short Links Page</p>
 
           <div class="flex items-center justify-between py-2">
-            <span class="text-sm text-gray-600">Create new short link</span>
-            <kbd class="rounded border border-gray-200 bg-gray-50 px-2 py-0.5 text-xs font-medium text-gray-500">N</kbd>
+            <span class="text-sm text-gray-600 dark:text-gray-400">Create new short link</span>
+            <kbd class="rounded border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 px-2 py-0.5 text-xs font-medium text-gray-500 dark:text-gray-400">N</kbd>
           </div>
 
           <div class="flex items-center justify-between py-2">
-            <span class="text-sm text-gray-600">Focus search</span>
-            <kbd class="rounded border border-gray-200 bg-gray-50 px-2 py-0.5 text-xs font-medium text-gray-500">/</kbd>
+            <span class="text-sm text-gray-600 dark:text-gray-400">Focus search</span>
+            <kbd class="rounded border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 px-2 py-0.5 text-xs font-medium text-gray-500 dark:text-gray-400">/</kbd>
           </div>
 
-          <div class="border-t border-gray-100" />
+          <div class="border-t border-gray-100 dark:border-gray-800" />
 
           <div class="flex items-center justify-between py-2">
-            <span class="text-sm text-gray-600">Close panels / Cancel</span>
-            <kbd class="rounded border border-gray-200 bg-gray-50 px-2 py-0.5 text-xs font-medium text-gray-500">Esc</kbd>
+            <span class="text-sm text-gray-600 dark:text-gray-400">Close panels / Cancel</span>
+            <kbd class="rounded border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 px-2 py-0.5 text-xs font-medium text-gray-500 dark:text-gray-400">Esc</kbd>
           </div>
         </div>
       </div>

--- a/web-ui/src/pages/DashboardPage.vue
+++ b/web-ui/src/pages/DashboardPage.vue
@@ -514,22 +514,22 @@ onMounted(() => fetchDashboardData())
       </div>
 
       <!-- Today's Visits -->
-      <div class="rounded-xl border border-gray-200 bg-white p-3 shadow-sm sm:p-5">
+      <div class="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 p-3 shadow-sm sm:p-5">
         <div class="flex items-center justify-between">
           <div>
-            <p class="text-xs font-medium text-gray-500 sm:text-sm">{{ t('dashboard.todayVisits') }}</p>
+            <p class="text-xs font-medium text-gray-500 dark:text-gray-400 sm:text-sm">{{ t('dashboard.todayVisits') }}</p>
             <div class="mt-1 flex items-baseline gap-2">
-              <p class="text-xl font-bold text-gray-900 sm:text-2xl">
+              <p class="text-xl font-bold text-gray-900 dark:text-white sm:text-2xl">
                 <span
                   v-if="loading"
-                  class="inline-block h-7 w-16 animate-pulse rounded bg-gray-200"
+                  class="inline-block h-7 w-16 animate-pulse rounded bg-gray-200 dark:bg-gray-700"
                 />
                 <template v-else>{{ todayVisits.toLocaleString() }}</template>
               </p>
               <span
                 v-if="!loading && todayTrend"
                 class="inline-flex items-center gap-0.5 text-xs font-medium"
-                :class="todayTrend.dir === 'up' ? 'text-green-600' : todayTrend.dir === 'down' ? 'text-red-500' : 'text-gray-400'"
+                :class="todayTrend.dir === 'up' ? 'text-green-600 dark:text-green-400' : todayTrend.dir === 'down' ? 'text-red-500 dark:text-red-400' : 'text-gray-400'"
               >
                 <TrendingUp v-if="todayTrend.dir === 'up'" class="h-3 w-3" />
                 <TrendingDown v-else-if="todayTrend.dir === 'down'" class="h-3 w-3" />
@@ -538,7 +538,7 @@ onMounted(() => fetchDashboardData())
               </span>
             </div>
           </div>
-          <div class="flex h-8 w-8 items-center justify-center rounded-lg bg-purple-50 sm:h-10 sm:w-10">
+          <div class="flex h-8 w-8 items-center justify-center rounded-lg bg-purple-50 dark:bg-purple-900/20 sm:h-10 sm:w-10">
             <MousePointerClick class="h-4 w-4 text-purple-600 sm:h-5 sm:w-5" />
           </div>
         </div>
@@ -546,22 +546,22 @@ onMounted(() => fetchDashboardData())
       </div>
 
       <!-- Period Visits -->
-      <div class="rounded-xl border border-gray-200 bg-white p-3 shadow-sm sm:p-5">
+      <div class="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 p-3 shadow-sm sm:p-5">
         <div class="flex items-center justify-between">
           <div>
-            <p class="text-xs font-medium text-gray-500 sm:text-sm">{{ periodLabel }}</p>
+            <p class="text-xs font-medium text-gray-500 dark:text-gray-400 sm:text-sm">{{ periodLabel }}</p>
             <div class="mt-1 flex items-baseline gap-2">
-              <p class="text-xl font-bold text-gray-900 sm:text-2xl">
+              <p class="text-xl font-bold text-gray-900 dark:text-white sm:text-2xl">
                 <span
                   v-if="loading"
-                  class="inline-block h-7 w-16 animate-pulse rounded bg-gray-200"
+                  class="inline-block h-7 w-16 animate-pulse rounded bg-gray-200 dark:bg-gray-700"
                 />
                 <template v-else>{{ periodVisits.toLocaleString() }}</template>
               </p>
               <span
                 v-if="!loading && periodTrend"
                 class="inline-flex items-center gap-0.5 text-xs font-medium"
-                :class="periodTrend.dir === 'up' ? 'text-green-600' : periodTrend.dir === 'down' ? 'text-red-500' : 'text-gray-400'"
+                :class="periodTrend.dir === 'up' ? 'text-green-600 dark:text-green-400' : periodTrend.dir === 'down' ? 'text-red-500 dark:text-red-400' : 'text-gray-400'"
               >
                 <TrendingUp v-if="periodTrend.dir === 'up'" class="h-3 w-3" />
                 <TrendingDown v-else-if="periodTrend.dir === 'down'" class="h-3 w-3" />
@@ -570,7 +570,7 @@ onMounted(() => fetchDashboardData())
               </span>
             </div>
           </div>
-          <div class="flex h-8 w-8 items-center justify-center rounded-lg bg-orange-50 sm:h-10 sm:w-10">
+          <div class="flex h-8 w-8 items-center justify-center rounded-lg bg-orange-50 dark:bg-orange-900/20 sm:h-10 sm:w-10">
             <BarChart3 class="h-4 w-4 text-orange-600 sm:h-5 sm:w-5" />
           </div>
         </div>
@@ -581,17 +581,17 @@ onMounted(() => fetchDashboardData())
     <!-- Chart + Recent Links -->
     <div class="grid grid-cols-1 gap-4 lg:grid-cols-5 lg:gap-6">
       <!-- Visit Trend Chart -->
-      <div class="rounded-xl border border-gray-200 bg-white p-3 shadow-sm sm:p-5 lg:col-span-3">
+      <div class="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 p-3 shadow-sm sm:p-5 lg:col-span-3">
         <div class="mb-4 flex items-center justify-between">
           <div class="flex items-center gap-2">
-            <TrendingUp class="h-4 w-4 text-gray-500" />
-            <h2 class="text-base font-semibold text-gray-900">{{ t('dashboard.visitTrends') }}</h2>
+            <TrendingUp class="h-4 w-4 text-gray-500 dark:text-gray-400" />
+            <h2 class="text-base font-semibold text-gray-900 dark:text-white">{{ t('dashboard.visitTrends') }}</h2>
           </div>
-          <div class="flex rounded-lg border border-gray-200 p-0.5">
+          <div class="flex rounded-lg border border-gray-200 dark:border-gray-700 p-0.5">
             <button
               :class="[
                 'rounded-md px-3 py-1 text-xs font-medium transition-colors',
-                trendDays === 7 ? 'bg-blue-600 text-white' : 'text-gray-500 hover:text-gray-700',
+                trendDays === 7 ? 'bg-blue-600 text-white' : 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200',
               ]"
               @click="switchTrend(7)"
             >
@@ -600,7 +600,7 @@ onMounted(() => fetchDashboardData())
             <button
               :class="[
                 'rounded-md px-3 py-1 text-xs font-medium transition-colors',
-                trendDays === 30 ? 'bg-blue-600 text-white' : 'text-gray-500 hover:text-gray-700',
+                trendDays === 30 ? 'bg-blue-600 text-white' : 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200',
               ]"
               @click="switchTrend(30)"
             >
@@ -611,19 +611,19 @@ onMounted(() => fetchDashboardData())
         <div v-if="chartLoading" class="h-64">
           <!-- Chart skeleton -->
           <div class="flex h-full items-end gap-3 px-2 pt-4">
-            <div class="flex-1 animate-pulse rounded-t bg-gray-100" style="height: 55%" />
-            <div class="flex-1 animate-pulse rounded-t bg-gray-100" style="height: 75%" />
-            <div class="flex-1 animate-pulse rounded-t bg-gray-100" style="height: 45%" />
-            <div class="flex-1 animate-pulse rounded-t bg-gray-100" style="height: 85%" />
-            <div class="flex-1 animate-pulse rounded-t bg-gray-100" style="height: 65%" />
-            <div class="flex-1 animate-pulse rounded-t bg-gray-100" style="height: 40%" />
-            <div class="flex-1 animate-pulse rounded-t bg-gray-100" style="height: 70%" />
+            <div class="flex-1 animate-pulse rounded-t bg-gray-100 dark:bg-gray-800" style="height: 55%" />
+            <div class="flex-1 animate-pulse rounded-t bg-gray-100 dark:bg-gray-800" style="height: 75%" />
+            <div class="flex-1 animate-pulse rounded-t bg-gray-100 dark:bg-gray-800" style="height: 45%" />
+            <div class="flex-1 animate-pulse rounded-t bg-gray-100 dark:bg-gray-800" style="height: 85%" />
+            <div class="flex-1 animate-pulse rounded-t bg-gray-100 dark:bg-gray-800" style="height: 65%" />
+            <div class="flex-1 animate-pulse rounded-t bg-gray-100 dark:bg-gray-800" style="height: 40%" />
+            <div class="flex-1 animate-pulse rounded-t bg-gray-100 dark:bg-gray-800" style="height: 70%" />
           </div>
           <div class="mt-3 flex justify-between px-2">
-            <div class="h-2.5 w-10 animate-pulse rounded bg-gray-100" />
-            <div class="h-2.5 w-10 animate-pulse rounded bg-gray-100" />
-            <div class="h-2.5 w-10 animate-pulse rounded bg-gray-100" />
-            <div class="h-2.5 w-10 animate-pulse rounded bg-gray-100" />
+            <div class="h-2.5 w-10 animate-pulse rounded bg-gray-100 dark:bg-gray-800" />
+            <div class="h-2.5 w-10 animate-pulse rounded bg-gray-100 dark:bg-gray-800" />
+            <div class="h-2.5 w-10 animate-pulse rounded bg-gray-100 dark:bg-gray-800" />
+            <div class="h-2.5 w-10 animate-pulse rounded bg-gray-100 dark:bg-gray-800" />
           </div>
         </div>
         <div v-else class="h-48 sm:h-64">
@@ -638,22 +638,22 @@ onMounted(() => fetchDashboardData())
       </div>
 
       <!-- Recent Links -->
-      <div class="rounded-xl border border-gray-200 bg-white p-3 shadow-sm sm:p-5 lg:col-span-2">
+      <div class="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 p-3 shadow-sm sm:p-5 lg:col-span-2">
         <div class="mb-4 flex items-center justify-between">
           <div class="flex items-center gap-2">
-            <Clock class="h-4 w-4 text-gray-500" />
-            <h2 class="text-base font-semibold text-gray-900">{{ t('dashboard.recentLinks') }}</h2>
+            <Clock class="h-4 w-4 text-gray-500 dark:text-gray-400" />
+            <h2 class="text-base font-semibold text-gray-900 dark:text-white">{{ t('dashboard.recentLinks') }}</h2>
           </div>
           <router-link
             :to="{ name: 'short-links' }"
-            class="inline-flex items-center gap-1 text-xs font-medium text-blue-600 hover:text-blue-700"
+            class="inline-flex items-center gap-1 text-xs font-medium text-blue-600 dark:text-blue-400 hover:text-blue-700 dark:hover:text-blue-300"
           >
             {{ t('dashboard.viewAll') }}
             <ArrowRight class="h-3 w-3" />
           </router-link>
         </div>
         <div v-if="loading" class="space-y-3">
-          <div v-for="i in 5" :key="i" class="h-12 animate-pulse rounded-lg bg-gray-100" />
+          <div v-for="i in 5" :key="i" class="h-12 animate-pulse rounded-lg bg-gray-100 dark:bg-gray-800" />
         </div>
         <div v-else-if="recentLinks.length === 0" class="py-8 text-center">
           <Link class="mx-auto h-8 w-8 text-gray-300" />
@@ -666,7 +666,7 @@ onMounted(() => fetchDashboardData())
             {{ t('dashboard.createFirstLink') }}
           </router-link>
         </div>
-        <ul v-else class="divide-y divide-gray-100">
+        <ul v-else class="divide-y divide-gray-100 dark:divide-gray-800">
           <li
             v-for="link in recentLinks"
             :key="link.id"
@@ -674,23 +674,23 @@ onMounted(() => fetchDashboardData())
           >
             <div class="min-w-0 flex-1">
               <div class="flex items-center gap-2">
-                <span class="font-mono text-sm font-medium text-gray-900">{{ link.id }}</span>
+                <span class="font-mono text-sm font-medium text-gray-900 dark:text-white">{{ link.id }}</span>
                 <span
                   class="inline-flex items-center rounded-full px-1.5 py-0.5 text-[10px] font-medium"
                   :class="
-                    link.isEnable ? 'bg-green-50 text-green-700' : 'bg-gray-100 text-gray-500'
+                    link.isEnable ? 'bg-green-50 dark:bg-green-900/20 text-green-700 dark:text-green-400' : 'bg-gray-100 dark:bg-gray-800 text-gray-500 dark:text-gray-400'
                   "
                 >
                   {{ link.isEnable ? t('common.active') : t('common.inactive') }}
                 </span>
               </div>
-              <p class="mt-0.5 truncate text-xs text-gray-500">{{ link.url }}</p>
+              <p class="mt-0.5 truncate text-xs text-gray-500 dark:text-gray-400">{{ link.url }}</p>
             </div>
             <div
               class="ml-3 flex shrink-0 items-center gap-1 opacity-0 transition-opacity group-hover:opacity-100"
             >
               <button
-                class="rounded p-1 text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-600"
+                class="rounded p-1 text-gray-400 transition-colors hover:bg-gray-100 dark:hover:bg-gray-800 hover:text-gray-600 dark:hover:text-gray-300"
                 :title="t('dashboard.copyShortLink')"
                 @click="copyLink(link.id)"
               >
@@ -698,7 +698,7 @@ onMounted(() => fetchDashboardData())
                 <Check v-else class="h-3.5 w-3.5 text-green-500" />
               </button>
               <button
-                class="rounded p-1 text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-600"
+                class="rounded p-1 text-gray-400 transition-colors hover:bg-gray-100 dark:hover:bg-gray-800 hover:text-gray-600 dark:hover:text-gray-300"
                 :title="t('dashboard.viewDetails')"
                 @click="router.push({ name: 'short-link-detail', params: { id: link.id } })"
               >
@@ -711,17 +711,17 @@ onMounted(() => fetchDashboardData())
     </div>
 
     <!-- Top 10 Links -->
-    <div class="rounded-xl border border-gray-200 bg-white shadow-sm">
-      <div class="flex items-center justify-between border-b border-gray-100 px-5 py-4">
+    <div class="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 shadow-sm">
+      <div class="flex items-center justify-between border-b border-gray-100 dark:border-gray-800 px-5 py-4">
         <div class="flex items-center gap-2">
           <BarChart3 class="h-4 w-4 text-gray-500" />
-          <h2 class="text-base font-semibold text-gray-900">{{ t('dashboard.topLinks') }}</h2>
+          <h2 class="text-base font-semibold text-gray-900 dark:text-white">{{ t('dashboard.topLinks') }}</h2>
         </div>
         <span class="text-xs text-gray-400">{{ t('dashboard.basedOnDays', { days: trendDays }) }}</span>
       </div>
       <div v-if="loading" class="p-6">
         <div class="space-y-3">
-          <div v-for="i in 5" :key="i" class="h-10 animate-pulse rounded-lg bg-gray-100" />
+          <div v-for="i in 5" :key="i" class="h-10 animate-pulse rounded-lg bg-gray-100 dark:bg-gray-800" />
         </div>
       </div>
       <div v-else-if="topLinks.length === 0" class="px-5 py-12 text-center">
@@ -730,7 +730,7 @@ onMounted(() => fetchDashboardData())
       </div>
       <div v-else>
         <!-- Mobile cards -->
-        <div class="divide-y divide-gray-50 md:hidden">
+        <div class="divide-y divide-gray-50 dark:divide-gray-800 md:hidden">
           <div
             v-for="(item, index) in topLinks"
             :key="item.link.id"
@@ -739,7 +739,7 @@ onMounted(() => fetchDashboardData())
             <span
               :class="[
                 'inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-full text-xs font-semibold',
-                index < 3 ? 'bg-blue-100 text-blue-700' : 'bg-gray-100 text-gray-500',
+                index < 3 ? 'bg-blue-100 dark:bg-blue-900/20 text-blue-700 dark:text-blue-400' : 'bg-gray-100 dark:bg-gray-800 text-gray-500 dark:text-gray-400',
               ]"
             >
               {{ index + 1 }}
@@ -747,14 +747,14 @@ onMounted(() => fetchDashboardData())
             <div class="min-w-0 flex-1">
               <router-link
                 :to="{ name: 'short-link-detail', params: { id: item.link.id } }"
-                class="font-mono text-sm font-medium text-blue-600 hover:text-blue-700"
+                class="font-mono text-sm font-medium text-blue-600 dark:text-blue-400 hover:text-blue-700 dark:hover:text-blue-300"
               >
                 {{ item.link.id }}
               </router-link>
               <p class="truncate text-xs text-gray-400">{{ item.link.url }}</p>
             </div>
             <div class="shrink-0 text-right text-sm">
-              <p class="font-semibold text-gray-900">{{ item.pv.toLocaleString() }}</p>
+              <p class="font-semibold text-gray-900 dark:text-white">{{ item.pv.toLocaleString() }}</p>
               <p class="text-xs text-gray-400">{{ item.uv.toLocaleString() }} uv</p>
             </div>
           </div>
@@ -764,7 +764,7 @@ onMounted(() => fetchDashboardData())
           <table class="w-full text-sm">
             <thead>
               <tr
-                class="border-b border-gray-100 text-left text-xs font-medium uppercase tracking-wider text-gray-500"
+                class="border-b border-gray-100 dark:border-gray-800 text-left text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400"
               >
                 <th class="w-12 px-5 py-3">#</th>
                 <th class="px-5 py-3">{{ t('dashboard.shortLink') }}</th>
@@ -773,17 +773,17 @@ onMounted(() => fetchDashboardData())
                 <th class="px-5 py-3 text-right">UV</th>
               </tr>
             </thead>
-            <tbody class="divide-y divide-gray-50">
+            <tbody class="divide-y divide-gray-50 dark:divide-gray-800">
               <tr
                 v-for="(item, index) in topLinks"
                 :key="item.link.id"
-                class="transition-colors hover:bg-gray-50"
+                class="transition-colors hover:bg-gray-50 dark:hover:bg-gray-800"
               >
                 <td class="px-5 py-3">
                   <span
                     :class="[
                       'inline-flex h-6 w-6 items-center justify-center rounded-full text-xs font-semibold',
-                      index < 3 ? 'bg-blue-100 text-blue-700' : 'bg-gray-100 text-gray-500',
+                      index < 3 ? 'bg-blue-100 dark:bg-blue-900/20 text-blue-700 dark:text-blue-400' : 'bg-gray-100 dark:bg-gray-800 text-gray-500 dark:text-gray-400',
                     ]"
                   >
                     {{ index + 1 }}
@@ -792,18 +792,18 @@ onMounted(() => fetchDashboardData())
                 <td class="px-5 py-3">
                   <router-link
                     :to="{ name: 'short-link-detail', params: { id: item.link.id } }"
-                    class="inline-flex items-center gap-1 font-mono text-sm font-medium text-blue-600 hover:text-blue-700"
+                    class="inline-flex items-center gap-1 font-mono text-sm font-medium text-blue-600 dark:text-blue-400 hover:text-blue-700 dark:hover:text-blue-300"
                   >
                     {{ item.link.id }}
                   </router-link>
                 </td>
-                <td class="max-w-[280px] truncate px-5 py-3 text-gray-500">
+                <td class="max-w-[280px] truncate px-5 py-3 text-gray-500 dark:text-gray-400">
                   {{ item.link.url }}
                 </td>
-                <td class="whitespace-nowrap px-5 py-3 text-right font-semibold text-gray-900">
+                <td class="whitespace-nowrap px-5 py-3 text-right font-semibold text-gray-900 dark:text-white">
                   {{ item.pv.toLocaleString() }}
                 </td>
-                <td class="whitespace-nowrap px-5 py-3 text-right text-gray-600">
+                <td class="whitespace-nowrap px-5 py-3 text-right text-gray-600 dark:text-gray-400">
                   {{ item.uv.toLocaleString() }}
                 </td>
               </tr>

--- a/web-ui/src/pages/DashboardPage.vue
+++ b/web-ui/src/pages/DashboardPage.vue
@@ -3,6 +3,7 @@ import { ref, computed, onMounted } from 'vue'
 import { useRouter } from 'vue-router'
 import { useI18n } from 'vue-i18n'
 import { useAuthStore } from '@/stores/auth'
+import { useTheme } from '@/composables/useTheme'
 import { listShortLinks, getShortLinkData } from '@/api/short-link'
 import type { ShortLinkData, DailyStats, RequestHistory } from '@/types/api'
 import {
@@ -44,6 +45,7 @@ defineOptions({ name: 'DashboardPage' })
 const router = useRouter()
 const auth = useAuthStore()
 const { t } = useI18n()
+const { darkMode } = useTheme()
 
 const loading = ref(true)
 const refreshing = ref(false)
@@ -224,20 +226,21 @@ const chartOption = computed(() => {
   const dates = trendData.value.map((d) => formatShortDate(d.date))
   const pvData = trendData.value.map((d) => d.pv)
   const uvData = trendData.value.map((d) => d.uv)
+  const dark = darkMode.value
 
   return {
     tooltip: {
       trigger: 'axis' as const,
-      backgroundColor: '#fff',
-      borderColor: '#e5e7eb',
+      backgroundColor: dark ? '#1f2937' : '#fff',
+      borderColor: dark ? '#374151' : '#e5e7eb',
       borderWidth: 1,
-      textStyle: { color: '#374151', fontSize: 13 },
+      textStyle: { color: dark ? '#d1d5db' : '#374151', fontSize: 13 },
       axisPointer: { type: 'shadow' as const },
     },
     legend: {
       data: ['PV', 'UV'],
       bottom: 0,
-      textStyle: { color: '#6b7280', fontSize: 12 },
+      textStyle: { color: dark ? '#9ca3af' : '#6b7280', fontSize: 12 },
       itemWidth: 16,
       itemHeight: 2,
       itemGap: 24,
@@ -252,13 +255,13 @@ const chartOption = computed(() => {
       type: 'category' as const,
       data: dates,
       boundaryGap: false,
-      axisLine: { lineStyle: { color: '#e5e7eb' } },
+      axisLine: { lineStyle: { color: dark ? '#374151' : '#e5e7eb' } },
       axisTick: { show: false },
       axisLabel: { color: '#9ca3af', fontSize: 11 },
     },
     yAxis: {
       type: 'value' as const,
-      splitLine: { lineStyle: { color: '#f3f4f6', type: 'dashed' as const } },
+      splitLine: { lineStyle: { color: dark ? '#1f2937' : '#f3f4f6', type: 'dashed' as const } },
       axisLine: { show: false },
       axisTick: { show: false },
       axisLabel: { color: '#9ca3af', fontSize: 11 },
@@ -271,7 +274,7 @@ const chartOption = computed(() => {
         symbol: 'circle',
         symbolSize: 6,
         lineStyle: { width: 2.5, color: '#2563eb' },
-        itemStyle: { color: '#2563eb', borderWidth: 2, borderColor: '#fff' },
+        itemStyle: { color: '#2563eb', borderWidth: 2, borderColor: dark ? '#111827' : '#fff' },
         areaStyle: {
           color: {
             type: 'linear' as const,
@@ -294,7 +297,7 @@ const chartOption = computed(() => {
         symbol: 'circle',
         symbolSize: 6,
         lineStyle: { width: 2.5, color: '#8b5cf6' },
-        itemStyle: { color: '#8b5cf6', borderWidth: 2, borderColor: '#fff' },
+        itemStyle: { color: '#8b5cf6', borderWidth: 2, borderColor: dark ? '#111827' : '#fff' },
         areaStyle: {
           color: {
             type: 'linear' as const,
@@ -660,7 +663,7 @@ onMounted(() => fetchDashboardData())
           <p class="mt-2 text-sm text-gray-400">{{ t('dashboard.noShortLinks') }}</p>
           <router-link
             :to="{ name: 'short-link-create' }"
-            class="mt-2 inline-flex items-center gap-1 text-sm font-medium text-blue-600 hover:text-blue-700"
+            class="mt-2 inline-flex items-center gap-1 text-sm font-medium text-blue-600 dark:text-blue-400 hover:text-blue-700 dark:hover:text-blue-300"
           >
             <Plus class="h-3.5 w-3.5" />
             {{ t('dashboard.createFirstLink') }}
@@ -714,7 +717,7 @@ onMounted(() => fetchDashboardData())
     <div class="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 shadow-sm">
       <div class="flex items-center justify-between border-b border-gray-100 dark:border-gray-800 px-5 py-4">
         <div class="flex items-center gap-2">
-          <BarChart3 class="h-4 w-4 text-gray-500" />
+          <BarChart3 class="h-4 w-4 text-gray-500 dark:text-gray-400" />
           <h2 class="text-base font-semibold text-gray-900 dark:text-white">{{ t('dashboard.topLinks') }}</h2>
         </div>
         <span class="text-xs text-gray-400">{{ t('dashboard.basedOnDays', { days: trendDays }) }}</span>

--- a/web-ui/src/pages/InvitationsPage.vue
+++ b/web-ui/src/pages/InvitationsPage.vue
@@ -106,7 +106,7 @@ async function handleReject(id: string) {
           <span
             v-else
             class="rounded-full px-2.5 py-0.5 text-xs font-medium"
-            :class="inv.status === 'accepted' ? 'bg-green-50 text-green-700' : 'bg-gray-100 dark:bg-gray-800 text-gray-500 dark:text-gray-400'"
+            :class="inv.status === 'accepted' ? 'bg-green-50 dark:bg-green-900/20 text-green-700 dark:text-green-400' : 'bg-gray-100 dark:bg-gray-800 text-gray-500 dark:text-gray-400'"
           >
             {{ inv.status === 'accepted' ? t('invitations.accepted') : t('invitations.rejected') }}
           </span>

--- a/web-ui/src/pages/MembersPage.vue
+++ b/web-ui/src/pages/MembersPage.vue
@@ -251,7 +251,7 @@ onMounted(fetchMembers)
               <div class="flex items-center gap-3">
                 <div
                   class="flex h-8 w-8 shrink-0 items-center justify-center rounded-full text-xs font-bold"
-                  :class="m.role === UserRole.Admin ? 'bg-blue-100 text-blue-700' : 'bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-400'"
+                  :class="m.role === UserRole.Admin ? 'bg-blue-100 dark:bg-blue-900/30 text-blue-700 dark:text-blue-400' : 'bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-400'"
                 >
                   {{ m.username.charAt(0).toUpperCase() }}
                 </div>
@@ -264,7 +264,7 @@ onMounted(fetchMembers)
             <td class="px-4 py-3">
               <span
                 class="inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium"
-                :class="m.role === UserRole.Admin ? 'bg-blue-50 text-blue-700' : 'bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-400'"
+                :class="m.role === UserRole.Admin ? 'bg-blue-50 dark:bg-blue-900/20 text-blue-700 dark:text-blue-400' : 'bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-400'"
               >
                 <Shield v-if="m.role === UserRole.Admin" class="h-3 w-3" />
                 <User v-else class="h-3 w-3" />
@@ -358,7 +358,7 @@ onMounted(fetchMembers)
             <div class="flex justify-end gap-2">
               <button
                 type="button"
-                class="rounded-md border px-3 py-1.5 text-sm text-gray-600 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-700 dark:bg-gray-800/50"
+                class="rounded-md border px-3 py-1.5 text-sm text-gray-600 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-800"
                 @click="showInvite = false"
               >
                 {{ t('common.cancel') }}

--- a/web-ui/src/pages/NotFoundPage.vue
+++ b/web-ui/src/pages/NotFoundPage.vue
@@ -9,7 +9,7 @@ const router = useRouter()
 
 <template>
   <div class="flex min-h-[60vh] flex-col items-center justify-center text-center">
-    <h1 class="text-7xl font-bold text-gray-200 dark:text-gray-700">{{ t('notFound.title') }}</h1>
+    <h1 class="text-7xl font-bold text-gray-200 dark:text-gray-600">{{ t('notFound.title') }}</h1>
     <p class="mt-4 text-lg text-gray-500 dark:text-gray-400">{{ t('notFound.message') }}</p>
     <p class="mt-1 text-sm text-gray-400 dark:text-gray-500">
       {{ t('notFound.description') }}

--- a/web-ui/src/pages/SelectTenantPage.vue
+++ b/web-ui/src/pages/SelectTenantPage.vue
@@ -123,7 +123,7 @@ async function handleLogout() {
                 <div class="font-medium text-gray-900 dark:text-white">{{ tenant.tenantName }}</div>
                 <span
                   class="inline-block rounded-full px-2 py-0.5 text-xs font-medium"
-                  :class="tenant.role === 'admin' ? 'bg-red-50 text-red-700' : 'bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-300'"
+                  :class="tenant.role === 'admin' ? 'bg-red-50 dark:bg-red-900/20 text-red-700 dark:text-red-400' : 'bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-300'"
                 >
                   {{ tenant.role }}
                 </span>
@@ -135,7 +135,7 @@ async function handleLogout() {
 
         <button
           v-if="auth.isSuper"
-          class="mt-3 flex w-full items-center justify-between rounded-lg border-2 border-dashed border-amber-300 bg-amber-50 p-4 text-left transition hover:border-amber-400"
+          class="mt-3 flex w-full items-center justify-between rounded-lg border-2 border-dashed border-amber-300 dark:border-amber-600 bg-amber-50 dark:bg-amber-900/20 p-4 text-left transition hover:border-amber-400 dark:hover:border-amber-500"
           @click="enterSuperAdmin"
         >
           <div class="flex items-center gap-3">

--- a/web-ui/src/pages/ShortLinkCreatePage.vue
+++ b/web-ui/src/pages/ShortLinkCreatePage.vue
@@ -145,15 +145,15 @@ function goToLinks() {
     <!-- Success state -->
     <div
       v-if="createdLink"
-      class="mt-6 max-w-lg rounded-lg border border-green-200 bg-green-50 p-6"
+      class="mt-6 max-w-lg rounded-lg border border-green-200 dark:border-green-800/50 bg-green-50 dark:bg-green-900/20 p-6"
     >
-      <h2 class="text-lg font-semibold text-green-800">{{ t('shortLinkCreate.success') }}</h2>
-      <div class="mt-3 flex items-center gap-2 rounded-md bg-white p-3 shadow-sm">
+      <h2 class="text-lg font-semibold text-green-800 dark:text-green-300">{{ t('shortLinkCreate.success') }}</h2>
+      <div class="mt-3 flex items-center gap-2 rounded-md bg-white dark:bg-gray-800 p-3 shadow-sm">
         <span class="font-mono text-sm font-medium text-gray-900 dark:text-white">
           {{ getShortLinkUrl(createdLink.id) }}
         </span>
         <button
-          class="rounded p-1 text-gray-400 dark:text-gray-500 transition-colors hover:text-green-600"
+          class="rounded p-1 text-gray-400 dark:text-gray-500 transition-colors hover:text-green-600 dark:hover:text-green-400"
           title="Copy short link"
           @click="copyCreatedLink"
         >
@@ -164,7 +164,7 @@ function goToLinks() {
           :href="getShortLinkUrl(createdLink.id)"
           target="_blank"
           rel="noopener noreferrer"
-          class="rounded p-1 text-gray-400 dark:text-gray-500 transition-colors hover:text-blue-600"
+          class="rounded p-1 text-gray-400 dark:text-gray-500 transition-colors hover:text-blue-600 dark:hover:text-blue-400"
           title="Open short link"
         >
           <ExternalLink class="h-4 w-4" />

--- a/web-ui/src/pages/ShortLinkDetailPage.vue
+++ b/web-ui/src/pages/ShortLinkDetailPage.vue
@@ -356,14 +356,14 @@ onMounted(() => {
   <div>
     <div class="flex items-center gap-3">
       <button
-        class="rounded p-1.5 text-gray-400 dark:text-gray-500 transition-colors hover:bg-gray-100 dark:hover:bg-gray-800 dark:bg-gray-800 hover:text-gray-600 dark:text-gray-400 dark:text-gray-500 dark:hover:text-gray-300 dark:text-gray-600"
+        class="rounded p-1.5 text-gray-400 dark:text-gray-500 transition-colors hover:bg-gray-100 dark:hover:bg-gray-800 hover:text-gray-600 dark:hover:text-gray-300"
         @click="router.push({ name: 'short-links' })"
       >
         <ArrowLeft class="h-5 w-5" />
       </button>
       <div class="flex-1">
         <h1 class="text-xl font-semibold text-gray-900 dark:text-white">{{ t('shortLinkDetail.title') }}</h1>
-        <p v-if="link" class="mt-0.5 text-sm text-gray-500 dark:text-gray-400 dark:text-gray-500">
+        <p v-if="link" class="mt-0.5 text-sm text-gray-500 dark:text-gray-400">
           <span class="font-mono font-medium text-blue-600">{{ shortLinkUrl }}</span>
         </p>
       </div>
@@ -391,7 +391,7 @@ onMounted(() => {
 
     <template v-else-if="link">
       <!-- Basic info card -->
-      <div class="mt-4 rounded-lg border bg-white dark:bg-gray-900 p-5">
+      <div class="mt-4 rounded-lg border dark:border-gray-700 bg-white dark:bg-gray-900 p-5">
         <div class="grid gap-4 sm:grid-cols-2">
           <div>
             <label class="text-xs font-medium uppercase text-gray-400 dark:text-gray-500">{{ t('shortLinkDetail.shortLink') }}</label>
@@ -427,13 +427,13 @@ onMounted(() => {
           </div>
           <div>
             <label class="text-xs font-medium uppercase text-gray-400 dark:text-gray-500">{{ t('shortLinkDetail.description') }}</label>
-            <p class="mt-1 text-sm text-gray-700 dark:text-gray-300 dark:text-gray-600">{{ link.description || '—' }}</p>
+            <p class="mt-1 text-sm text-gray-700 dark:text-gray-300">{{ link.description || '—' }}</p>
           </div>
           <div>
             <label class="text-xs font-medium uppercase text-gray-400 dark:text-gray-500">{{ t('shortLinkDetail.status') }}</label>
             <span
               class="mt-1 inline-flex items-center gap-1.5 rounded-full px-2.5 py-0.5 text-xs font-medium"
-              :class="link.isEnable ? 'bg-green-50 text-green-700' : 'bg-gray-100 dark:bg-gray-800 text-gray-500 dark:text-gray-400 dark:text-gray-500'"
+              :class="link.isEnable ? 'bg-green-50 dark:bg-green-900/20 text-green-700 dark:text-green-400' : 'bg-gray-100 dark:bg-gray-800 text-gray-500 dark:text-gray-400'"
             >
               <span
                 class="h-1.5 w-1.5 rounded-full"
@@ -444,11 +444,11 @@ onMounted(() => {
           </div>
           <div>
             <label class="text-xs font-medium uppercase text-gray-400 dark:text-gray-500">{{ t('shortLinkDetail.createdBy') }}</label>
-            <p class="mt-1 text-sm text-gray-700 dark:text-gray-300 dark:text-gray-600">{{ link.createdBy }}</p>
+            <p class="mt-1 text-sm text-gray-700 dark:text-gray-300">{{ link.createdBy }}</p>
           </div>
           <div>
             <label class="text-xs font-medium uppercase text-gray-400 dark:text-gray-500">{{ t('shortLinkDetail.created') }}</label>
-            <p class="mt-1 text-sm text-gray-700 dark:text-gray-300 dark:text-gray-600">{{ formatDate(link.createTime) }}</p>
+            <p class="mt-1 text-sm text-gray-700 dark:text-gray-300">{{ formatDate(link.createTime) }}</p>
           </div>
         </div>
       </div>
@@ -458,12 +458,12 @@ onMounted(() => {
         <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
           <h2 class="text-lg font-semibold text-gray-900 dark:text-white">{{ t('shortLinkDetail.accessAnalytics') }}</h2>
           <div class="flex items-center gap-2">
-            <div class="flex items-center gap-1 rounded-lg border bg-white dark:bg-gray-900 p-1">
+            <div class="flex items-center gap-1 rounded-lg border dark:border-gray-700 bg-white dark:bg-gray-900 p-1">
               <button
                 v-for="d in [7, 14, 30]"
                 :key="d"
                 class="rounded-md px-3 py-1 text-xs font-medium transition-colors"
-                :class="daysAgo === d ? 'bg-blue-600 text-white' : 'text-gray-600 dark:text-gray-400 dark:text-gray-500 hover:bg-gray-100 dark:hover:bg-gray-800 dark:bg-gray-800'"
+                :class="daysAgo === d ? 'bg-blue-600 text-white' : 'text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800'"
                 @click="setDateRange(d)"
               >
                 {{ d }}d
@@ -474,28 +474,28 @@ onMounted(() => {
 
         <!-- Stats cards -->
         <div class="mt-4 grid grid-cols-2 gap-3 sm:grid-cols-4">
-          <div class="rounded-lg border bg-white dark:bg-gray-900 p-4">
+          <div class="rounded-lg border dark:border-gray-700 bg-white dark:bg-gray-900 p-4">
             <div class="flex items-center gap-2 text-gray-400 dark:text-gray-500">
               <Calendar class="h-4 w-4" />
               <span class="text-xs font-medium uppercase">{{ t('shortLinkDetail.totalVisits') }}</span>
             </div>
             <p class="mt-2 text-2xl font-bold text-gray-900 dark:text-white">{{ totalVisits }}</p>
           </div>
-          <div class="rounded-lg border bg-white dark:bg-gray-900 p-4">
+          <div class="rounded-lg border dark:border-gray-700 bg-white dark:bg-gray-900 p-4">
             <div class="flex items-center gap-2 text-gray-400 dark:text-gray-500">
               <Globe class="h-4 w-4" />
               <span class="text-xs font-medium uppercase">{{ t('shortLinkDetail.uniqueIps') }}</span>
             </div>
             <p class="mt-2 text-2xl font-bold text-gray-900 dark:text-white">{{ uniqueIps }}</p>
           </div>
-          <div class="rounded-lg border bg-white dark:bg-gray-900 p-4">
+          <div class="rounded-lg border dark:border-gray-700 bg-white dark:bg-gray-900 p-4">
             <div class="flex items-center gap-2 text-gray-400 dark:text-gray-500">
               <Monitor class="h-4 w-4" />
               <span class="text-xs font-medium uppercase">{{ t('shortLinkDetail.platforms') }}</span>
             </div>
             <p class="mt-2 text-2xl font-bold text-gray-900 dark:text-white">{{ osDistribution.length }}</p>
           </div>
-          <div class="rounded-lg border bg-white dark:bg-gray-900 p-4">
+          <div class="rounded-lg border dark:border-gray-700 bg-white dark:bg-gray-900 p-4">
             <div class="flex items-center gap-2 text-gray-400 dark:text-gray-500">
               <Calendar class="h-4 w-4" />
               <span class="text-xs font-medium uppercase">{{ t('shortLinkDetail.avgDay') }}</span>
@@ -507,10 +507,10 @@ onMounted(() => {
         </div>
 
         <!-- Tab switcher -->
-        <div class="mt-6 flex gap-1 rounded-lg border bg-white dark:bg-gray-900 p-1 w-fit">
+        <div class="mt-6 flex gap-1 rounded-lg border dark:border-gray-700 bg-white dark:bg-gray-900 p-1 w-fit">
           <button
             class="inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 text-xs font-medium transition-colors"
-            :class="activeTab === 'trend' ? 'bg-blue-600 text-white' : 'text-gray-600 dark:text-gray-400 dark:text-gray-500 hover:bg-gray-100 dark:hover:bg-gray-800 dark:bg-gray-800'"
+            :class="activeTab === 'trend' ? 'bg-blue-600 text-white' : 'text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800'"
             @click="activeTab = 'trend'"
           >
             <LayoutGrid class="h-3.5 w-3.5" />
@@ -518,7 +518,7 @@ onMounted(() => {
           </button>
           <button
             class="inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 text-xs font-medium transition-colors"
-            :class="activeTab === 'records' ? 'bg-blue-600 text-white' : 'text-gray-600 dark:text-gray-400 dark:text-gray-500 hover:bg-gray-100 dark:hover:bg-gray-800 dark:bg-gray-800'"
+            :class="activeTab === 'records' ? 'bg-blue-600 text-white' : 'text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800'"
             @click="activeTab = 'records'"
           >
             <FileText class="h-3.5 w-3.5" />
@@ -529,8 +529,8 @@ onMounted(() => {
         <!-- Charts tab -->
         <template v-if="activeTab === 'trend'">
           <!-- Visit trend chart -->
-          <div class="mt-4 rounded-lg border bg-white dark:bg-gray-900 p-5">
-            <h3 class="mb-4 text-sm font-semibold text-gray-700 dark:text-gray-300 dark:text-gray-600">{{ t('shortLinkDetail.visitTrend') }}</h3>
+          <div class="mt-4 rounded-lg border dark:border-gray-700 bg-white dark:bg-gray-900 p-5">
+            <h3 class="mb-4 text-sm font-semibold text-gray-700 dark:text-gray-300">{{ t('shortLinkDetail.visitTrend') }}</h3>
             <div v-if="chartLoading" class="flex h-56 items-center justify-center">
               <Loader2 class="h-5 w-5 animate-spin text-gray-400 dark:text-gray-500" />
             </div>
@@ -553,8 +553,8 @@ onMounted(() => {
 
           <!-- OS & Browser distribution charts -->
           <div class="mt-4 grid gap-4 lg:grid-cols-2">
-            <div class="rounded-lg border bg-white dark:bg-gray-900 p-5">
-              <h3 class="mb-4 text-sm font-semibold text-gray-700 dark:text-gray-300 dark:text-gray-600">{{ t('shortLinkDetail.osDistribution') }}</h3>
+            <div class="rounded-lg border dark:border-gray-700 bg-white dark:bg-gray-900 p-5">
+              <h3 class="mb-4 text-sm font-semibold text-gray-700 dark:text-gray-300">{{ t('shortLinkDetail.osDistribution') }}</h3>
               <div v-if="chartLoading" class="flex h-56 items-center justify-center">
                 <Loader2 class="h-5 w-5 animate-spin text-gray-400 dark:text-gray-500" />
               </div>
@@ -575,8 +575,8 @@ onMounted(() => {
               </div>
             </div>
 
-            <div class="rounded-lg border bg-white dark:bg-gray-900 p-5">
-              <h3 class="mb-4 text-sm font-semibold text-gray-700 dark:text-gray-300 dark:text-gray-600">{{ t('shortLinkDetail.browserDistribution') }}</h3>
+            <div class="rounded-lg border dark:border-gray-700 bg-white dark:bg-gray-900 p-5">
+              <h3 class="mb-4 text-sm font-semibold text-gray-700 dark:text-gray-300">{{ t('shortLinkDetail.browserDistribution') }}</h3>
               <div v-if="chartLoading" class="flex h-56 items-center justify-center">
                 <Loader2 class="h-5 w-5 animate-spin text-gray-400 dark:text-gray-500" />
               </div>
@@ -599,8 +599,8 @@ onMounted(() => {
           </div>
 
           <!-- Referer distribution -->
-          <div class="mt-4 rounded-lg border bg-white dark:bg-gray-900 p-5">
-            <h3 class="mb-4 text-sm font-semibold text-gray-700 dark:text-gray-300 dark:text-gray-600">{{ t('shortLinkDetail.refererSources') }}</h3>
+          <div class="mt-4 rounded-lg border dark:border-gray-700 bg-white dark:bg-gray-900 p-5">
+            <h3 class="mb-4 text-sm font-semibold text-gray-700 dark:text-gray-300">{{ t('shortLinkDetail.refererSources') }}</h3>
             <div v-if="chartLoading" class="flex h-56 items-center justify-center">
               <Loader2 class="h-5 w-5 animate-spin text-gray-400 dark:text-gray-500" />
             </div>
@@ -622,8 +622,8 @@ onMounted(() => {
           </div>
 
           <!-- IP distribution table -->
-          <div class="mt-4 rounded-lg border bg-white dark:bg-gray-900 p-5">
-            <h3 class="mb-4 text-sm font-semibold text-gray-700 dark:text-gray-300 dark:text-gray-600">{{ t('shortLinkDetail.topIps') }}</h3>
+          <div class="mt-4 rounded-lg border dark:border-gray-700 bg-white dark:bg-gray-900 p-5">
+            <h3 class="mb-4 text-sm font-semibold text-gray-700 dark:text-gray-300">{{ t('shortLinkDetail.topIps') }}</h3>
             <div v-if="ipDistribution.length === 0" class="py-8 text-center text-sm text-gray-400 dark:text-gray-500">
               No data for this period.
             </div>
@@ -641,11 +641,11 @@ onMounted(() => {
                   :key="item.ip"
                   class="border-b border-gray-50 dark:border-gray-800 last:border-0"
                 >
-                  <td class="py-2 pr-4 font-mono text-gray-700 dark:text-gray-300 dark:text-gray-600">{{ item.ip }}</td>
-                  <td class="py-2 pr-4 text-right font-medium text-gray-600 dark:text-gray-400 dark:text-gray-500">{{ item.count }}</td>
+                  <td class="py-2 pr-4 font-mono text-gray-700 dark:text-gray-300">{{ item.ip }}</td>
+                  <td class="py-2 pr-4 text-right font-medium text-gray-600 dark:text-gray-400">{{ item.count }}</td>
                   <td class="py-2 text-right">
                     <span class="inline-flex items-center gap-2">
-                      <span class="text-gray-500 dark:text-gray-400 dark:text-gray-500">{{ item.percent }}%</span>
+                      <span class="text-gray-500 dark:text-gray-400">{{ item.percent }}%</span>
                       <span class="inline-block h-1.5 w-16 overflow-hidden rounded-full bg-gray-100 dark:bg-gray-800">
                         <span
                           class="inline-block h-full rounded-full bg-emerald-500"
@@ -662,7 +662,7 @@ onMounted(() => {
 
         <!-- Access records tab -->
         <template v-if="activeTab === 'records'">
-          <div class="mt-4 rounded-lg border bg-white dark:bg-gray-900">
+          <div class="mt-4 rounded-lg border dark:border-gray-700 bg-white dark:bg-gray-900">
             <div v-if="chartLoading" class="flex h-40 items-center justify-center">
               <Loader2 class="h-5 w-5 animate-spin text-gray-400 dark:text-gray-500" />
             </div>
@@ -691,19 +691,19 @@ onMounted(() => {
                       :key="h.id"
                       class="border-b border-gray-50 dark:border-gray-800 hover:bg-gray-50 dark:hover:bg-gray-700 dark:bg-gray-800/50/50"
                     >
-                      <td class="whitespace-nowrap px-4 py-2.5 text-gray-600 dark:text-gray-400 dark:text-gray-500">
+                      <td class="whitespace-nowrap px-4 py-2.5 text-gray-600 dark:text-gray-400">
                         {{ formatDate(h.time) }}
                       </td>
-                      <td class="whitespace-nowrap px-4 py-2.5 font-mono text-gray-700 dark:text-gray-300 dark:text-gray-600">
+                      <td class="whitespace-nowrap px-4 py-2.5 font-mono text-gray-700 dark:text-gray-300">
                         {{ h.ip }}
                       </td>
-                      <td class="whitespace-nowrap px-4 py-2.5 text-gray-600 dark:text-gray-400 dark:text-gray-500">
+                      <td class="whitespace-nowrap px-4 py-2.5 text-gray-600 dark:text-gray-400">
                         {{ h.browser || parseBrowser(h.ua) || '—' }}
                       </td>
-                      <td class="whitespace-nowrap px-4 py-2.5 text-gray-600 dark:text-gray-400 dark:text-gray-500">
+                      <td class="whitespace-nowrap px-4 py-2.5 text-gray-600 dark:text-gray-400">
                         {{ parseOS(h.ua) }}
                       </td>
-                      <td class="max-w-[200px] truncate px-4 py-2.5 text-gray-600 dark:text-gray-400 dark:text-gray-500">
+                      <td class="max-w-[200px] truncate px-4 py-2.5 text-gray-600 dark:text-gray-400">
                         {{ h.referer ? extractRefererSource(h.referer) : 'Direct' }}
                       </td>
                       <td

--- a/web-ui/src/pages/ShortLinkEditPage.vue
+++ b/web-ui/src/pages/ShortLinkEditPage.vue
@@ -115,21 +115,21 @@ onMounted(fetchData)
   <div>
     <div class="flex items-center gap-3">
       <button
-        class="rounded p-1.5 text-gray-400 dark:text-gray-500 transition-colors hover:bg-gray-100 dark:hover:bg-gray-800 dark:bg-gray-800 hover:text-gray-600 dark:text-gray-400 dark:text-gray-500 dark:hover:text-gray-300 dark:text-gray-600"
+        class="rounded p-1.5 text-gray-400 dark:text-gray-500 transition-colors hover:bg-gray-100 dark:hover:bg-gray-800 hover:text-gray-600 dark:hover:text-gray-300"
         @click="router.push({ name: 'short-links' })"
       >
         <ArrowLeft class="h-5 w-5" />
       </button>
       <div>
         <h1 class="text-xl font-semibold text-gray-900 dark:text-white">{{ t('shortLinkEdit.title') }}</h1>
-        <p class="mt-0.5 text-sm text-gray-500 dark:text-gray-400 dark:text-gray-500">
-          Editing <span class="font-mono font-medium text-gray-700 dark:text-gray-300 dark:text-gray-600">{{ id }}</span>
+        <p class="mt-0.5 text-sm text-gray-500 dark:text-gray-400">
+          Editing <span class="font-mono font-medium text-gray-700 dark:text-gray-300">{{ id }}</span>
         </p>
       </div>
     </div>
 
     <!-- Skeleton loading -->
-    <div v-if="loading" class="mt-6 max-w-lg rounded-lg border bg-white dark:bg-gray-900 p-6">
+    <div v-if="loading" class="mt-6 max-w-lg rounded-lg border dark:border-gray-700 bg-white dark:bg-gray-900 p-6">
       <div class="mb-5 rounded-md bg-gray-50 dark:bg-gray-800/50 p-3">
         <div class="grid grid-cols-2 gap-2">
           <div class="h-4 w-32 animate-pulse rounded bg-gray-200 dark:bg-gray-700" />
@@ -172,23 +172,23 @@ onMounted(fetchData)
       <div class="mb-5 rounded-md bg-gray-50 dark:bg-gray-800/50 p-3">
         <div class="grid grid-cols-2 gap-2 text-sm">
           <div>
-            <span class="text-gray-500 dark:text-gray-400 dark:text-gray-500">{{ t('shortLinkEdit.infoId') }}</span>
+            <span class="text-gray-500 dark:text-gray-400">{{ t('shortLinkEdit.infoId') }}</span>
             <span class="ml-1 font-mono font-medium text-gray-900 dark:text-white">{{ id }}</span>
           </div>
           <div>
-            <span class="text-gray-500 dark:text-gray-400 dark:text-gray-500">{{ t('shortLinkEdit.infoCreatedBy') }}</span>
-            <span class="ml-1 text-gray-700 dark:text-gray-300 dark:text-gray-600">{{ createdBy }}</span>
+            <span class="text-gray-500 dark:text-gray-400">{{ t('shortLinkEdit.infoCreatedBy') }}</span>
+            <span class="ml-1 text-gray-700 dark:text-gray-300">{{ createdBy }}</span>
           </div>
           <div class="col-span-2">
-            <span class="text-gray-500 dark:text-gray-400 dark:text-gray-500">{{ t('shortLinkEdit.infoCreated') }}</span>
-            <span class="ml-1 text-gray-700 dark:text-gray-300 dark:text-gray-600">{{ formatDate(createTime) }}</span>
+            <span class="text-gray-500 dark:text-gray-400">{{ t('shortLinkEdit.infoCreated') }}</span>
+            <span class="ml-1 text-gray-700 dark:text-gray-300">{{ formatDate(createTime) }}</span>
           </div>
         </div>
       </div>
 
       <div class="space-y-5">
         <div>
-          <label class="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300 dark:text-gray-600">
+          <label class="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300">
             Target URL <span class="text-red-500">*</span>
           </label>
           <input
@@ -206,7 +206,7 @@ onMounted(fetchData)
         </div>
 
         <div>
-          <label class="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300 dark:text-gray-600">{{ t('shortLinkEdit.description') }}</label>
+          <label class="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300">{{ t('shortLinkEdit.description') }}</label>
           <textarea
             v-model="description"
             rows="3"
@@ -215,7 +215,7 @@ onMounted(fetchData)
         </div>
 
         <div class="flex items-center gap-3">
-          <label class="text-sm font-medium text-gray-700 dark:text-gray-300 dark:text-gray-600">{{ t('shortLinkEdit.enabled') }}</label>
+          <label class="text-sm font-medium text-gray-700 dark:text-gray-300">{{ t('shortLinkEdit.enabled') }}</label>
           <button
             type="button"
             role="switch"
@@ -244,7 +244,7 @@ onMounted(fetchData)
         </button>
         <button
           type="button"
-          class="rounded-md px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 dark:text-gray-600 transition-colors hover:bg-gray-100 dark:hover:bg-gray-800 dark:bg-gray-800"
+          class="rounded-md px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 transition-colors hover:bg-gray-100 dark:hover:bg-gray-800"
           @click="router.push({ name: 'short-links' })"
         >
           Cancel

--- a/web-ui/src/pages/ShortLinksPage.vue
+++ b/web-ui/src/pages/ShortLinksPage.vue
@@ -289,7 +289,7 @@ onMounted(fetchLinks)
     <div class="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
       <div>
         <h1 class="text-xl font-semibold text-gray-900 dark:text-white">{{ t('shortLinks.title') }}</h1>
-        <p class="mt-1 text-sm text-gray-500 dark:text-gray-400 dark:text-gray-500">{{ t('shortLinks.linkCountTotal', { count: total, suffix: total !== 1 ? 's' : '' }) }}</p>
+        <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">{{ t('shortLinks.linkCountTotal', { count: total, suffix: total !== 1 ? 's' : '' }) }}</p>
       </div>
       <router-link
         :to="{ name: 'short-link-create' }"
@@ -335,24 +335,24 @@ onMounted(fetchLinks)
 
     <!-- Batch actions -->
     <div v-if="selectedIds.size > 0" class="mt-3 flex flex-wrap items-center gap-2">
-      <span class="text-sm text-gray-600 dark:text-gray-400 dark:text-gray-500">{{ t('shortLinks.selected', { count: selectedIds.size }) }}</span>
+      <span class="text-sm text-gray-600 dark:text-gray-400">{{ t('shortLinks.selected', { count: selectedIds.size }) }}</span>
       <button
         :disabled="batchUpdating"
-        class="inline-flex items-center gap-1.5 rounded-md bg-green-50 px-3 py-1.5 text-sm font-medium text-green-600 transition-colors hover:bg-green-100 disabled:opacity-50"
+        class="inline-flex items-center gap-1.5 rounded-md bg-green-50 dark:bg-green-900/20 px-3 py-1.5 text-sm font-medium text-green-600 dark:text-green-400 transition-colors hover:bg-green-100 dark:hover:bg-green-800/30 disabled:opacity-50"
         @click="handleBatchToggleEnable(true)"
       >
         {{ t('shortLinks.enableSelected') }}
       </button>
       <button
         :disabled="batchUpdating"
-        class="inline-flex items-center gap-1.5 rounded-md bg-gray-100 dark:bg-gray-800 px-3 py-1.5 text-sm font-medium text-gray-600 dark:text-gray-400 dark:text-gray-500 transition-colors hover:bg-gray-200 dark:bg-gray-700 disabled:opacity-50"
+        class="inline-flex items-center gap-1.5 rounded-md bg-gray-100 dark:bg-gray-800 px-3 py-1.5 text-sm font-medium text-gray-600 dark:text-gray-400 transition-colors hover:bg-gray-200 dark:bg-gray-700 disabled:opacity-50"
         @click="handleBatchToggleEnable(false)"
       >
         {{ t('shortLinks.disableSelected') }}
       </button>
       <button
         :disabled="deleting === 'batch'"
-        class="inline-flex items-center gap-1.5 rounded-md bg-red-50 px-3 py-1.5 text-sm font-medium text-red-600 transition-colors hover:bg-red-100 disabled:opacity-50"
+        class="inline-flex items-center gap-1.5 rounded-md bg-red-50 dark:bg-red-900/20 px-3 py-1.5 text-sm font-medium text-red-600 dark:text-red-400 transition-colors hover:bg-red-100 dark:hover:bg-red-800/30 disabled:opacity-50"
         @click="handleBatchDelete"
       >
         <Trash2 class="h-3.5 w-3.5" />
@@ -379,7 +379,7 @@ onMounted(fetchLinks)
       <!-- Empty state -->
       <div v-else-if="filteredLinks.length === 0 && total === 0" class="rounded-lg border bg-white dark:bg-gray-900 py-12 text-center">
         <Link class="mx-auto h-10 w-10 text-gray-300 dark:text-gray-600" />
-        <p class="mt-3 text-sm font-medium text-gray-500 dark:text-gray-400 dark:text-gray-500">{{ t('shortLinks.noLinksYet') }}</p>
+        <p class="mt-3 text-sm font-medium text-gray-500 dark:text-gray-400">{{ t('shortLinks.noLinksYet') }}</p>
         <router-link
           :to="{ name: 'short-link-create' }"
           class="mt-3 inline-flex items-center gap-1.5 rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700"
@@ -396,7 +396,7 @@ onMounted(fetchLinks)
         v-for="link in sortedLinks"
         :key="link.id"
         class="rounded-lg border bg-white dark:bg-gray-900 transition-colors"
-        :class="{ 'border-blue-200 bg-blue-50/30': selectedIds.has(link.id) }"
+        :class="{ 'border-blue-200 dark:border-blue-800 bg-blue-50/30 dark:bg-blue-900/10': selectedIds.has(link.id) }"
       >
         <div class="flex items-center justify-between p-4">
           <div class="flex items-center gap-2">
@@ -420,7 +420,7 @@ onMounted(fetchLinks)
           <button
             :disabled="togglingId === link.id"
             class="inline-flex items-center gap-1.5 rounded-full px-2 py-0.5 text-xs font-medium"
-            :class="link.isEnable ? 'bg-green-50 text-green-700' : 'bg-gray-100 dark:bg-gray-800 text-gray-500 dark:text-gray-400 dark:text-gray-500'"
+            :class="link.isEnable ? 'bg-green-50 text-green-700' : 'bg-gray-100 dark:bg-gray-800 text-gray-500 dark:text-gray-400'"
             @click="handleToggleEnable(link)"
           >
             <Loader2 v-if="togglingId === link.id" class="h-3 w-3 animate-spin" />
@@ -444,7 +444,7 @@ onMounted(fetchLinks)
           <span class="text-xs text-gray-400 dark:text-gray-500">{{ formatDate(link.createTime) }}</span>
           <div class="flex items-center gap-1">
             <button
-              class="rounded p-1.5 text-gray-400 dark:text-gray-500 hover:bg-gray-100 dark:hover:bg-gray-800 dark:bg-gray-800 hover:text-gray-600 dark:text-gray-400 dark:text-gray-500 dark:hover:text-gray-300 dark:text-gray-600"
+              class="rounded p-1.5 text-gray-400 dark:text-gray-500 transition-colors hover:bg-gray-100 dark:hover:bg-gray-800 hover:text-gray-600 dark:hover:text-gray-300"
               :title="t('common.viewDetails')"
               aria-label="View details"
               @click="router.push({ name: 'short-link-detail', params: { id: link.id } })"
@@ -452,7 +452,7 @@ onMounted(fetchLinks)
               <Eye class="h-4 w-4" />
             </button>
             <button
-              class="rounded p-1.5 text-gray-400 dark:text-gray-500 hover:bg-gray-100 dark:hover:bg-gray-800 dark:bg-gray-800 hover:text-gray-600 dark:text-gray-400 dark:text-gray-500 dark:hover:text-gray-300 dark:text-gray-600"
+              class="rounded p-1.5 text-gray-400 dark:text-gray-500 transition-colors hover:bg-gray-100 dark:hover:bg-gray-800 hover:text-gray-600 dark:hover:text-gray-300"
               :title="t('common.edit')"
               aria-label="Edit"
               @click="router.push({ name: 'short-link-edit', params: { id: link.id } })"
@@ -460,7 +460,7 @@ onMounted(fetchLinks)
               <Pencil class="h-4 w-4" />
             </button>
             <button
-              class="rounded p-1.5 text-gray-400 dark:text-gray-500 hover:bg-red-50 hover:text-red-600"
+              class="rounded p-1.5 text-gray-400 dark:text-gray-500 hover:bg-red-50 dark:hover:bg-red-900/20 hover:text-red-600 dark:hover:text-red-400"
               :title="t('common.delete')"
               aria-label="Delete"
               @click="confirmDeleteId = link.id"
@@ -482,16 +482,16 @@ onMounted(fetchLinks)
         <div class="flex items-center gap-1">
           <button
             :disabled="page <= 1"
-            class="rounded p-1.5 text-gray-400 dark:text-gray-500 transition-colors hover:bg-gray-100 dark:hover:bg-gray-800 dark:bg-gray-800 disabled:opacity-30"
+            class="rounded p-1.5 text-gray-400 dark:text-gray-500 transition-colors hover:bg-gray-100 dark:hover:bg-gray-800 disabled:opacity-30"
             aria-label="Previous page"
             @click="goPage(page - 1)"
           >
             <ChevronLeft class="h-5 w-5" />
           </button>
-          <span class="min-w-[60px] text-center text-sm font-medium text-gray-700 dark:text-gray-300 dark:text-gray-600">{{ page }} / {{ totalPages }}</span>
+          <span class="min-w-[60px] text-center text-sm font-medium text-gray-700 dark:text-gray-300">{{ page }} / {{ totalPages }}</span>
           <button
             :disabled="page >= totalPages"
-            class="rounded p-1.5 text-gray-400 dark:text-gray-500 transition-colors hover:bg-gray-100 dark:hover:bg-gray-800 dark:bg-gray-800 disabled:opacity-30"
+            class="rounded p-1.5 text-gray-400 dark:text-gray-500 transition-colors hover:bg-gray-100 dark:hover:bg-gray-800 disabled:opacity-30"
             aria-label="Next page"
             @click="goPage(page + 1)"
           >
@@ -502,12 +502,12 @@ onMounted(fetchLinks)
     </div>
 
     <!-- Desktop table (hidden below md) -->
-    <div class="mt-4 hidden overflow-hidden rounded-lg border bg-white dark:bg-gray-900 dark:bg-gray-900 md:block">
+    <div class="mt-4 hidden overflow-hidden rounded-lg border bg-white dark:bg-gray-900 md:block">
       <div class="overflow-x-auto">
         <table class="w-full text-sm">
           <thead>
             <tr
-              class="border-b bg-gray-50 dark:bg-gray-800/50 text-left text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400 dark:text-gray-500"
+              class="border-b bg-gray-50 dark:bg-gray-800/50 text-left text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400"
             >
               <th class="w-10 px-4 py-3">
                 <input
@@ -581,7 +581,7 @@ onMounted(fetchLinks)
             <tr v-else-if="filteredLinks.length === 0 && total === 0">
               <td colspan="8" class="px-4 py-12 text-center">
                 <Link class="mx-auto h-10 w-10 text-gray-300 dark:text-gray-600" />
-                <p class="mt-3 text-sm font-medium text-gray-500 dark:text-gray-400 dark:text-gray-500">{{ t('shortLinks.noLinksYet') }}</p>
+                <p class="mt-3 text-sm font-medium text-gray-500 dark:text-gray-400">{{ t('shortLinks.noLinksYet') }}</p>
                 <p class="mt-1 text-sm text-gray-400 dark:text-gray-500">
                   Create your first short link to get started.
                 </p>
@@ -638,7 +638,7 @@ onMounted(fetchLinks)
                   <ExternalLink class="h-3 w-3 shrink-0" />
                 </a>
               </td>
-              <td class="hidden max-w-[180px] truncate px-4 py-3 text-gray-500 dark:text-gray-400 dark:text-gray-500 md:table-cell">
+              <td class="hidden max-w-[180px] truncate px-4 py-3 text-gray-500 dark:text-gray-400 md:table-cell">
                 {{ link.description || '—' }}
               </td>
               <td class="px-4 py-3">
@@ -647,8 +647,8 @@ onMounted(fetchLinks)
                   class="inline-flex items-center gap-1.5 rounded-full px-2.5 py-0.5 text-xs font-medium transition-colors"
                   :class="
                     link.isEnable
-                      ? 'bg-green-50 text-green-700 hover:bg-green-100'
-                      : 'bg-gray-100 dark:bg-gray-800 text-gray-500 dark:text-gray-400 dark:text-gray-500 hover:bg-gray-200 dark:bg-gray-700'
+                      ? 'bg-green-50 dark:bg-green-900/20 text-green-700 dark:text-green-400 hover:bg-green-100 dark:hover:bg-green-800/30'
+                      : 'bg-gray-100 dark:bg-gray-800 text-gray-500 dark:text-gray-400 hover:bg-gray-200 dark:bg-gray-700'
                   "
                   @click="handleToggleEnable(link)"
                 >
@@ -661,30 +661,30 @@ onMounted(fetchLinks)
                   {{ link.isEnable ? 'Enabled' : 'Disabled' }}
                 </button>
               </td>
-              <td class="hidden whitespace-nowrap px-4 py-3 text-gray-500 dark:text-gray-400 dark:text-gray-500 lg:table-cell">
+              <td class="hidden whitespace-nowrap px-4 py-3 text-gray-500 dark:text-gray-400 lg:table-cell">
                 {{ formatDate(link.createTime) }}
               </td>
-              <td class="hidden whitespace-nowrap px-4 py-3 text-gray-500 dark:text-gray-400 dark:text-gray-500 lg:table-cell">
+              <td class="hidden whitespace-nowrap px-4 py-3 text-gray-500 dark:text-gray-400 lg:table-cell">
                 {{ formatDate(link.updateTime) }}
               </td>
               <td class="px-4 py-3">
                 <div class="flex items-center justify-end gap-1">
                   <button
-                    class="rounded p-1.5 text-gray-400 dark:text-gray-500 transition-colors hover:bg-gray-100 dark:hover:bg-gray-800 dark:bg-gray-800 hover:text-gray-600 dark:text-gray-400 dark:text-gray-500 dark:hover:text-gray-300 dark:text-gray-600"
+                    class="rounded p-1.5 text-gray-400 dark:text-gray-500 transition-colors hover:bg-gray-100 dark:hover:bg-gray-800 hover:text-gray-600 dark:hover:text-gray-300"
                     :title="t('common.viewDetails')"
                     @click="router.push({ name: 'short-link-detail', params: { id: link.id } })"
                   >
                     <Eye class="h-4 w-4" />
                   </button>
                   <button
-                    class="rounded p-1.5 text-gray-400 dark:text-gray-500 transition-colors hover:bg-gray-100 dark:hover:bg-gray-800 dark:bg-gray-800 hover:text-gray-600 dark:text-gray-400 dark:text-gray-500 dark:hover:text-gray-300 dark:text-gray-600"
+                    class="rounded p-1.5 text-gray-400 dark:text-gray-500 transition-colors hover:bg-gray-100 dark:hover:bg-gray-800 hover:text-gray-600 dark:hover:text-gray-300"
                     :title="t('common.edit')"
                     @click="router.push({ name: 'short-link-edit', params: { id: link.id } })"
                   >
                     <Pencil class="h-4 w-4" />
                   </button>
                   <button
-                    class="rounded p-1.5 text-gray-400 dark:text-gray-500 transition-colors hover:bg-red-50 hover:text-red-600"
+                    class="rounded p-1.5 text-gray-400 dark:text-gray-500 transition-colors hover:bg-red-50 dark:hover:bg-red-900/20 hover:text-red-600 dark:hover:text-red-400"
                     :title="t('common.delete')"
                     @click="confirmDeleteId = link.id"
                   >
@@ -703,7 +703,7 @@ onMounted(fetchLinks)
         class="flex flex-col items-center justify-between gap-3 border-t px-4 py-3 sm:flex-row"
       >
         <div class="flex items-center gap-2">
-          <span class="text-sm text-gray-500 dark:text-gray-400 dark:text-gray-500">Show</span>
+          <span class="text-sm text-gray-500 dark:text-gray-400">Show</span>
           <select
             v-model="pageSize"
             class="rounded-md border border-gray-300 dark:border-gray-600 px-2 py-1 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
@@ -713,7 +713,7 @@ onMounted(fetchLinks)
               {{ size }}
             </option>
           </select>
-          <span class="text-sm text-gray-500 dark:text-gray-400 dark:text-gray-500">per page</span>
+          <span class="text-sm text-gray-500 dark:text-gray-400">per page</span>
           <span class="ml-2 text-sm text-gray-400 dark:text-gray-500">
             {{ (page - 1) * pageSize + 1 }}–{{ Math.min(page * pageSize, total) }} of {{ total }}
           </span>
@@ -721,7 +721,7 @@ onMounted(fetchLinks)
         <div v-if="totalPages > 1" class="flex items-center gap-1">
           <button
             :disabled="page <= 1"
-            class="rounded p-1.5 text-gray-400 dark:text-gray-500 transition-colors hover:bg-gray-100 dark:hover:bg-gray-800 dark:bg-gray-800 hover:text-gray-600 dark:text-gray-400 dark:text-gray-500 dark:hover:text-gray-300 dark:text-gray-600 disabled:opacity-30"
+            class="rounded p-1.5 text-gray-400 dark:text-gray-500 transition-colors hover:bg-gray-100 dark:hover:bg-gray-800 hover:text-gray-600 dark:hover:text-gray-300 disabled:opacity-30"
             @click="goPage(page - 1)"
           >
             <ChevronLeft class="h-5 w-5" />
@@ -734,7 +734,7 @@ onMounted(fetchLinks)
                 'min-w-[32px] rounded px-2 py-1 text-sm font-medium transition-colors',
                 p === page
                   ? 'bg-blue-600 text-white'
-                  : 'text-gray-600 dark:text-gray-400 dark:text-gray-500 hover:bg-gray-100 dark:hover:bg-gray-800 dark:bg-gray-800',
+                  : 'text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800',
               ]"
               @click="goPage(p as number)"
             >
@@ -743,7 +743,7 @@ onMounted(fetchLinks)
           </template>
           <button
             :disabled="page >= totalPages"
-            class="rounded p-1.5 text-gray-400 dark:text-gray-500 transition-colors hover:bg-gray-100 dark:hover:bg-gray-800 dark:bg-gray-800 hover:text-gray-600 dark:text-gray-400 dark:text-gray-500 dark:hover:text-gray-300 dark:text-gray-600 disabled:opacity-30"
+            class="rounded p-1.5 text-gray-400 dark:text-gray-500 transition-colors hover:bg-gray-100 dark:hover:bg-gray-800 hover:text-gray-600 dark:hover:text-gray-300 disabled:opacity-30"
             @click="goPage(page + 1)"
           >
             <ChevronRight class="h-5 w-5" />
@@ -772,9 +772,9 @@ onMounted(fetchLinks)
       @confirm="handleDelete(confirmDeleteId!)"
       @cancel="confirmDeleteId = null"
     >
-      <p class="mt-2 text-sm text-gray-500 dark:text-gray-400 dark:text-gray-500">
+      <p class="mt-2 text-sm text-gray-500 dark:text-gray-400">
         Are you sure you want to delete
-        <span class="font-mono font-medium text-gray-700 dark:text-gray-300 dark:text-gray-600">{{ confirmDeleteId }}</span
+        <span class="font-mono font-medium text-gray-700 dark:text-gray-300">{{ confirmDeleteId }}</span
         >? This action cannot be undone.
       </p>
     </ConfirmDialog>

--- a/web-ui/src/pages/TenantDetailPage.vue
+++ b/web-ui/src/pages/TenantDetailPage.vue
@@ -136,15 +136,15 @@ onMounted(() => {
   <div>
     <div class="flex items-center gap-3">
       <button
-        class="rounded p-1.5 text-gray-400 dark:text-gray-500 transition-colors hover:bg-gray-100 dark:hover:bg-gray-800 dark:bg-gray-800 hover:text-gray-600 dark:text-gray-400 dark:text-gray-500 dark:hover:text-gray-300 dark:text-gray-600"
+        class="rounded p-1.5 text-gray-400 dark:text-gray-500 transition-colors hover:bg-gray-100 dark:hover:bg-gray-800 hover:text-gray-600 dark:hover:text-gray-300"
         @click="router.push({ name: 'tenants' })"
       >
         <ArrowLeft class="h-5 w-5" />
       </button>
       <div class="flex-1">
         <h1 class="text-xl font-semibold text-gray-900 dark:text-white">{{ t('tenantDetail.title') }}</h1>
-        <p v-if="tenant" class="mt-0.5 text-sm text-gray-500 dark:text-gray-400 dark:text-gray-500">
-          <span class="font-mono font-medium text-gray-700 dark:text-gray-300 dark:text-gray-600">{{ tenant.id }}</span>
+        <p v-if="tenant" class="mt-0.5 text-sm text-gray-500 dark:text-gray-400">
+          <span class="font-mono font-medium text-gray-700 dark:text-gray-300">{{ tenant.id }}</span>
         </p>
       </div>
     </div>
@@ -178,11 +178,11 @@ onMounted(() => {
           </div>
           <div>
             <h2 class="text-lg font-semibold text-gray-900 dark:text-white">{{ tenant.name }}</h2>
-            <p class="text-sm text-gray-500 dark:text-gray-400 dark:text-gray-500">{{ tenant.slug }}</p>
+            <p class="text-sm text-gray-500 dark:text-gray-400">{{ tenant.slug }}</p>
           </div>
           <span
             class="ml-auto inline-flex items-center gap-1.5 rounded-full px-2.5 py-0.5 text-xs font-medium"
-            :class="tenant.isActive ? 'bg-green-50 text-green-700' : 'bg-gray-100 dark:bg-gray-800 text-gray-500 dark:text-gray-400 dark:text-gray-500'"
+            :class="tenant.isActive ? 'bg-green-50 dark:bg-green-900/20 text-green-700 dark:text-green-400' : 'bg-gray-100 dark:bg-gray-800 text-gray-500 dark:text-gray-400'"
           >
             <span
               class="h-1.5 w-1.5 rounded-full"
@@ -202,11 +202,11 @@ onMounted(() => {
           </div>
           <div>
             <label class="text-xs font-medium uppercase text-gray-400 dark:text-gray-500">{{ t('tenantDetail.created') }}</label>
-            <p class="mt-1 text-sm text-gray-700 dark:text-gray-300 dark:text-gray-600">{{ formatDate(tenant.createdAt) }}</p>
+            <p class="mt-1 text-sm text-gray-700 dark:text-gray-300">{{ formatDate(tenant.createdAt) }}</p>
           </div>
           <div>
             <label class="text-xs font-medium uppercase text-gray-400 dark:text-gray-500">{{ t('tenantDetail.updated') }}</label>
-            <p class="mt-1 text-sm text-gray-700 dark:text-gray-300 dark:text-gray-600">{{ formatDate(tenant.updatedAt) }}</p>
+            <p class="mt-1 text-sm text-gray-700 dark:text-gray-300">{{ formatDate(tenant.updatedAt) }}</p>
           </div>
         </div>
       </div>
@@ -215,9 +215,9 @@ onMounted(() => {
       <div class="mt-6">
         <div class="flex items-center justify-between">
           <div class="flex items-center gap-2">
-            <Globe class="h-5 w-5 text-gray-500 dark:text-gray-400 dark:text-gray-500" />
+            <Globe class="h-5 w-5 text-gray-500 dark:text-gray-400" />
             <h2 class="text-lg font-semibold text-gray-900 dark:text-white">{{ t('tenantDetail.domains') }}</h2>
-            <span class="rounded-full bg-gray-100 dark:bg-gray-800 px-2 py-0.5 text-xs font-medium text-gray-600 dark:text-gray-400 dark:text-gray-500">
+            <span class="rounded-full bg-gray-100 dark:bg-gray-800 px-2 py-0.5 text-xs font-medium text-gray-600 dark:text-gray-400">
               {{ domains.length }}
             </span>
           </div>
@@ -227,7 +227,7 @@ onMounted(() => {
         <div class="mt-4 rounded-lg border bg-white dark:bg-gray-900 p-4">
           <div class="flex flex-col gap-3 sm:flex-row sm:items-end">
             <div class="flex-1">
-              <label class="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300 dark:text-gray-600">{{ t('tenantDetail.domain') }}</label>
+              <label class="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300">{{ t('tenantDetail.domain') }}</label>
               <input
                 v-model="newDomain"
                 type="text"
@@ -237,7 +237,7 @@ onMounted(() => {
               />
             </div>
             <div class="flex items-center gap-3">
-              <label class="flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300 dark:text-gray-600">
+              <label class="flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300">
                 <input
                   v-model="newDomainIsDefault"
                   type="checkbox"
@@ -262,11 +262,11 @@ onMounted(() => {
         <div v-if="domainsLoading" class="mt-4 flex items-center justify-center rounded-lg border bg-white dark:bg-gray-900 py-8">
           <Loader2 class="h-5 w-5 animate-spin text-gray-400 dark:text-gray-500" />
         </div>
-        <div v-else-if="domains.length > 0" class="mt-4 overflow-hidden rounded-lg border bg-white dark:bg-gray-900 dark:bg-gray-900">
+        <div v-else-if="domains.length > 0" class="mt-4 overflow-hidden rounded-lg border bg-white dark:bg-gray-900">
           <table class="w-full text-sm">
             <thead>
               <tr
-                class="border-b bg-gray-50 dark:bg-gray-800/50 text-left text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400 dark:text-gray-500"
+                class="border-b bg-gray-50 dark:bg-gray-800/50 text-left text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400"
               >
                 <th class="px-4 py-3">{{ t('tenantDetail.domain') }}</th>
                 <th class="px-4 py-3">{{ t('tenantDetail.default') }}</th>
@@ -293,7 +293,7 @@ onMounted(() => {
                   </span>
                   <span v-else class="text-xs text-gray-400 dark:text-gray-500">—</span>
                 </td>
-                <td class="hidden whitespace-nowrap px-4 py-3 text-gray-500 dark:text-gray-400 dark:text-gray-500 lg:table-cell">
+                <td class="hidden whitespace-nowrap px-4 py-3 text-gray-500 dark:text-gray-400 lg:table-cell">
                   {{ formatDate(d.createdAt) }}
                 </td>
                 <td class="px-4 py-3">
@@ -302,7 +302,7 @@ onMounted(() => {
                       :href="'https://' + d.domain"
                       target="_blank"
                       rel="noopener noreferrer"
-                      class="rounded p-1.5 text-gray-400 dark:text-gray-500 transition-colors hover:bg-gray-100 dark:hover:bg-gray-800 dark:bg-gray-800 hover:text-gray-600 dark:text-gray-400 dark:text-gray-500 dark:hover:text-gray-300 dark:text-gray-600"
+                      class="rounded p-1.5 text-gray-400 dark:text-gray-500 transition-colors hover:bg-gray-100 dark:hover:bg-gray-800 hover:text-gray-600 dark:hover:text-gray-300"
                       :title="t('tenantDetail.openDomain')"
                     >
                       <ExternalLink class="h-4 w-4" />
@@ -342,12 +342,12 @@ onMounted(() => {
           class="mx-4 w-full max-w-sm rounded-lg bg-white dark:bg-gray-900 p-6 shadow-xl"
         >
           <h3 id="remove-domain-title" class="text-lg font-semibold text-gray-900 dark:text-white">{{ t('tenantDetail.removeDomain') }}</h3>
-          <p class="mt-2 text-sm text-gray-500 dark:text-gray-400 dark:text-gray-500">
+          <p class="mt-2 text-sm text-gray-500 dark:text-gray-400">
             {{ t('tenantDetail.removeDomainConfirm', { domain: confirmDeleteDomain }) }}
           </p>
           <div class="mt-4 flex justify-end gap-2">
             <button
-              class="rounded-md px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 dark:text-gray-600 transition-colors hover:bg-gray-100 dark:hover:bg-gray-800 dark:bg-gray-800"
+              class="rounded-md px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 transition-colors hover:bg-gray-100 dark:hover:bg-gray-800"
               @click="confirmDeleteDomain = null"
             >
               {{ t('common.cancel') }}

--- a/web-ui/src/pages/TenantsPage.vue
+++ b/web-ui/src/pages/TenantsPage.vue
@@ -83,12 +83,12 @@ onMounted(fetchTenants)
     </div>
 
     <!-- Table -->
-    <div class="mt-4 overflow-hidden rounded-lg border bg-white dark:bg-gray-900 dark:bg-gray-900">
+    <div class="mt-4 overflow-hidden rounded-lg border bg-white dark:bg-gray-900">
       <div class="overflow-x-auto">
         <table class="w-full text-sm">
           <thead>
             <tr
-              class="border-b bg-gray-50 dark:bg-gray-800/50 text-left text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400 dark:text-gray-500"
+              class="border-b bg-gray-50 dark:bg-gray-800/50 text-left text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400"
             >
               <th class="px-4 py-3">{{ t('tenants.name') }}</th>
               <th class="px-4 py-3">{{ t('tenants.slug') }}</th>
@@ -128,15 +128,15 @@ onMounted(fetchTenants)
                 </div>
               </td>
               <td class="px-4 py-3">
-                <span class="font-mono text-sm text-gray-600 dark:text-gray-400 dark:text-gray-500">{{ tenant.slug }}</span>
+                <span class="font-mono text-sm text-gray-600 dark:text-gray-400">{{ tenant.slug }}</span>
               </td>
               <td class="px-4 py-3">
                 <span
                   class="inline-flex items-center gap-1.5 rounded-full px-2.5 py-0.5 text-xs font-medium"
                   :class="
                     tenant.isActive
-                      ? 'bg-green-50 text-green-700'
-                      : 'bg-gray-100 dark:bg-gray-800 text-gray-500 dark:text-gray-400 dark:text-gray-500'
+                      ? 'bg-green-50 dark:bg-green-900/20 text-green-700 dark:text-green-400'
+                      : 'bg-gray-100 dark:bg-gray-800 text-gray-500 dark:text-gray-400'
                   "
                 >
                   <span
@@ -146,13 +146,13 @@ onMounted(fetchTenants)
                   {{ tenant.isActive ? t('common.active') : t('common.inactive') }}
                 </span>
               </td>
-              <td class="hidden whitespace-nowrap px-4 py-3 text-gray-500 dark:text-gray-400 dark:text-gray-500 lg:table-cell">
+              <td class="hidden whitespace-nowrap px-4 py-3 text-gray-500 dark:text-gray-400 lg:table-cell">
                 {{ formatDate(tenant.createdAt) }}
               </td>
               <td class="px-4 py-3">
                 <div class="flex items-center justify-end gap-1">
                   <button
-                    class="rounded p-1.5 text-gray-400 dark:text-gray-500 transition-colors hover:bg-gray-100 dark:hover:bg-gray-800 dark:bg-gray-800 hover:text-gray-600 dark:text-gray-400 dark:text-gray-500 dark:hover:text-gray-300 dark:text-gray-600"
+                    class="rounded p-1.5 text-gray-400 dark:text-gray-500 transition-colors hover:bg-gray-100 dark:hover:bg-gray-800 hover:text-gray-600 dark:hover:text-gray-300"
                     :title="t('tenants.viewDetails')"
                     @click="router.push({ name: 'tenant-detail', params: { id: tenant.id } })"
                   >

--- a/web-ui/src/pages/super/SuperDashboardPage.vue
+++ b/web-ui/src/pages/super/SuperDashboardPage.vue
@@ -113,34 +113,34 @@ onMounted(fetchDashboardData)
       <div v-else class="overflow-x-auto">
         <table class="w-full text-sm">
           <thead>
-            <tr class="border-b border-gray-100 text-left text-xs font-medium uppercase tracking-wider text-gray-500">
+            <tr class="border-b border-gray-100 dark:border-gray-800 text-left text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400">
               <th class="px-5 py-3">{{ t('common.name') }}</th>
               <th class="px-5 py-3">{{ t('common.slug') }}</th>
               <th class="px-5 py-3">{{ t('common.status') }}</th>
               <th class="hidden px-5 py-3 md:table-cell">{{ t('common.created') }}</th>
             </tr>
           </thead>
-          <tbody class="divide-y divide-gray-50">
-            <tr v-for="tenant in recentTenants" :key="tenant.id" class="transition-colors hover:bg-gray-50">
+          <tbody class="divide-y divide-gray-50 dark:divide-gray-800">
+            <tr v-for="tenant in recentTenants" :key="tenant.id" class="transition-colors hover:bg-gray-50 dark:hover:bg-gray-800">
               <td class="px-5 py-3">
                 <router-link
                   :to="{ name: 'super-tenant-detail', params: { id: tenant.id } }"
-                  class="font-medium text-blue-600 hover:text-blue-700"
+                  class="font-medium text-blue-600 dark:text-blue-400 hover:text-blue-700 dark:hover:text-blue-300"
                 >
                   {{ tenant.name }}
                 </router-link>
               </td>
-              <td class="px-5 py-3 font-mono text-xs text-gray-600">{{ tenant.slug }}</td>
+              <td class="px-5 py-3 font-mono text-xs text-gray-600 dark:text-gray-400">{{ tenant.slug }}</td>
               <td class="px-5 py-3">
                 <span
                   class="inline-flex items-center gap-1.5 rounded-full px-2.5 py-0.5 text-xs font-medium"
-                  :class="tenant.isActive ? 'bg-green-50 text-green-700' : 'bg-gray-100 text-gray-500'"
+                  :class="tenant.isActive ? 'bg-green-50 dark:bg-green-900/20 text-green-700 dark:text-green-400' : 'bg-gray-100 dark:bg-gray-800 text-gray-500 dark:text-gray-400'"
                 >
                   <span class="h-1.5 w-1.5 rounded-full" :class="tenant.isActive ? 'bg-green-500' : 'bg-gray-400'" />
                   {{ tenant.isActive ? t('common.active') : t('common.inactive') }}
                 </span>
               </td>
-              <td class="hidden whitespace-nowrap px-5 py-3 text-gray-500 md:table-cell">
+              <td class="hidden whitespace-nowrap px-5 py-3 text-gray-500 dark:text-gray-400 md:table-cell">
                 {{ formatDate(tenant.createdAt) }}
               </td>
             </tr>

--- a/web-ui/src/pages/super/SuperTenantDetailPage.vue
+++ b/web-ui/src/pages/super/SuperTenantDetailPage.vue
@@ -169,15 +169,15 @@ onMounted(fetchTenant)
   <div>
     <div class="flex items-center gap-3">
       <button
-        class="rounded p-1.5 text-gray-400 dark:text-gray-500 transition-colors hover:bg-gray-100 dark:hover:bg-gray-800 dark:bg-gray-800 hover:text-gray-600 dark:text-gray-400 dark:text-gray-500 dark:hover:text-gray-300 dark:text-gray-600"
+        class="rounded p-1.5 text-gray-400 dark:text-gray-500 transition-colors hover:bg-gray-100 dark:hover:bg-gray-800 hover:text-gray-600 dark:hover:text-gray-300"
         @click="router.push({ name: 'super-tenants' })"
       >
         <ArrowLeft class="h-5 w-5" />
       </button>
       <div class="flex-1">
         <h1 class="text-xl font-semibold text-gray-900 dark:text-white">{{ t('super.tenantDetail.title') }}</h1>
-        <p v-if="tenant" class="mt-0.5 text-sm text-gray-500 dark:text-gray-400 dark:text-gray-500">
-          <span class="font-mono font-medium text-gray-700 dark:text-gray-300 dark:text-gray-600">{{ tenant.id }}</span>
+        <p v-if="tenant" class="mt-0.5 text-sm text-gray-500 dark:text-gray-400">
+          <span class="font-mono font-medium text-gray-700 dark:text-gray-300">{{ tenant.id }}</span>
         </p>
       </div>
     </div>
@@ -206,7 +206,7 @@ onMounted(fetchTenant)
       </button>
     </div>
 
-    <div v-else-if="pageError" class="mt-6 rounded-lg border border-red-200 bg-red-50 p-4">
+    <div v-else-if="pageError" class="mt-6 rounded-lg border border-red-200 dark:border-red-800/50 bg-red-50 dark:bg-red-900/20 p-4">
       <p class="text-sm text-red-600">{{ pageError }}</p>
     </div>
 
@@ -221,11 +221,11 @@ onMounted(fetchTenant)
           </div>
           <div>
             <h2 class="text-lg font-semibold text-gray-900 dark:text-white">{{ tenant.name }}</h2>
-            <p class="text-sm text-gray-500 dark:text-gray-400 dark:text-gray-500">{{ tenant.slug }}</p>
+            <p class="text-sm text-gray-500 dark:text-gray-400">{{ tenant.slug }}</p>
           </div>
           <span
             class="ml-auto inline-flex items-center gap-1.5 rounded-full px-2.5 py-0.5 text-xs font-medium"
-            :class="tenant.isActive ? 'bg-green-50 text-green-700' : 'bg-gray-100 dark:bg-gray-800 text-gray-500 dark:text-gray-400 dark:text-gray-500'"
+            :class="tenant.isActive ? 'bg-green-50 dark:bg-green-900/20 text-green-700 dark:text-green-400' : 'bg-gray-100 dark:bg-gray-800 text-gray-500 dark:text-gray-400'"
           >
             <span class="h-1.5 w-1.5 rounded-full" :class="tenant.isActive ? 'bg-green-500' : 'bg-gray-400'" />
             {{ tenant.isActive ? t('common.active') : t('common.inactive') }}
@@ -234,8 +234,8 @@ onMounted(fetchTenant)
             :disabled="toggleLoading"
             class="rounded-md px-3 py-1.5 text-xs font-medium transition-colors"
             :class="tenant.isActive
-              ? 'bg-red-50 text-red-600 hover:bg-red-100'
-              : 'bg-green-50 text-green-600 hover:bg-green-100'"
+              ? 'bg-red-50 dark:bg-red-900/20 text-red-600 dark:text-red-400 hover:bg-red-100 dark:hover:bg-red-900/30'
+              : 'bg-green-50 dark:bg-green-900/20 text-green-600 dark:text-green-400 hover:bg-green-100 dark:hover:bg-green-900/30'"
             @click="handleToggleStatus"
           >
             <Loader2 v-if="toggleLoading" class="mr-1 inline h-3 w-3 animate-spin" />
@@ -249,11 +249,11 @@ onMounted(fetchTenant)
           </div>
           <div>
             <label class="text-xs font-medium uppercase text-gray-400 dark:text-gray-500">{{ t('common.created') }}</label>
-            <p class="mt-1 text-sm text-gray-700 dark:text-gray-300 dark:text-gray-600">{{ formatDate(tenant.createdAt) }}</p>
+            <p class="mt-1 text-sm text-gray-700 dark:text-gray-300">{{ formatDate(tenant.createdAt) }}</p>
           </div>
           <div>
             <label class="text-xs font-medium uppercase text-gray-400 dark:text-gray-500">{{ t('common.updated') }}</label>
-            <p class="mt-1 text-sm text-gray-700 dark:text-gray-300 dark:text-gray-600">{{ formatDate(tenant.updatedAt) }}</p>
+            <p class="mt-1 text-sm text-gray-700 dark:text-gray-300">{{ formatDate(tenant.updatedAt) }}</p>
           </div>
         </div>
       </div>
@@ -267,7 +267,7 @@ onMounted(fetchTenant)
             class="whitespace-nowrap border-b-2 pb-3 pt-2 text-sm font-medium transition-colors"
             :class="activeTab === tab
               ? 'border-blue-600 text-blue-600'
-              : 'border-transparent text-gray-500 dark:text-gray-400 dark:text-gray-500 hover:text-gray-700 dark:hover:text-gray-200 dark:text-gray-300 dark:text-gray-600'"
+              : 'border-transparent text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200'"
             @click="onTabChange(tab)"
           >
             {{ tab === 'short-links' ? 'Short Links' : tab.charAt(0).toUpperCase() + tab.slice(1) }}
@@ -296,10 +296,10 @@ onMounted(fetchTenant)
           <div v-if="membersLoading" class="flex items-center justify-center rounded-lg border bg-white dark:bg-gray-900 py-8">
             <Loader2 class="h-5 w-5 animate-spin text-gray-400 dark:text-gray-500" />
           </div>
-          <div v-else class="overflow-hidden rounded-lg border bg-white dark:bg-gray-900 dark:bg-gray-900">
+          <div v-else class="overflow-hidden rounded-lg border bg-white dark:bg-gray-900">
             <table class="w-full text-sm">
               <thead>
-                <tr class="border-b bg-gray-50 dark:bg-gray-800/50 text-left text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400 dark:text-gray-500">
+                <tr class="border-b bg-gray-50 dark:bg-gray-800/50 text-left text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400">
                   <th class="px-4 py-3">{{ t('super.users.username') }}</th>
                   <th class="px-4 py-3">{{ t('members.role') }}</th>
                   <th class="hidden px-4 py-3 lg:table-cell">{{ t('members.joined') }}</th>
@@ -312,7 +312,7 @@ onMounted(fetchTenant)
                 <tr v-for="m in members" :key="m.userId" class="transition-colors hover:bg-gray-50 dark:hover:bg-gray-700 dark:bg-gray-800/50">
                   <td class="px-4 py-3">
                     <div class="flex items-center gap-2">
-                      <div class="flex h-7 w-7 items-center justify-center rounded-full bg-gray-100 dark:bg-gray-800 text-xs font-bold text-gray-600 dark:text-gray-400 dark:text-gray-500">
+                      <div class="flex h-7 w-7 items-center justify-center rounded-full bg-gray-100 dark:bg-gray-800 text-xs font-bold text-gray-600 dark:text-gray-400">
                         {{ m.username.charAt(0).toUpperCase() }}
                       </div>
                       <span class="font-medium text-gray-900 dark:text-white">{{ m.username }}</span>
@@ -321,12 +321,12 @@ onMounted(fetchTenant)
                   <td class="px-4 py-3">
                     <span
                       class="inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium"
-                      :class="m.role === 'admin' ? 'bg-blue-50 text-blue-700' : 'bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-400 dark:text-gray-500'"
+                      :class="m.role === 'admin' ? 'bg-blue-50 dark:bg-blue-900/20 text-blue-700 dark:text-blue-400' : 'bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-400'"
                     >
                       {{ m.role }}
                     </span>
                   </td>
-                  <td class="hidden whitespace-nowrap px-4 py-3 text-gray-500 dark:text-gray-400 dark:text-gray-500 lg:table-cell">
+                  <td class="hidden whitespace-nowrap px-4 py-3 text-gray-500 dark:text-gray-400 lg:table-cell">
                     {{ formatDate(m.joinedAt) }}
                   </td>
                 </tr>
@@ -340,10 +340,10 @@ onMounted(fetchTenant)
           <div v-if="shortLinksLoading" class="flex items-center justify-center rounded-lg border bg-white dark:bg-gray-900 py-8">
             <Loader2 class="h-5 w-5 animate-spin text-gray-400 dark:text-gray-500" />
           </div>
-          <div v-else class="overflow-hidden rounded-lg border bg-white dark:bg-gray-900 dark:bg-gray-900">
+          <div v-else class="overflow-hidden rounded-lg border bg-white dark:bg-gray-900">
             <table class="w-full text-sm">
               <thead>
-                <tr class="border-b bg-gray-50 dark:bg-gray-800/50 text-left text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400 dark:text-gray-500">
+                <tr class="border-b bg-gray-50 dark:bg-gray-800/50 text-left text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400">
                   <th class="px-4 py-3">{{ t('common.name') }}</th>
                   <th class="hidden px-4 py-3 md:table-cell">{{ t('shortLinkDetail.targetUrl') }}</th>
                   <th class="px-4 py-3">{{ t('common.status') }}</th>
@@ -357,18 +357,18 @@ onMounted(fetchTenant)
                 </tr>
                 <tr v-for="sl in shortLinks" :key="sl.id" class="transition-colors hover:bg-gray-50 dark:hover:bg-gray-700 dark:bg-gray-800/50">
                   <td class="px-4 py-3 font-mono text-sm font-medium text-gray-900 dark:text-white">{{ sl.id }}</td>
-                  <td class="hidden max-w-[240px] truncate px-4 py-3 text-gray-500 dark:text-gray-400 dark:text-gray-500 md:table-cell">{{ sl.url }}</td>
+                  <td class="hidden max-w-[240px] truncate px-4 py-3 text-gray-500 dark:text-gray-400 md:table-cell">{{ sl.url }}</td>
                   <td class="px-4 py-3">
                     <span
                       class="inline-flex items-center gap-1.5 rounded-full px-2 py-0.5 text-xs font-medium"
-                      :class="sl.isEnable ? 'bg-green-50 text-green-700' : 'bg-gray-100 dark:bg-gray-800 text-gray-500 dark:text-gray-400 dark:text-gray-500'"
+                      :class="sl.isEnable ? 'bg-green-50 dark:bg-green-900/20 text-green-700 dark:text-green-400' : 'bg-gray-100 dark:bg-gray-800 text-gray-500 dark:text-gray-400'"
                     >
                       <span class="h-1.5 w-1.5 rounded-full" :class="sl.isEnable ? 'bg-green-500' : 'bg-gray-400'" />
                       {{ sl.isEnable ? t('common.active') : t('common.inactive') }}
                     </span>
                   </td>
-                  <td class="hidden px-4 py-3 text-gray-500 dark:text-gray-400 dark:text-gray-500 lg:table-cell">{{ sl.createdBy }}</td>
-                  <td class="hidden whitespace-nowrap px-4 py-3 text-gray-500 dark:text-gray-400 dark:text-gray-500 lg:table-cell">{{ formatDate(sl.createTime) }}</td>
+                  <td class="hidden px-4 py-3 text-gray-500 dark:text-gray-400 lg:table-cell">{{ sl.createdBy }}</td>
+                  <td class="hidden whitespace-nowrap px-4 py-3 text-gray-500 dark:text-gray-400 lg:table-cell">{{ formatDate(sl.createTime) }}</td>
                 </tr>
               </tbody>
             </table>
@@ -384,7 +384,7 @@ onMounted(fetchTenant)
           <div class="mb-4 rounded-lg border bg-white dark:bg-gray-900 p-4">
             <div class="flex flex-col gap-3 sm:flex-row sm:items-end">
               <div class="flex-1">
-                <label class="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300 dark:text-gray-600">{{ t('common.domain') }}</label>
+                <label class="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300">{{ t('common.domain') }}</label>
                 <input
                   v-model="newDomain"
                   type="text"
@@ -408,10 +408,10 @@ onMounted(fetchTenant)
           <div v-if="domainsLoading" class="flex items-center justify-center rounded-lg border bg-white dark:bg-gray-900 py-8">
             <Loader2 class="h-5 w-5 animate-spin text-gray-400 dark:text-gray-500" />
           </div>
-          <div v-else-if="domains.length > 0" class="overflow-hidden rounded-lg border bg-white dark:bg-gray-900 dark:bg-gray-900">
+          <div v-else-if="domains.length > 0" class="overflow-hidden rounded-lg border bg-white dark:bg-gray-900">
             <table class="w-full text-sm">
               <thead>
-                <tr class="border-b bg-gray-50 dark:bg-gray-800/50 text-left text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400 dark:text-gray-500">
+                <tr class="border-b bg-gray-50 dark:bg-gray-800/50 text-left text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400">
                   <th class="px-4 py-3">{{ t('common.domain') }}</th>
                   <th class="px-4 py-3">{{ t('common.default') }}</th>
                   <th class="hidden px-4 py-3 lg:table-cell">{{ t('common.created') }}</th>
@@ -433,19 +433,19 @@ onMounted(fetchTenant)
                     </span>
                     <span v-else class="text-xs text-gray-400 dark:text-gray-500">-</span>
                   </td>
-                  <td class="hidden whitespace-nowrap px-4 py-3 text-gray-500 dark:text-gray-400 dark:text-gray-500 lg:table-cell">{{ formatDate(d.createdAt) }}</td>
+                  <td class="hidden whitespace-nowrap px-4 py-3 text-gray-500 dark:text-gray-400 lg:table-cell">{{ formatDate(d.createdAt) }}</td>
                   <td class="px-4 py-3">
                     <div class="flex items-center justify-end gap-1">
                       <a
                         :href="'https://' + d.domain"
                         target="_blank"
                         rel="noopener noreferrer"
-                        class="rounded p-1.5 text-gray-400 dark:text-gray-500 transition-colors hover:bg-gray-100 dark:hover:bg-gray-800 dark:bg-gray-800 hover:text-gray-600 dark:text-gray-400 dark:text-gray-500 dark:hover:text-gray-300 dark:text-gray-600"
+                        class="rounded p-1.5 text-gray-400 dark:text-gray-500 transition-colors hover:bg-gray-100 dark:hover:bg-gray-800 hover:text-gray-600 dark:hover:text-gray-300"
                       >
                         <ExternalLink class="h-4 w-4" />
                       </a>
                       <button
-                        class="rounded p-1.5 text-gray-400 dark:text-gray-500 transition-colors hover:bg-red-50 hover:text-red-600"
+                        class="rounded p-1.5 text-gray-400 dark:text-gray-500 transition-colors hover:bg-red-50 dark:hover:bg-red-900/20 hover:text-red-600"
                         @click="confirmDeleteDomain = d.domain"
                       >
                         <Trash2 class="h-4 w-4" />
@@ -472,13 +472,13 @@ onMounted(fetchTenant)
       >
         <div class="mx-4 w-full max-w-sm rounded-lg bg-white dark:bg-gray-900 p-6 shadow-xl">
           <h3 class="text-lg font-semibold text-gray-900 dark:text-white">{{ t('settings.removeDomain') }}</h3>
-          <p class="mt-2 text-sm text-gray-500 dark:text-gray-400 dark:text-gray-500">
+          <p class="mt-2 text-sm text-gray-500 dark:text-gray-400">
             Are you sure you want to remove
-            <span class="font-mono font-medium text-gray-700 dark:text-gray-300 dark:text-gray-600">{{ confirmDeleteDomain }}</span>?
+            <span class="font-mono font-medium text-gray-700 dark:text-gray-300">{{ confirmDeleteDomain }}</span>?
           </p>
           <div class="mt-4 flex justify-end gap-2">
             <button
-              class="rounded-md px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 dark:text-gray-600 transition-colors hover:bg-gray-100 dark:hover:bg-gray-800 dark:bg-gray-800"
+              class="rounded-md px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 transition-colors hover:bg-gray-100 dark:hover:bg-gray-800"
               @click="confirmDeleteDomain = null"
             >
               Cancel

--- a/web-ui/src/pages/super/SuperTenantsPage.vue
+++ b/web-ui/src/pages/super/SuperTenantsPage.vue
@@ -112,15 +112,15 @@ onMounted(fetchTenants)
   <div>
     <div>
       <h1 class="text-xl font-semibold text-gray-900 dark:text-white">{{ t('super.tenants.title') }}</h1>
-      <p class="mt-1 text-sm text-gray-500 dark:text-gray-400 dark:text-gray-500">{{ t('super.tenants.tenantCount', { count: total, suffix: total !== 1 ? 's' : '' }) }}</p>
+      <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">{{ t('super.tenants.tenantCount', { count: total, suffix: total !== 1 ? 's' : '' }) }}</p>
     </div>
 
     <!-- Table -->
-    <div class="mt-4 overflow-hidden rounded-lg border bg-white dark:bg-gray-900 dark:bg-gray-900">
+    <div class="mt-4 overflow-hidden rounded-lg border bg-white dark:bg-gray-900">
       <div class="overflow-x-auto">
         <table class="w-full text-sm">
           <thead>
-            <tr class="border-b bg-gray-50 dark:bg-gray-800/50 text-left text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400 dark:text-gray-500">
+            <tr class="border-b bg-gray-50 dark:bg-gray-800/50 text-left text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400">
               <th
                 class="px-4 py-3"
                 :aria-sort="sortField === 'name' ? (sortDirection === 'asc' ? 'ascending' : 'descending') : 'none'"
@@ -161,7 +161,7 @@ onMounted(fetchTenants)
             <tr v-else-if="tenants.length === 0">
               <td colspan="5" class="px-4 py-12 text-center">
                 <Building2 class="mx-auto h-10 w-10 text-gray-300 dark:text-gray-600" />
-                <p class="mt-3 text-sm font-medium text-gray-500 dark:text-gray-400 dark:text-gray-500">{{ t('super.tenants.noTenants') }}</p>
+                <p class="mt-3 text-sm font-medium text-gray-500 dark:text-gray-400">{{ t('super.tenants.noTenants') }}</p>
                 <p class="mt-1 text-sm text-gray-400 dark:text-gray-500">Tenants will appear here once created by users.</p>
               </td>
             </tr>
@@ -184,14 +184,14 @@ onMounted(fetchTenants)
                 </div>
               </td>
               <td class="px-4 py-3">
-                <span class="font-mono text-sm text-gray-600 dark:text-gray-400 dark:text-gray-500">{{ tenant.slug }}</span>
+                <span class="font-mono text-sm text-gray-600 dark:text-gray-400">{{ tenant.slug }}</span>
               </td>
               <td class="px-4 py-3">
                 <button
                   :disabled="toggleLoading === tenant.id"
                   class="inline-flex items-center gap-1.5 rounded-full px-2.5 py-0.5 text-xs font-medium transition-colors"
                   :class="[
-                    tenant.isActive ? 'bg-green-50 text-green-700 hover:bg-green-100' : 'bg-gray-100 dark:bg-gray-800 text-gray-500 dark:text-gray-400 dark:text-gray-500 hover:bg-gray-200 dark:bg-gray-700',
+                    tenant.isActive ? 'bg-green-50 dark:bg-green-900/20 text-green-700 dark:text-green-400 dark:hover:bg-green-800/30 hover:bg-green-100' : 'bg-gray-100 dark:bg-gray-800 text-gray-500 dark:text-gray-400 hover:bg-gray-200 dark:bg-gray-700',
                     toggleLoading === tenant.id ? 'opacity-50' : 'cursor-pointer',
                   ]"
                   @click="handleToggleStatus(tenant)"
@@ -201,13 +201,13 @@ onMounted(fetchTenants)
                   {{ tenant.isActive ? t('common.active') : t('common.inactive') }}
                 </button>
               </td>
-              <td class="hidden whitespace-nowrap px-4 py-3 text-gray-500 dark:text-gray-400 dark:text-gray-500 lg:table-cell">
+              <td class="hidden whitespace-nowrap px-4 py-3 text-gray-500 dark:text-gray-400 lg:table-cell">
                 {{ formatDate(tenant.createdAt) }}
               </td>
               <td class="px-4 py-3">
                 <div class="flex items-center justify-end gap-1">
                   <button
-                    class="rounded p-1.5 text-gray-400 dark:text-gray-500 transition-colors hover:bg-gray-100 dark:hover:bg-gray-800 dark:bg-gray-800 hover:text-gray-600 dark:text-gray-400 dark:text-gray-500 dark:hover:text-gray-300 dark:text-gray-600"
+                    class="rounded p-1.5 text-gray-400 dark:text-gray-500 transition-colors hover:bg-gray-100 dark:hover:bg-gray-800 hover:text-gray-600 dark:hover:text-gray-300"
                     :title="t('common.viewDetails')"
                     @click="router.push({ name: 'super-tenant-detail', params: { id: tenant.id } })"
                   >
@@ -222,20 +222,20 @@ onMounted(fetchTenants)
 
       <!-- Pagination -->
       <div v-if="total > pageSize" class="flex items-center justify-between border-t px-4 py-3">
-        <p class="text-xs text-gray-500 dark:text-gray-400 dark:text-gray-500">
+        <p class="text-xs text-gray-500 dark:text-gray-400">
           {{ t('super.tenants.pageOf', { current: page, total: Math.ceil(total / pageSize), count: total }) }}
         </p>
         <div class="flex items-center gap-1">
           <button
             :disabled="page <= 1"
-            class="rounded p-1.5 text-gray-400 dark:text-gray-500 transition-colors hover:bg-gray-100 dark:hover:bg-gray-800 dark:bg-gray-800 hover:text-gray-600 dark:text-gray-400 dark:text-gray-500 dark:hover:text-gray-300 dark:text-gray-600 disabled:opacity-50"
+            class="rounded p-1.5 text-gray-400 dark:text-gray-500 transition-colors hover:bg-gray-100 dark:hover:bg-gray-800 hover:text-gray-600 dark:hover:text-gray-300 disabled:opacity-50"
             @click="goToPage(page - 1)"
           >
             <ChevronLeft class="h-4 w-4" />
           </button>
           <button
             :disabled="page >= Math.ceil(total / pageSize)"
-            class="rounded p-1.5 text-gray-400 dark:text-gray-500 transition-colors hover:bg-gray-100 dark:hover:bg-gray-800 dark:bg-gray-800 hover:text-gray-600 dark:text-gray-400 dark:text-gray-500 dark:hover:text-gray-300 dark:text-gray-600 disabled:opacity-50"
+            class="rounded p-1.5 text-gray-400 dark:text-gray-500 transition-colors hover:bg-gray-100 dark:hover:bg-gray-800 hover:text-gray-600 dark:hover:text-gray-300 disabled:opacity-50"
             @click="goToPage(page + 1)"
           >
             <ChevronRight class="h-4 w-4" />

--- a/web-ui/src/pages/super/SuperUsersPage.vue
+++ b/web-ui/src/pages/super/SuperUsersPage.vue
@@ -158,7 +158,7 @@ onMounted(fetchUsers)
     <div class="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
       <div>
         <h1 class="text-xl font-semibold text-gray-900 dark:text-white">{{ t('super.users.title') }}</h1>
-        <p class="mt-1 text-sm text-gray-500 dark:text-gray-400 dark:text-gray-500">{{ t('super.users.userCount', { count: total, suffix: total !== 1 ? 's' : '' }) }}</p>
+        <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">{{ t('super.users.userCount', { count: total, suffix: total !== 1 ? 's' : '' }) }}</p>
       </div>
       <button
         class="inline-flex items-center gap-2 rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-blue-700"
@@ -182,7 +182,7 @@ onMounted(fetchUsers)
         />
       </div>
       <button
-        class="rounded-md bg-gray-100 dark:bg-gray-800 px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 dark:text-gray-600 transition-colors hover:bg-gray-200 dark:bg-gray-700"
+        class="rounded-md bg-gray-100 dark:bg-gray-800 px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 transition-colors hover:bg-gray-200 dark:bg-gray-700"
         @click="handleSearch"
       >
         Search
@@ -190,11 +190,11 @@ onMounted(fetchUsers)
     </div>
 
     <!-- Table -->
-    <div class="mt-4 overflow-hidden rounded-lg border bg-white dark:bg-gray-900 dark:bg-gray-900">
+    <div class="mt-4 overflow-hidden rounded-lg border bg-white dark:bg-gray-900">
       <div class="overflow-x-auto">
         <table class="w-full text-sm">
           <thead>
-            <tr class="border-b bg-gray-50 dark:bg-gray-800/50 text-left text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400 dark:text-gray-500">
+            <tr class="border-b bg-gray-50 dark:bg-gray-800/50 text-left text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400">
               <th class="px-4 py-3">{{ t('super.users.username') }}</th>
               <th class="px-4 py-3">{{ t('common.status') }}</th>
               <th class="hidden px-4 py-3 md:table-cell">{{ t('super.users.superAdmin') }}</th>
@@ -211,7 +211,7 @@ onMounted(fetchUsers)
             <tr v-else-if="users.length === 0">
               <td colspan="5" class="px-4 py-12 text-center">
                 <Users class="mx-auto h-10 w-10 text-gray-300 dark:text-gray-600" />
-                <p class="mt-3 text-sm font-medium text-gray-500 dark:text-gray-400 dark:text-gray-500">{{ t('super.users.noUsers') }}</p>
+                <p class="mt-3 text-sm font-medium text-gray-500 dark:text-gray-400">{{ t('super.users.noUsers') }}</p>
                 <p class="mt-1 text-sm text-gray-400 dark:text-gray-500">{{ t('super.users.createToStart') }}</p>
                 <button
                   class="mt-3 inline-flex items-center gap-1.5 rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-blue-700"
@@ -229,7 +229,7 @@ onMounted(fetchUsers)
             >
               <td class="px-4 py-3">
                 <div class="flex items-center gap-2">
-                  <div class="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-gray-100 dark:bg-gray-800 text-xs font-bold text-gray-600 dark:text-gray-400 dark:text-gray-500">
+                  <div class="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-gray-100 dark:bg-gray-800 text-xs font-bold text-gray-600 dark:text-gray-400">
                     {{ user.username.charAt(0).toUpperCase() }}
                   </div>
                   <div>
@@ -243,7 +243,7 @@ onMounted(fetchUsers)
                   :disabled="toggleLoading === user.id || user.isSuper"
                   class="inline-flex items-center gap-1.5 rounded-full px-2.5 py-0.5 text-xs font-medium transition-colors"
                   :class="[
-                    user.isActive ? 'bg-green-50 text-green-700 hover:bg-green-100' : 'bg-gray-100 dark:bg-gray-800 text-gray-500 dark:text-gray-400 dark:text-gray-500 hover:bg-gray-200 dark:bg-gray-700',
+                    user.isActive ? 'bg-green-50 dark:bg-green-900/20 text-green-700 dark:text-green-400 dark:hover:bg-green-800/30 hover:bg-green-100' : 'bg-gray-100 dark:bg-gray-800 text-gray-500 dark:text-gray-400 hover:bg-gray-200 dark:bg-gray-700',
                     (user.isSuper || toggleLoading === user.id) ? 'cursor-not-allowed opacity-50' : 'cursor-pointer',
                   ]"
                   @click="handleToggleStatus(user)"
@@ -260,20 +260,20 @@ onMounted(fetchUsers)
                 </span>
                 <span v-else class="text-xs text-gray-400 dark:text-gray-500">-</span>
               </td>
-              <td class="hidden whitespace-nowrap px-4 py-3 text-gray-500 dark:text-gray-400 dark:text-gray-500 lg:table-cell">
+              <td class="hidden whitespace-nowrap px-4 py-3 text-gray-500 dark:text-gray-400 lg:table-cell">
                 {{ formatDate(user.createdAt) }}
               </td>
               <td class="px-4 py-3">
                 <div class="flex items-center justify-end gap-1">
                   <button
-                    class="rounded p-1.5 text-gray-400 dark:text-gray-500 transition-colors hover:bg-gray-100 dark:hover:bg-gray-800 dark:bg-gray-800 hover:text-gray-600 dark:text-gray-400 dark:text-gray-500 dark:hover:text-gray-300 dark:text-gray-600"
+                    class="rounded p-1.5 text-gray-400 dark:text-gray-500 transition-colors hover:bg-gray-100 dark:hover:bg-gray-800 hover:text-gray-600 dark:hover:text-gray-300"
                     title="View details"
                     @click="openDetailModal(user)"
                   >
                     <Eye class="h-4 w-4" />
                   </button>
                   <button
-                    class="rounded p-1.5 text-gray-400 dark:text-gray-500 transition-colors hover:bg-gray-100 dark:hover:bg-gray-800 dark:bg-gray-800 hover:text-gray-600 dark:text-gray-400 dark:text-gray-500 dark:hover:text-gray-300 dark:text-gray-600"
+                    class="rounded p-1.5 text-gray-400 dark:text-gray-500 transition-colors hover:bg-gray-100 dark:hover:bg-gray-800 hover:text-gray-600 dark:hover:text-gray-300"
                     title="Reset password"
                     @click="openResetModal(user)"
                   >
@@ -288,20 +288,20 @@ onMounted(fetchUsers)
 
       <!-- Pagination -->
       <div v-if="total > pageSize" class="flex items-center justify-between border-t px-4 py-3">
-        <p class="text-xs text-gray-500 dark:text-gray-400 dark:text-gray-500">
+        <p class="text-xs text-gray-500 dark:text-gray-400">
           {{ t('super.users.pageOf', { current: page, total: Math.ceil(total / pageSize), count: total }) }}
         </p>
         <div class="flex items-center gap-1">
           <button
             :disabled="page <= 1"
-            class="rounded p-1.5 text-gray-400 dark:text-gray-500 transition-colors hover:bg-gray-100 dark:hover:bg-gray-800 dark:bg-gray-800 hover:text-gray-600 dark:text-gray-400 dark:text-gray-500 dark:hover:text-gray-300 dark:text-gray-600 disabled:opacity-50"
+            class="rounded p-1.5 text-gray-400 dark:text-gray-500 transition-colors hover:bg-gray-100 dark:hover:bg-gray-800 hover:text-gray-600 dark:hover:text-gray-300 disabled:opacity-50"
             @click="goToPage(page - 1)"
           >
             <ChevronLeft class="h-4 w-4" />
           </button>
           <button
             :disabled="page >= Math.ceil(total / pageSize)"
-            class="rounded p-1.5 text-gray-400 dark:text-gray-500 transition-colors hover:bg-gray-100 dark:hover:bg-gray-800 dark:bg-gray-800 hover:text-gray-600 dark:text-gray-400 dark:text-gray-500 dark:hover:text-gray-300 dark:text-gray-600 disabled:opacity-50"
+            class="rounded p-1.5 text-gray-400 dark:text-gray-500 transition-colors hover:bg-gray-100 dark:hover:bg-gray-800 hover:text-gray-600 dark:hover:text-gray-300 disabled:opacity-50"
             @click="goToPage(page + 1)"
           >
             <ChevronRight class="h-4 w-4" />
@@ -320,13 +320,13 @@ onMounted(fetchUsers)
         <div class="mx-4 w-full max-w-md rounded-lg bg-white dark:bg-gray-900 p-6 shadow-xl">
           <div class="flex items-center justify-between">
             <h3 class="text-lg font-semibold text-gray-900 dark:text-white">{{ t('super.users.createUser') }}</h3>
-            <button class="rounded p-1 text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:text-gray-400 dark:text-gray-500 dark:hover:text-gray-300 dark:text-gray-600" @click="showCreateModal = false">
+            <button class="rounded p-1 text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300" @click="showCreateModal = false">
               <X class="h-5 w-5" />
             </button>
           </div>
           <div class="mt-4 space-y-4">
             <div>
-              <label class="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300 dark:text-gray-600">{{ t('super.users.username') }}</label>
+              <label class="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300">{{ t('super.users.username') }}</label>
               <input
                 v-model="newUsername"
                 type="text"
@@ -335,7 +335,7 @@ onMounted(fetchUsers)
               />
             </div>
             <div>
-              <label class="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300 dark:text-gray-600">{{ t('auth.password') }}</label>
+              <label class="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300">{{ t('auth.password') }}</label>
               <input
                 v-model="newPassword"
                 type="password"
@@ -347,7 +347,7 @@ onMounted(fetchUsers)
           </div>
           <div class="mt-5 flex justify-end gap-2">
             <button
-              class="rounded-md px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 dark:text-gray-600 transition-colors hover:bg-gray-100 dark:hover:bg-gray-800 dark:bg-gray-800"
+              class="rounded-md px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 transition-colors hover:bg-gray-100 dark:hover:bg-gray-800"
               @click="showCreateModal = false"
             >
               Cancel
@@ -375,15 +375,15 @@ onMounted(fetchUsers)
         <div class="mx-4 w-full max-w-md rounded-lg bg-white dark:bg-gray-900 p-6 shadow-xl">
           <div class="flex items-center justify-between">
             <h3 class="text-lg font-semibold text-gray-900 dark:text-white">{{ t('super.users.resetPassword') }}</h3>
-            <button class="rounded p-1 text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:text-gray-400 dark:text-gray-500 dark:hover:text-gray-300 dark:text-gray-600" @click="showResetModal = false">
+            <button class="rounded p-1 text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300" @click="showResetModal = false">
               <X class="h-5 w-5" />
             </button>
           </div>
-          <p class="mt-2 text-sm text-gray-500 dark:text-gray-400 dark:text-gray-500">
+          <p class="mt-2 text-sm text-gray-500 dark:text-gray-400">
             {{ t('super.users.resetFor', { username: resetUsername }) }}
           </p>
           <div class="mt-4">
-            <label class="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300 dark:text-gray-600">{{ t('super.users.newPassword') }}</label>
+            <label class="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300">{{ t('super.users.newPassword') }}</label>
             <input
               v-model="resetNewPassword"
               type="password"
@@ -394,7 +394,7 @@ onMounted(fetchUsers)
           </div>
           <div class="mt-5 flex justify-end gap-2">
             <button
-              class="rounded-md px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 dark:text-gray-600 transition-colors hover:bg-gray-100 dark:hover:bg-gray-800 dark:bg-gray-800"
+              class="rounded-md px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 transition-colors hover:bg-gray-100 dark:hover:bg-gray-800"
               @click="showResetModal = false"
             >
               Cancel
@@ -422,7 +422,7 @@ onMounted(fetchUsers)
         <div class="mx-4 w-full max-w-lg rounded-lg bg-white dark:bg-gray-900 p-6 shadow-xl">
           <div class="flex items-center justify-between">
             <h3 class="text-lg font-semibold text-gray-900 dark:text-white">{{ t('super.users.userDetail') }}</h3>
-            <button class="rounded p-1 text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:text-gray-400 dark:text-gray-500 dark:hover:text-gray-300 dark:text-gray-600" @click="showDetailModal = false">
+            <button class="rounded p-1 text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300" @click="showDetailModal = false">
               <X class="h-5 w-5" />
             </button>
           </div>
@@ -434,7 +434,7 @@ onMounted(fetchUsers)
           <template v-else-if="userDetail">
             <div class="mt-4 space-y-3">
               <div class="flex items-center gap-3">
-                <div class="flex h-10 w-10 items-center justify-center rounded-full bg-gray-100 dark:bg-gray-800 text-sm font-bold text-gray-600 dark:text-gray-400 dark:text-gray-500">
+                <div class="flex h-10 w-10 items-center justify-center rounded-full bg-gray-100 dark:bg-gray-800 text-sm font-bold text-gray-600 dark:text-gray-400">
                   {{ userDetail.username.charAt(0).toUpperCase() }}
                 </div>
                 <div>
@@ -443,7 +443,7 @@ onMounted(fetchUsers)
                 </div>
                 <span
                   class="ml-auto inline-flex items-center gap-1.5 rounded-full px-2.5 py-0.5 text-xs font-medium"
-                  :class="userDetail.isActive ? 'bg-green-50 text-green-700' : 'bg-gray-100 dark:bg-gray-800 text-gray-500 dark:text-gray-400 dark:text-gray-500'"
+                  :class="userDetail.isActive ? 'bg-green-50 dark:bg-green-900/20 text-green-700 dark:text-green-400' : 'bg-gray-100 dark:bg-gray-800 text-gray-500 dark:text-gray-400'"
                 >
                   <span class="h-1.5 w-1.5 rounded-full" :class="userDetail.isActive ? 'bg-green-500' : 'bg-gray-400'" />
                   {{ userDetail.isActive ? t('common.active') : t('common.disabled') }}
@@ -454,19 +454,19 @@ onMounted(fetchUsers)
                 <div class="grid gap-2 sm:grid-cols-2">
                   <div>
                     <span class="text-xs text-gray-400 dark:text-gray-500">Super Admin</span>
-                    <p class="font-medium" :class="userDetail.isSuper ? 'text-indigo-600' : 'text-gray-600 dark:text-gray-400 dark:text-gray-500'">
+                    <p class="font-medium" :class="userDetail.isSuper ? 'text-indigo-600' : 'text-gray-600 dark:text-gray-400'">
                       {{ userDetail.isSuper ? 'Yes' : 'No' }}
                     </p>
                   </div>
                   <div>
                     <span class="text-xs text-gray-400 dark:text-gray-500">Created</span>
-                    <p class="font-medium text-gray-600 dark:text-gray-400 dark:text-gray-500">{{ formatDate(userDetail.createdAt) }}</p>
+                    <p class="font-medium text-gray-600 dark:text-gray-400">{{ formatDate(userDetail.createdAt) }}</p>
                   </div>
                 </div>
               </div>
 
               <div>
-                <h4 class="mb-2 text-sm font-medium text-gray-700 dark:text-gray-300 dark:text-gray-600">{{ t('super.users.tenantMemberships') }}</h4>
+                <h4 class="mb-2 text-sm font-medium text-gray-700 dark:text-gray-300">{{ t('super.users.tenantMemberships') }}</h4>
                 <div v-if="userDetail.tenants.length === 0" class="text-sm text-gray-400 dark:text-gray-500">
                   {{ t('super.users.noMemberships') }}
                 </div>
@@ -474,12 +474,12 @@ onMounted(fetchUsers)
                   <div
                     v-for="t in userDetail.tenants"
                     :key="t.tenantId"
-                    class="flex items-center justify-between rounded-md border bg-white px-3 py-2"
+                    class="flex items-center justify-between rounded-md border dark:border-gray-700 bg-white dark:bg-gray-800 px-3 py-2"
                   >
-                    <span class="font-mono text-sm text-gray-700 dark:text-gray-300 dark:text-gray-600">{{ t.tenantId }}</span>
+                    <span class="font-mono text-sm text-gray-700 dark:text-gray-300">{{ t.tenantId }}</span>
                     <span
                       class="inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium"
-                      :class="t.role === 'admin' ? 'bg-blue-50 text-blue-700' : 'bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-400 dark:text-gray-500'"
+                      :class="t.role === 'admin' ? 'bg-blue-50 dark:bg-blue-900/20 text-blue-700 dark:text-blue-400' : 'bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-400'"
                     >
                       {{ t.role }}
                     </span>


### PR DESCRIPTION
## Summary

- Systematically audit and fix dark mode (`dark:` Tailwind classes) across all pages and components
- Add missing dark variants for backgrounds, text colors, borders, hover states, and status badges
- Clean up all duplicate/conflicting dark mode classes throughout the codebase
- Make ECharts chart option reactive to dark mode theme for DashboardPage

## Changes

**17 files modified** across components, pages, and super admin pages:

### Components
- `GlobalSearch.vue` — Modal panel, inputs, results, keyboard shortcut badges
- `ShortcutHelp.vue` — Modal panel, keyboard key badges, dividers, section labels

### Pages
- `DashboardPage.vue` — Stat cards, chart containers, recent links, top links table, ECharts theme
- `ShortLinksPage.vue` — Batch action buttons, status badges, action buttons, pagination
- `ShortLinkCreatePage.vue` — Success state container, copy/open link buttons
- `ShortLinkEditPage.vue` — Back button, info labels, cancel button cleanup
- `ShortLinkDetailPage.vue` — All card containers, status badge, charts, tables
- `MembersPage.vue` — Admin avatar, role badge
- `InvitationsPage.vue` — Accepted status badge
- `TenantsPage.vue` — Table container, status badge, slug/date columns
- `TenantDetailPage.vue` — All duplicate dark class cleanup, status badges, action buttons
- `SelectTenantPage.vue` — Admin role badge, super admin button
- `NotFoundPage.vue` — Title contrast improvement

### Super Admin Pages
- `SuperDashboardPage.vue` — Table header, body, status badges, tenant links
- `SuperTenantsPage.vue` — All duplicate dark classes, status badges, action buttons
- `SuperTenantDetailPage.vue` — Error message box, tab buttons, status/role badges, all modals
- `SuperUsersPage.vue` — User detail card, role badges, all modals

## Test plan

- [x] TypeScript type-check passes
- [x] Vite build succeeds
- [ ] Visual verification in light mode (no regressions)
- [ ] Visual verification in dark mode (all elements properly styled)
- [ ] Toggle between light/dark modes to verify smooth transitions

Closes [JWM-70](mention://issue/3c4e1e8d-b0ee-4135-ab85-5b6186d606d9)

🤖 Generated with [Claude Code](https://claude.com/claude-code)