### PR TITLE
refactor: simplify global search to icon-only button

### DIFF
--- a/web-ui/src/components/AppTopBar.vue
+++ b/web-ui/src/components/AppTopBar.vue
@@ -64,12 +64,10 @@ onBeforeUnmount(() => document.removeEventListener('click', closeDropdowns))
       <slot name="breadcrumb" />
     </div>
 
-    <div class="flex items-center gap-3">
+    <div class="flex items-center gap-2">
       <!-- Global Search -->
       <GlobalSearch />
-    </div>
 
-    <div class="flex items-center gap-2">
       <!-- Theme toggle -->
       <div class="topbar-dropdown relative">
         <button

--- a/web-ui/src/components/GlobalSearch.vue
+++ b/web-ui/src/components/GlobalSearch.vue
@@ -55,12 +55,11 @@ onBeforeUnmount(() => {
 <template>
   <!-- Search trigger button -->
   <button
-    class="flex items-center gap-2 rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 px-3 py-1.5 text-sm text-gray-400 dark:text-gray-500 transition-colors hover:border-gray-300 dark:hover:border-gray-600 hover:text-gray-500"
+    class="rounded p-1.5 text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-600 dark:hover:bg-gray-800 dark:hover:text-gray-300"
+    aria-label="Search"
     @click="openSearch"
   >
-    <Search class="h-4 w-4" />
-    <span class="hidden sm:inline">Search...</span>
-    <kbd class="hidden rounded border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 px-1.5 py-0.5 text-[10px] font-medium text-gray-400 dark:text-gray-500 sm:inline">Ctrl+K</kbd>
+    <Search class="h-5 w-5" />
   </button>
 
   <!-- Search modal -->
@@ -123,7 +122,11 @@ onBeforeUnmount(() => {
 
         <!-- Empty state -->
         <div v-else class="px-4 py-6 text-center">
-          <p class="text-sm text-gray-400 dark:text-gray-500">Start typing to search...</p>
+          <p class="text-sm text-gray-400 dark:text-gray-500">Start typing to search…</p>
+          <p class="mt-1 text-xs text-gray-300 dark:text-gray-600">
+            <kbd class="rounded border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 px-1.5 py-0.5 text-[10px] font-medium text-gray-400 dark:text-gray-500">Ctrl+K</kbd>
+            to quick search anytime
+          </p>
         </div>
       </div>
     </div>

--- a/web-ui/src/components/GlobalSearch.vue
+++ b/web-ui/src/components/GlobalSearch.vue
@@ -8,6 +8,7 @@ const { query, results, loading, open, hasResults, openSearch, closeSearch, sele
 
 const inputRef = ref<HTMLInputElement | null>(null)
 const activeIndex = ref(-1)
+const shortcutLabel = /Mac|iPod|iPhone|iPad/.test(navigator.userAgent) ? '⌘K' : 'Ctrl+K'
 
 watch(open, async (isOpen) => {
   if (isOpen) {
@@ -123,9 +124,9 @@ onBeforeUnmount(() => {
         <!-- Empty state -->
         <div v-else class="px-4 py-6 text-center">
           <p class="text-sm text-gray-400 dark:text-gray-500">Start typing to search…</p>
-          <p class="mt-1 text-xs text-gray-300 dark:text-gray-600">
-            <kbd class="rounded border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 px-1.5 py-0.5 text-[10px] font-medium text-gray-400 dark:text-gray-500">Ctrl+K</kbd>
-            to quick search anytime
+          <p class="mt-1 text-xs text-gray-400 dark:text-gray-500">
+            <kbd class="rounded border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 px-1.5 py-0.5 text-[10px] font-medium text-gray-400 dark:text-gray-500">{{ shortcutLabel }}</kbd>
+            to quickly search anytime
           </p>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Replace the search input-style trigger button with a minimal Search icon button, matching the style of theme toggle and notification icons
- Move the search icon from the center of the TopBar to the right side, aligned with theme/notification/user icons
- Show Ctrl+K shortcut hint inside the search modal's empty state instead of on the trigger button

## Test plan
- [ ] Verify search icon appears on the right side of the TopBar, aligned with theme and notification icons
- [ ] Click the search icon to open the search modal
- [ ] Confirm Ctrl+K hint is visible in the modal's empty state
- [ ] Verify Ctrl+K keyboard shortcut still opens the search modal
- [ ] Check the icon button styling is consistent with other icon buttons (hover states, dark mode)

Closes [JWM-69](mention://issue/73fb11ba-4954-406b-8809-a7d4e6ddb405)

🤖 Generated with [Claude Code](https://claude.com/claude-code)