### PR TITLE
fix: improve Toast visibility in dark mode

### DIFF
--- a/web-ui/src/components/AppToast.vue
+++ b/web-ui/src/components/AppToast.vue
@@ -13,12 +13,12 @@ const iconMap = {
 
 const styleMap = {
   success:
-    'bg-green-50 border-green-200 text-green-800 dark:bg-green-900/20 dark:border-green-800 dark:text-green-300',
+    'bg-green-50 border-green-200 text-green-800 dark:bg-green-900/90 dark:border-green-700 dark:text-green-200',
   error:
-    'bg-red-50 border-red-200 text-red-800 dark:bg-red-900/20 dark:border-red-800 dark:text-red-300',
+    'bg-red-50 border-red-200 text-red-800 dark:bg-red-900/90 dark:border-red-700 dark:text-red-200',
   warning:
-    'bg-amber-50 border-amber-200 text-amber-800 dark:bg-amber-900/20 dark:border-amber-800 dark:text-amber-300',
-  info: 'bg-blue-50 border-blue-200 text-blue-800 dark:bg-blue-900/20 dark:border-blue-800 dark:text-blue-300',
+    'bg-amber-50 border-amber-200 text-amber-800 dark:bg-amber-900/90 dark:border-amber-700 dark:text-amber-200',
+  info: 'bg-blue-50 border-blue-200 text-blue-800 dark:bg-blue-900/90 dark:border-blue-700 dark:text-blue-200',
 } as const
 
 const iconStyleMap = {


### PR DESCRIPTION
## Summary
- Increase dark mode Toast background opacity from `/20` (20%) to `/90` (90%) for all four toast types (success, error, warning, info)
- Adjust border colors from `-800` to `-700` and text colors from `-300` to `-200` for improved contrast

Fixes [JWM-75](mention://issue/1b88d41d-2c6a-4eea-9c8f-7ad72c7f33fc)

## Test plan
- [ ] Switch to dark mode and trigger each toast type (success, error, warning, info)
- [ ] Verify backgrounds are clearly visible and no longer blend into the page
- [ ] Verify text remains readable with good contrast against the darker backgrounds

🤖 Generated with [Claude Code](https://claude.com/claude-code)