### PR TITLE
fix: improve toast visibility in dark theme

### DIFF
--- a/web-ui/src/components/AppToast.vue
+++ b/web-ui/src/components/AppToast.vue
@@ -13,19 +13,19 @@ const iconMap = {
 
 const styleMap = {
   success:
-    'bg-green-50 border-green-200 text-green-800 dark:bg-green-900/20 dark:border-green-800 dark:text-green-300',
+    'bg-green-50 border-green-200 text-green-800 dark:bg-green-900/90 dark:border-green-700 dark:text-green-200',
   error:
-    'bg-red-50 border-red-200 text-red-800 dark:bg-red-900/20 dark:border-red-800 dark:text-red-300',
+    'bg-red-50 border-red-200 text-red-800 dark:bg-red-900/90 dark:border-red-700 dark:text-red-200',
   warning:
-    'bg-amber-50 border-amber-200 text-amber-800 dark:bg-amber-900/20 dark:border-amber-800 dark:text-amber-300',
-  info: 'bg-blue-50 border-blue-200 text-blue-800 dark:bg-blue-900/20 dark:border-blue-800 dark:text-blue-300',
+    'bg-amber-50 border-amber-200 text-amber-800 dark:bg-amber-900/90 dark:border-amber-700 dark:text-amber-200',
+  info: 'bg-blue-50 border-blue-200 text-blue-800 dark:bg-blue-900/90 dark:border-blue-700 dark:text-blue-200',
 } as const
 
 const iconStyleMap = {
-  success: 'text-green-500',
-  error: 'text-red-500',
-  warning: 'text-amber-500',
-  info: 'text-blue-500',
+  success: 'text-green-500 dark:text-green-400',
+  error: 'text-red-500 dark:text-red-400',
+  warning: 'text-amber-500 dark:text-amber-400',
+  info: 'text-blue-500 dark:text-blue-400',
 } as const
 </script>
 


### PR DESCRIPTION
## Summary

- Fix Toast component (`AppToast.vue`) barely visible in dark theme due to 20% background opacity
- Increase dark mode background opacity from `/20` to `/90` for all toast types (success, error, warning, info)
- Adjust border colors from `-800` to `-700` and text colors from `-300` to `-200` for better contrast
- Add dark mode variants for icon colors (`dark:text-*-400`) for consistent visibility

## Changes

| Property | Before | After |
|----------|--------|-------|
| Background | `dark:bg-*-900/20` | `dark:bg-*-900/90` |
| Border | `dark:border-*-800` | `dark:border-*-700` |
| Text | `dark:text-*-300` | `dark:text-*-200` |
| Icon | no dark variant | `dark:text-*-400` |

## Test plan

- [x] `npm run build` passes (vue-tsc + vite build)
- [ ] Visually verify toast in light theme (unchanged)
- [ ] Visually verify toast in dark theme (improved visibility)

Closes: JWM-75

🤖 Generated with [Claude Code](https://claude.com/claude-code)