### PR TITLE
fix(web-ui): dark mode input text, page backgrounds, and icon colors

### DIFF
--- a/web-ui/src/pages/DashboardPage.vue
+++ b/web-ui/src/pages/DashboardPage.vue
@@ -491,8 +491,8 @@ onMounted(() => fetchDashboardData())
               <template v-else>{{ totalLinks.toLocaleString() }}</template>
             </p>
           </div>
-          <div class="flex h-8 w-8 items-center justify-center rounded-lg bg-blue-50 sm:h-10 sm:w-10">
-            <Link class="h-4 w-4 text-blue-600 sm:h-5 sm:w-5" />
+          <div class="flex h-8 w-8 items-center justify-center rounded-lg bg-blue-50 dark:bg-blue-900/20 sm:h-10 sm:w-10">
+            <Link class="h-4 w-4 text-blue-600 dark:text-blue-400 sm:h-5 sm:w-5" />
           </div>
         </div>
       </div>
@@ -510,8 +510,8 @@ onMounted(() => fetchDashboardData())
               <template v-else>{{ activeLinks.toLocaleString() }}</template>
             </p>
           </div>
-          <div class="flex h-8 w-8 items-center justify-center rounded-lg bg-green-50 sm:h-10 sm:w-10">
-            <LinkIcon class="h-4 w-4 text-green-600 sm:h-5 sm:w-5" />
+          <div class="flex h-8 w-8 items-center justify-center rounded-lg bg-green-50 dark:bg-green-900/20 sm:h-10 sm:w-10">
+            <LinkIcon class="h-4 w-4 text-green-600 dark:text-green-400 sm:h-5 sm:w-5" />
           </div>
         </div>
       </div>
@@ -542,7 +542,7 @@ onMounted(() => fetchDashboardData())
             </div>
           </div>
           <div class="flex h-8 w-8 items-center justify-center rounded-lg bg-purple-50 dark:bg-purple-900/20 sm:h-10 sm:w-10">
-            <MousePointerClick class="h-4 w-4 text-purple-600 sm:h-5 sm:w-5" />
+            <MousePointerClick class="h-4 w-4 text-purple-600 dark:text-purple-400 sm:h-5 sm:w-5" />
           </div>
         </div>
         <p v-if="!loading && todayTrend" class="mt-1 text-xs text-gray-400">{{ t('dashboard.vsYesterday') }}</p>
@@ -574,7 +574,7 @@ onMounted(() => fetchDashboardData())
             </div>
           </div>
           <div class="flex h-8 w-8 items-center justify-center rounded-lg bg-orange-50 dark:bg-orange-900/20 sm:h-10 sm:w-10">
-            <BarChart3 class="h-4 w-4 text-orange-600 sm:h-5 sm:w-5" />
+            <BarChart3 class="h-4 w-4 text-orange-600 dark:text-orange-400 sm:h-5 sm:w-5" />
           </div>
         </div>
         <p v-if="!loading && periodTrend" class="mt-1 text-xs text-gray-400">{{ t('dashboard.vsPrevious', { days: trendDays }) }}</p>

--- a/web-ui/src/pages/LoginPage.vue
+++ b/web-ui/src/pages/LoginPage.vue
@@ -38,7 +38,7 @@ async function handleLogin() {
 </script>
 
 <template>
-  <div class="flex min-h-screen items-center justify-center bg-gray-50 dark:bg-gray-800/50">
+  <div class="flex min-h-screen items-center justify-center bg-gray-50 dark:bg-gray-950">
     <div class="w-full max-w-sm">
       <div class="mb-8 text-center">
         <div class="mx-auto mb-3 flex h-12 w-12 items-center justify-center rounded-xl bg-blue-600">

--- a/web-ui/src/pages/MembersPage.vue
+++ b/web-ui/src/pages/MembersPage.vue
@@ -277,7 +277,7 @@ onMounted(fetchMembers)
             <td v-if="auth.isAdmin" class="px-4 py-3">
               <div v-if="m.userId !== auth.authUser?.id" class="flex items-center justify-end gap-1">
                 <button
-                  class="rounded p-1.5 text-gray-400 dark:text-gray-500 transition-colors hover:bg-blue-50 hover:text-blue-600"
+                  class="rounded p-1.5 text-gray-400 dark:text-gray-500 transition-colors hover:bg-blue-50 dark:hover:bg-blue-900/20 hover:text-blue-600 dark:hover:text-blue-400"
                   :title="t('members.changeRole')"
                   @click="requestRoleChange(m)"
                 >

--- a/web-ui/src/pages/SelectTenantPage.vue
+++ b/web-ui/src/pages/SelectTenantPage.vue
@@ -94,7 +94,7 @@ async function handleLogout() {
 </script>
 
 <template>
-  <div class="flex min-h-screen items-center justify-center bg-gray-50 dark:bg-gray-800/50">
+  <div class="flex min-h-screen items-center justify-center bg-gray-50 dark:bg-gray-950">
     <div class="w-full max-w-md">
       <template v-if="loading">
         <div class="flex flex-col items-center gap-3">
@@ -116,8 +116,8 @@ async function handleLogout() {
             @click="selectTenant(tenant.tenantId)"
           >
             <div class="flex items-center gap-3">
-              <div class="flex h-10 w-10 items-center justify-center rounded-lg bg-blue-50">
-                <Building2 class="h-5 w-5 text-blue-600" />
+              <div class="flex h-10 w-10 items-center justify-center rounded-lg bg-blue-50 dark:bg-blue-900/20">
+                <Building2 class="h-5 w-5 text-blue-600 dark:text-blue-400" />
               </div>
               <div>
                 <div class="font-medium text-gray-900 dark:text-white">{{ tenant.tenantName }}</div>
@@ -139,10 +139,10 @@ async function handleLogout() {
           @click="enterSuperAdmin"
         >
           <div class="flex items-center gap-3">
-            <Shield class="h-5 w-5 text-amber-600" />
-            <span class="font-medium text-amber-700">{{ t('selectTenant.superAdminPanel') }}</span>
+            <Shield class="h-5 w-5 text-amber-600 dark:text-amber-400" />
+            <span class="font-medium text-amber-700 dark:text-amber-300">{{ t('selectTenant.superAdminPanel') }}</span>
           </div>
-          <ArrowRight class="h-4 w-4 text-amber-400" />
+          <ArrowRight class="h-4 w-4 text-amber-400 dark:text-amber-300" />
         </button>
 
         <button

--- a/web-ui/src/pages/SettingsPage.vue
+++ b/web-ui/src/pages/SettingsPage.vue
@@ -445,7 +445,7 @@ onMounted(fetchAll)
                   </div>
                   <div class="mt-1 flex items-center gap-2 pl-6">
                     <span v-if="d.isDefault" class="inline-flex items-center gap-1 text-xs font-medium text-yellow-600">
-                      <Star class="h-3 w-3 fill-yellow-500 text-yellow-500" />
+                      <Star class="h-3 w-3 fill-yellow-500 text-yellow-500 dark:fill-yellow-400 dark:text-yellow-400" />
                       {{ t('settings.default') }}
                     </span>
                     <span class="text-xs text-gray-400 dark:text-gray-500">{{ formatDate(d.createdAt) }}</span>
@@ -493,7 +493,7 @@ onMounted(fetchAll)
                   </td>
                   <td class="px-4 py-3">
                     <span v-if="d.isDefault" class="inline-flex items-center gap-1 text-xs font-medium text-yellow-600">
-                      <Star class="h-3.5 w-3.5 fill-yellow-500 text-yellow-500" />
+                      <Star class="h-3.5 w-3.5 fill-yellow-500 text-yellow-500 dark:fill-yellow-400 dark:text-yellow-400" />
                       {{ t('settings.default') }}
                     </span>
                     <span v-else class="text-xs text-gray-400 dark:text-gray-500">&mdash;</span>
@@ -530,7 +530,7 @@ onMounted(fetchAll)
       <!-- ID Length Config (admin only) -->
       <div v-if="isAdmin" class="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 shadow-sm">
         <div class="flex items-center gap-2 border-b border-gray-100 dark:border-gray-800 px-4 py-3 sm:px-5 sm:py-4">
-          <Hash class="h-4 w-4 text-blue-600" />
+          <Hash class="h-4 w-4 text-blue-600 dark:text-blue-400" />
           <h2 class="text-base font-semibold text-gray-900 dark:text-white">{{ t('settings.idLengthConfig') }}</h2>
         </div>
         <div class="p-4 sm:p-5">
@@ -590,7 +590,7 @@ onMounted(fetchAll)
       <!-- 404 Config (admin only) -->
       <div v-if="isAdmin" class="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 shadow-sm">
         <div class="flex items-center gap-2 border-b border-gray-100 dark:border-gray-800 px-4 py-3 sm:px-5 sm:py-4">
-          <AlertTriangle class="h-4 w-4 text-orange-500" />
+          <AlertTriangle class="h-4 w-4 text-orange-500 dark:text-orange-400" />
           <h2 class="text-base font-semibold text-gray-900 dark:text-white">{{ t('settings.notFoundConfig') }}</h2>
         </div>
         <div class="p-4 sm:p-5">
@@ -688,7 +688,7 @@ onMounted(fetchAll)
               <p class="mb-2 text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400">{{ t('settings.notFoundHandling') }}</p>
               <span
                 class="inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium"
-                :class="notFoundMode === 'content' ? 'bg-blue-50 text-blue-700' : 'bg-orange-50 text-orange-700'"
+                :class="notFoundMode === 'content' ? 'bg-blue-50 dark:bg-blue-900/20 text-blue-700 dark:text-blue-400' : 'bg-orange-50 dark:bg-orange-900/20 text-orange-700 dark:text-orange-400'"
               >
                 {{ notFoundMode === 'content' ? t('settings.displayContent') : t('settings.redirect') }}
               </span>

--- a/web-ui/src/pages/ShortLinksPage.vue
+++ b/web-ui/src/pages/ShortLinksPage.vue
@@ -414,7 +414,7 @@ onMounted(fetchLinks)
               @click="copyLink(link.id)"
             >
               <Copy v-if="copiedId !== link.id" class="h-3.5 w-3.5" />
-              <Check v-else class="h-3.5 w-3.5 text-green-500" />
+              <Check v-else class="h-3.5 w-3.5 text-green-500 dark:text-green-400" />
             </button>
           </div>
           <button
@@ -623,7 +623,7 @@ onMounted(fetchLinks)
                     @click="copyLink(link.id)"
                   >
                     <Copy v-if="copiedId !== link.id" class="h-3.5 w-3.5" />
-                    <Check v-else class="h-3.5 w-3.5 text-green-500" />
+                    <Check v-else class="h-3.5 w-3.5 text-green-500 dark:text-green-400" />
                   </button>
                 </div>
               </td>

--- a/web-ui/src/pages/TenantDetailPage.vue
+++ b/web-ui/src/pages/TenantDetailPage.vue
@@ -172,7 +172,7 @@ onMounted(() => {
       <div class="mt-4 rounded-lg border bg-white dark:bg-gray-900 p-5">
         <div class="flex items-center gap-3 border-b border-gray-100 dark:border-gray-800 pb-4">
           <div
-            class="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-blue-50 text-sm font-bold text-blue-600"
+            class="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-blue-50 dark:bg-blue-900/20 text-sm font-bold text-blue-600 dark:text-blue-400"
           >
             {{ tenant.name.charAt(0).toUpperCase() }}
           </div>

--- a/web-ui/src/pages/TenantsPage.vue
+++ b/web-ui/src/pages/TenantsPage.vue
@@ -117,7 +117,7 @@ onMounted(fetchTenants)
               <td class="px-4 py-3">
                 <div class="flex items-center gap-2">
                   <div
-                    class="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-blue-50 text-xs font-bold text-blue-600"
+                    class="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-blue-50 dark:bg-blue-900/20 text-xs font-bold text-blue-600 dark:text-blue-400"
                   >
                     {{ tenant.name.charAt(0).toUpperCase() }}
                   </div>

--- a/web-ui/src/pages/super/SuperDashboardPage.vue
+++ b/web-ui/src/pages/super/SuperDashboardPage.vue
@@ -61,8 +61,8 @@ onMounted(fetchDashboardData)
               <template v-else>{{ totalTenants.toLocaleString() }}</template>
             </p>
           </div>
-          <div class="flex h-10 w-10 items-center justify-center rounded-lg bg-blue-50">
-            <Building2 class="h-5 w-5 text-blue-600" />
+          <div class="flex h-10 w-10 items-center justify-center rounded-lg bg-blue-50 dark:bg-blue-900/20">
+            <Building2 class="h-5 w-5 text-blue-600 dark:text-blue-400" />
           </div>
         </div>
       </div>

--- a/web-ui/src/pages/super/SuperTenantDetailPage.vue
+++ b/web-ui/src/pages/super/SuperTenantDetailPage.vue
@@ -215,7 +215,7 @@ onMounted(fetchTenant)
       <div class="mt-4 rounded-lg border bg-white dark:bg-gray-900 p-5">
         <div class="flex items-center gap-3">
           <div
-            class="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-blue-50 text-sm font-bold text-blue-600"
+            class="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-blue-50 dark:bg-blue-900/20 text-sm font-bold text-blue-600 dark:text-blue-400"
           >
             {{ tenant.name.charAt(0).toUpperCase() }}
           </div>

--- a/web-ui/src/pages/super/SuperTenantsPage.vue
+++ b/web-ui/src/pages/super/SuperTenantsPage.vue
@@ -173,7 +173,7 @@ onMounted(fetchTenants)
               <td class="px-4 py-3">
                 <div class="flex items-center gap-2">
                   <div
-                    class="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-blue-50 text-xs font-bold text-blue-600"
+                    class="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-blue-50 dark:bg-blue-900/20 text-xs font-bold text-blue-600 dark:text-blue-400"
                   >
                     {{ tenant.name.charAt(0).toUpperCase() }}
                   </div>

--- a/web-ui/src/style.css
+++ b/web-ui/src/style.css
@@ -29,7 +29,7 @@ select:disabled {
   cursor: not-allowed;
 }
 
-.dark input,
+.dark input:not([type="checkbox"]):not([type="radio"]):not([type="range"]):not([type="color"]):not([type="file"]):not([type="image"]):not([type="submit"]):not([type="reset"]):not([type="button"]),
 .dark textarea,
 .dark select {
   color: white;

--- a/web-ui/src/style.css
+++ b/web-ui/src/style.css
@@ -28,3 +28,9 @@ button:disabled,
 select:disabled {
   cursor: not-allowed;
 }
+
+.dark input,
+.dark textarea,
+.dark select {
+  color: white;
+}


### PR DESCRIPTION
## Summary

- Fix all input/textarea/select dark text on dark background — added global `.dark input, .dark textarea, .dark select { color: white }` in `style.css`
- Darken login and select tenant page backgrounds from `dark:bg-gray-800/50` to `dark:bg-gray-950` for proper dark theme feel
- Add dark mode variants for all SVG icons that lacked them (stat card icons, tenant avatars, settings icons, etc.)

## Changes

**Global:**
- `style.css` — Add `color: white` for all inputs/textareas/selects in dark mode

**Login & Select Tenant pages:**
- `LoginPage.vue` — Background `dark:bg-gray-950`
- `SelectTenantPage.vue` — Background `dark:bg-gray-950`, building icon `dark:bg-blue-900/20 dark:text-blue-400`, shield/amber icons dark variants

**Icon dark mode fixes across pages:**
- `DashboardPage.vue` — Stat card icon backgrounds (blue/green) and text colors (blue/green/purple/orange)
- `ShortLinksPage.vue` — Check icon `dark:text-green-400`
- `SettingsPage.vue` — Star `dark:fill-yellow-400 dark:text-yellow-400`, Hash `dark:text-blue-400`, AlertTriangle `dark:text-orange-400`, notFound mode badge
- `MembersPage.vue` — Role change button hover `dark:hover:bg-blue-900/20 dark:hover:text-blue-400`
- `TenantsPage.vue` — Tenant avatar container `dark:bg-blue-900/20 dark:text-blue-400`
- `TenantDetailPage.vue` — Tenant avatar container
- `SuperDashboardPage.vue` — Building icon container and text
- `SuperTenantsPage.vue` — Tenant avatar container
- `SuperTenantDetailPage.vue` — Tenant avatar container

## Test plan

- [x] TypeScript type-check + Vite build pass
- [ ] Login page: dark background is deep, subtitle text readable, form inputs show white text
- [ ] Select tenant page: dark background, all text/icons readable, Create Tenant modal inputs show white text
- [ ] All other pages: input fields show white text on dark backgrounds
- [ ] Pagination dropdown: text is white/light in dark mode
- [ ] All SVG icons properly visible in dark mode

Closes [JWM-70](mention://issue/3c4e1e8d-b0ee-4135-ab85-5b6186d606d9)

🤖 Generated with [Claude Code](https://claude.com/claude-code)