### PR TITLE
feat: add backend i18n infrastructure

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,11 +9,14 @@ require (
 	github.com/golang-jwt/jwt/v5 v5.2.1
 	github.com/jackc/pgx/v5 v5.7.1
 	github.com/mssola/user_agent v0.5.2
+	github.com/nicksnyder/go-i18n/v2 v2.6.1
+	github.com/pelletier/go-toml/v2 v2.2.2
 	github.com/redis/go-redis/v9 v9.7.0
 	github.com/swaggo/files v0.0.0-20190704085106-630677cd5c14
 	github.com/swaggo/gin-swagger v1.3.0
 	github.com/swaggo/swag v1.16.6
 	golang.org/x/crypto v0.47.0
+	golang.org/x/text v0.33.0
 )
 
 require (
@@ -49,7 +52,6 @@ require (
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
-	github.com/pelletier/go-toml/v2 v2.2.2 // indirect
 	github.com/rogpeppe/go-internal v1.13.1 // indirect
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
 	github.com/ugorji/go/codec v1.2.12 // indirect
@@ -58,7 +60,6 @@ require (
 	golang.org/x/net v0.49.0 // indirect
 	golang.org/x/sync v0.19.0 // indirect
 	golang.org/x/sys v0.40.0 // indirect
-	golang.org/x/text v0.33.0 // indirect
 	golang.org/x/tools v0.40.0 // indirect
 	google.golang.org/protobuf v1.36.7 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/BurntSushi/toml v1.6.0 h1:dRaEfpa2VI55EwlIW72hMRHdWouJeRF7TPYhI+AUQjk=
+github.com/BurntSushi/toml v1.6.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/KyleBanks/depth v1.2.1 h1:5h8fQADFrWtarTdtDudMmGsC7GPbOAu6RVB3ffsVFHc=
 github.com/KyleBanks/depth v1.2.1/go.mod h1:jzSb9d0L43HxTQfT+oSA1EEp2q+ne2uh6XgeJcm8brE=
 github.com/PuerkitoBio/purell v1.1.0/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
@@ -132,6 +134,8 @@ github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9G
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/mssola/user_agent v0.5.2 h1:CZkTUahjL1+OcZ5zv3kZr8QiJ8jy2H08vZIEkBeRbxo=
 github.com/mssola/user_agent v0.5.2/go.mod h1:TTPno8LPY3wAIEKRpAtkdMT0f8SE24pLRGPahjCH4uw=
+github.com/nicksnyder/go-i18n/v2 v2.6.1 h1:JDEJraFsQE17Dut9HFDHzCoAWGEQJom5s0TRd17NIEQ=
+github.com/nicksnyder/go-i18n/v2 v2.6.1/go.mod h1:Vee0/9RD3Quc/NmwEjzzD7VTZ+Ir7QbXocrkhOzmUKA=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/pelletier/go-toml/v2 v2.0.1/go.mod h1:r9LEWfGN8R5k0VXJ+0BkIe7MYkRdwZOjgMj2KwnJFUo=
 github.com/pelletier/go-toml/v2 v2.2.2 h1:aYUidT7k73Pcl9nb2gScu7NSrKCSHIDE89b3+6Wq+LM=
@@ -179,6 +183,8 @@ github.com/ugorji/go/codec v1.2.7/go.mod h1:WGN1fab3R1fzQlVQTkfxVtIBhWDRqOviHU95
 github.com/ugorji/go/codec v1.2.12 h1:9LC83zGrHhuUA9l16C9AHXAqEV/2wBQ4nkvumAE65EE=
 github.com/ugorji/go/codec v1.2.12/go.mod h1:UNopzCgEMSXjBc6AOMqYvWC1ktqTAfzJZUZgYf6w6lg=
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
+go.yaml.in/yaml/v3 v3.0.4 h1:tfq32ie2Jv2UxXFdLJdh3jXuOzWiL1fo0bu/FbuKpbc=
+go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
 golang.org/x/arch v0.0.0-20210923205945-b76863e36670/go.mod h1:5om86z9Hs0C8fWVUuoMHwpExlXzs5Tkyp9hOrfG7pp8=
 golang.org/x/arch v0.8.0 h1:3wRIsP3pM4yUptoR96otTUOXI367OS0+c9eeRi9doIc=
 golang.org/x/arch v0.8.0/go.mod h1:FEVrYAQjsQXMVJ1nsMoVVXPZg6p2JE2mx8psSWTDQys=

--- a/internal/app/cmd/server/server.go
+++ b/internal/app/cmd/server/server.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/jwma/jump-jump/internal/app/config"
 	"github.com/jwma/jump-jump/internal/app/db"
+	"github.com/jwma/jump-jump/internal/app/i18n"
 	"github.com/jwma/jump-jump/internal/app/routers"
 	"github.com/jwma/jump-jump/internal/app/workers"
 )
@@ -51,6 +52,10 @@ func Run(addr ...string) error {
 		return err
 	}
 
+	if err := i18n.Init(); err != nil {
+		return fmt.Errorf("i18n init failed: %w", err)
+	}
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	go workers.NewHistoryFlushWorker(db.GetRedisClient(), db.GetPostgresPool()).Run(ctx)
@@ -68,6 +73,10 @@ func RunLanding(addr ...string) error {
 
 	if err := config.SetupConfig(db.GetPostgresPool(), db.GetRedisClient()); err != nil {
 		return err
+	}
+
+	if err := i18n.Init(); err != nil {
+		return fmt.Errorf("i18n init failed: %w", err)
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/internal/app/config/config.go
+++ b/internal/app/config/config.go
@@ -74,7 +74,7 @@ func loadTenantConfig(tenantID string) *TenantConfig {
 		},
 		ShortLinkNotFoundConfig: &ShortLinkNotFoundConfig{
 			Mode:  ShortLinkNotFoundContentMode,
-			Value: "你访问的页面不存在哦",
+			Value: "The page you visited does not exist",
 		},
 	}
 

--- a/internal/app/config/config.go
+++ b/internal/app/config/config.go
@@ -74,7 +74,7 @@ func loadTenantConfig(tenantID string) *TenantConfig {
 		},
 		ShortLinkNotFoundConfig: &ShortLinkNotFoundConfig{
 			Mode:  ShortLinkNotFoundContentMode,
-			Value: "The page you visited does not exist",
+			Value: "landing.pageNotFound",
 		},
 	}
 

--- a/internal/app/handlers/landing.go
+++ b/internal/app/handlers/landing.go
@@ -7,6 +7,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/jwma/jump-jump/internal/app/config"
 	"github.com/jwma/jump-jump/internal/app/db"
+	"github.com/jwma/jump-jump/internal/app/i18n"
 	"github.com/jwma/jump-jump/internal/app/models"
 	"github.com/jwma/jump-jump/internal/app/repository"
 	"github.com/mssola/user_agent"
@@ -29,7 +30,7 @@ func Redirect(c *gin.Context) {
 		host := strings.Split(c.Request.Host, ":")[0]
 		tenantID, _ := config.ResolveTenantID(host)
 		if tenantID == "" {
-			c.String(http.StatusOK, "你访问的页面不存在哦")
+			c.String(http.StatusOK, i18n.T(c, "landing.pageNotFound"))
 			return
 		}
 
@@ -40,13 +41,13 @@ func Redirect(c *gin.Context) {
 		case config.ShortLinkNotFoundRedirectMode:
 			c.Redirect(http.StatusTemporaryRedirect, cc.Value)
 		default:
-			c.String(http.StatusOK, "你访问的页面不存在哦")
+			c.String(http.StatusOK, i18n.T(c, "landing.pageNotFound"))
 		}
 		return
 	}
 
 	if !s.IsEnable {
-		c.String(http.StatusOK, "你访问的页面不存在哦")
+		c.String(http.StatusOK, i18n.T(c, "landing.pageNotFound"))
 		return
 	}
 

--- a/internal/app/handlers/landing.go
+++ b/internal/app/handlers/landing.go
@@ -37,7 +37,7 @@ func Redirect(c *gin.Context) {
 		cc := config.GetShortLinkNotFoundConfig(tenantID)
 		switch cc.Mode {
 		case config.ShortLinkNotFoundContentMode:
-			c.String(http.StatusOK, cc.Value)
+			c.String(http.StatusOK, i18n.T(c, cc.Value))
 		case config.ShortLinkNotFoundRedirectMode:
 			c.Redirect(http.StatusTemporaryRedirect, cc.Value)
 		default:

--- a/internal/app/handlers/middleware.go
+++ b/internal/app/handlers/middleware.go
@@ -11,6 +11,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/jwma/jump-jump/internal/app/db"
+	"github.com/jwma/jump-jump/internal/app/i18n"
 	"github.com/jwma/jump-jump/internal/app/models"
 	"github.com/jwma/jump-jump/internal/app/repository"
 	"github.com/jwma/jump-jump/internal/app/utils"
@@ -24,7 +25,7 @@ func writeErrorResponse(c *gin.Context, err error) {
 	if errors.As(err, &nf) {
 		status = http.StatusNotFound
 	}
-	c.JSON(status, models.NewErrorResponse(err.Error()))
+	c.JSON(status, models.NewErrorResponse(i18n.TranslateError(c, err)))
 }
 
 // AuthContext carries the authenticated user and their tenant membership for the current request.
@@ -35,11 +36,11 @@ type AuthContext struct {
 
 func parseAuthorizationHeader(a string) (string, error) {
 	if a == "" {
-		return "", fmt.Errorf("authorization 为空字符串")
+		return "", fmt.Errorf("authorization header is empty")
 	}
 	t := strings.Split(a, " ")
 	if len(t) < 2 {
-		return "", fmt.Errorf("authorization 格式不正确")
+		return "", fmt.Errorf("invalid authorization header format")
 	}
 	return t[1], nil
 }
@@ -107,7 +108,7 @@ func TenantContextMiddleware() gin.HandlerFunc {
 
 		tenantID := c.GetHeader("X-Tenant-ID")
 		if tenantID == "" {
-			c.JSON(http.StatusOK, models.NewErrorResponse("X-Tenant-ID header is required"))
+			c.JSON(http.StatusOK, models.NewErrorResponse(i18n.T(c, "middleware.tenantIdRequired")))
 			c.Abort()
 			return
 		}
@@ -121,7 +122,7 @@ func TenantContextMiddleware() gin.HandlerFunc {
 			memberRepo := repository.GetTenantMemberRepo(db.GetPostgresPool())
 			m, err := memberRepo.Get(tenantID, ctx.User.ID)
 			if err != nil {
-				c.JSON(http.StatusOK, models.NewErrorResponse("你不是该租户的成员"))
+				c.JSON(http.StatusOK, models.NewErrorResponse(i18n.T(c, "tenant.notMember")))
 				c.Abort()
 				return
 			}
@@ -163,7 +164,7 @@ func SuperAdminMiddleware() gin.HandlerFunc {
 		}
 		ctx := ac.(*AuthContext)
 		if !ctx.User.IsSuper {
-			c.JSON(http.StatusOK, models.NewErrorResponse("仅超级管理员可执行此操作"))
+			c.JSON(http.StatusOK, models.NewErrorResponse(i18n.T(c, "middleware.superAdminOnly")))
 			c.Abort()
 			return
 		}

--- a/internal/app/handlers/preferences.go
+++ b/internal/app/handlers/preferences.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/jwma/jump-jump/internal/app/db"
+	"github.com/jwma/jump-jump/internal/app/i18n"
 	"github.com/jwma/jump-jump/internal/app/models"
 	"github.com/jwma/jump-jump/internal/app/repository"
 )
@@ -52,7 +53,7 @@ func UpdateUserPreferencesAPI() gin.HandlerFunc {
 	return Authenticator(func(c *gin.Context, ctx *AuthContext) {
 		req := &updatePreferencesRequest{}
 		if err := c.ShouldBindJSON(req); err != nil {
-			c.JSON(http.StatusOK, models.NewErrorResponse("参数错误"))
+			c.JSON(http.StatusOK, models.NewErrorResponse(i18n.T(c, "common.invalidParameters")))
 			return
 		}
 

--- a/internal/app/handlers/shortlink.go
+++ b/internal/app/handlers/shortlink.go
@@ -1,7 +1,6 @@
 package handlers
 
 import (
-	"fmt"
 	"log"
 	"net/http"
 	"time"
@@ -9,6 +8,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/jwma/jump-jump/internal/app/config"
 	"github.com/jwma/jump-jump/internal/app/db"
+	"github.com/jwma/jump-jump/internal/app/i18n"
 	"github.com/jwma/jump-jump/internal/app/models"
 	"github.com/jwma/jump-jump/internal/app/repository"
 	"github.com/jwma/jump-jump/internal/app/utils"
@@ -64,7 +64,7 @@ func toShortLinkDataWithUsername(s *models.ShortLink) *models.ShortLinkData {
 // checkTenantOwnership verifies that a short link belongs to the current tenant.
 func checkTenantOwnership(c *gin.Context, s *models.ShortLink) bool {
 	if s.TenantID != getTenantID(c) {
-		c.JSON(http.StatusNotFound, models.NewErrorResponse("短链接不存在"))
+		c.JSON(http.StatusNotFound, models.NewErrorResponse(i18n.T(c, "shortLink.notFound")))
 		return false
 	}
 	return true
@@ -115,7 +115,7 @@ func CreateShortLinkAPI() gin.HandlerFunc {
 	return Authenticator(func(c *gin.Context, ctx *AuthContext) {
 		params := &models.CreateShortLinkAPIRequest{}
 		if err := c.ShouldBindJSON(&params); err != nil {
-			c.JSON(http.StatusOK, models.NewErrorResponse("参数错误"))
+			c.JSON(http.StatusOK, models.NewErrorResponse(i18n.T(c, "common.invalidParameters")))
 			return
 		}
 
@@ -128,7 +128,7 @@ func CreateShortLinkAPI() gin.HandlerFunc {
 		if s.Id != "" {
 			checkShortLink, _ := repo.Get(s.Id)
 			if checkShortLink != nil && checkShortLink.Id != "" {
-				c.JSON(http.StatusOK, models.NewErrorResponse(fmt.Sprintf("%s 已被占用", s.Id)))
+				c.JSON(http.StatusOK, models.NewErrorResponse(i18n.TWithData(c, "shortLink.idOccupied", map[string]interface{}{"id": s.Id})))
 				return
 			}
 		} else {
@@ -138,14 +138,14 @@ func CreateShortLinkAPI() gin.HandlerFunc {
 			id, err := repo.GenerateId(idLen)
 			if err != nil {
 				log.Printf("generate id failed: %v", err)
-				c.JSON(http.StatusOK, models.NewErrorResponse("服务器繁忙，请稍后再试"))
+				c.JSON(http.StatusOK, models.NewErrorResponse(i18n.T(c, "common.serverBusy")))
 				return
 			}
 			s.Id = utils.TrimShortLinkId(id)
 		}
 
 		if s.Id == "" {
-			c.JSON(http.StatusOK, models.NewErrorResponse("ID 错误"))
+			c.JSON(http.StatusOK, models.NewErrorResponse(i18n.T(c, "shortLink.invalidId")))
 			return
 		}
 
@@ -293,14 +293,14 @@ func ShortLinkActionAPI() gin.HandlerFunc {
 			startDate := c.Query("startDate")
 			endDate := c.Query("endDate")
 			if startDate == "" || endDate == "" {
-				c.JSON(http.StatusOK, models.NewErrorResponse("参数错误"))
+				c.JSON(http.StatusOK, models.NewErrorResponse(i18n.T(c, "common.invalidParameters")))
 				return
 			}
 
 			startTime, _ := time.ParseInLocation("2006-01-02", startDate, time.Local)
 			endTime, err := time.ParseInLocation("2006-01-02", endDate, time.Local)
 			if err != nil {
-				c.JSON(http.StatusOK, models.NewErrorResponse("日期参数错误"))
+				c.JSON(http.StatusOK, models.NewErrorResponse(i18n.T(c, "shortLink.invalidDateParams")))
 				return
 			}
 
@@ -322,6 +322,6 @@ func ShortLinkActionAPI() gin.HandlerFunc {
 			return
 		}
 
-		c.JSON(http.StatusNotFound, models.NewErrorResponse("请求资源不存在"))
+		c.JSON(http.StatusNotFound, models.NewErrorResponse(i18n.T(c, "common.resourceNotFound")))
 	})
 }

--- a/internal/app/handlers/super_admin.go
+++ b/internal/app/handlers/super_admin.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/jwma/jump-jump/internal/app/db"
+	"github.com/jwma/jump-jump/internal/app/i18n"
 	"github.com/jwma/jump-jump/internal/app/models"
 	"github.com/jwma/jump-jump/internal/app/repository"
 )
@@ -25,7 +26,7 @@ import (
 func CreateUserAPI(c *gin.Context) {
 	req := &models.CreateUserRequest{}
 	if err := c.ShouldBindJSON(req); err != nil {
-		c.JSON(http.StatusOK, models.NewErrorResponse("请填写用户名和密码"))
+		c.JSON(http.StatusOK, models.NewErrorResponse(i18n.T(c, "superAdmin.usernamePasswordRequired")))
 		return
 	}
 
@@ -125,7 +126,7 @@ func ResetPasswordAPI(c *gin.Context) {
 	id := c.Param("id")
 	req := &models.ResetPasswordRequest{}
 	if err := c.ShouldBindJSON(req); err != nil {
-		c.JSON(http.StatusOK, models.NewErrorResponse("请填写新密码"))
+		c.JSON(http.StatusOK, models.NewErrorResponse(i18n.T(c, "superAdmin.newPasswordRequired")))
 		return
 	}
 
@@ -154,7 +155,7 @@ func UpdateUserStatusAPI(c *gin.Context) {
 	id := c.Param("id")
 	req := &models.UpdateUserStatusRequest{}
 	if err := c.ShouldBindJSON(req); err != nil {
-		c.JSON(http.StatusOK, models.NewErrorResponse("请指定用户状态"))
+		c.JSON(http.StatusOK, models.NewErrorResponse(i18n.T(c, "superAdmin.userStatusRequired")))
 		return
 	}
 
@@ -214,7 +215,7 @@ func UpdateTenantStatusAPI(c *gin.Context) {
 	id := c.Param("id")
 	req := &models.UpdateTenantStatusRequest{}
 	if err := c.ShouldBindJSON(req); err != nil {
-		c.JSON(http.StatusOK, models.NewErrorResponse("请指定租户状态"))
+		c.JSON(http.StatusOK, models.NewErrorResponse(i18n.T(c, "superAdmin.tenantStatusRequired")))
 		return
 	}
 
@@ -282,7 +283,7 @@ func SuperListTenantMembersAPI(c *gin.Context) {
 	memberRepo := repository.GetTenantMemberRepo(db.GetPostgresPool())
 	members, err := memberRepo.ListByTenant(tenantID)
 	if err != nil {
-		c.JSON(http.StatusOK, models.NewErrorResponse("查询成员列表失败"))
+		c.JSON(http.StatusOK, models.NewErrorResponse(i18n.T(c, "tenant.memberListFailed")))
 		return
 	}
 

--- a/internal/app/handlers/tenant.go
+++ b/internal/app/handlers/tenant.go
@@ -6,6 +6,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/jwma/jump-jump/internal/app/config"
 	"github.com/jwma/jump-jump/internal/app/db"
+	"github.com/jwma/jump-jump/internal/app/i18n"
 	"github.com/jwma/jump-jump/internal/app/models"
 	"github.com/jwma/jump-jump/internal/app/repository"
 )
@@ -25,7 +26,7 @@ func CreateTenantAPI() gin.HandlerFunc {
 	return Authenticator(func(c *gin.Context, ctx *AuthContext) {
 		p := &models.CreateTenantRequest{}
 		if err := c.ShouldBindJSON(p); err != nil {
-			c.JSON(http.StatusOK, models.NewErrorResponse("参数错误"))
+			c.JSON(http.StatusOK, models.NewErrorResponse(i18n.T(c, "common.invalidParameters")))
 			return
 		}
 
@@ -42,7 +43,7 @@ func CreateTenantAPI() gin.HandlerFunc {
 			UserID:   ctx.User.ID,
 			Role:     models.RoleAdmin,
 		}); err != nil {
-			c.JSON(http.StatusOK, models.NewErrorResponse("创建租户成员关系失败"))
+			c.JSON(http.StatusOK, models.NewErrorResponse(i18n.T(c, "tenant.memberCreationFailed")))
 			return
 		}
 
@@ -65,7 +66,7 @@ func GetTenantAPI() gin.HandlerFunc {
 	return Authenticator(func(c *gin.Context, ctx *AuthContext) {
 		tenantID := c.Param("id")
 		if getMemberOrNil(ctx.User, tenantID) == nil {
-			c.JSON(http.StatusOK, models.NewErrorResponse("你无权查看此租户"))
+			c.JSON(http.StatusOK, models.NewErrorResponse(i18n.T(c, "tenant.noViewPermission")))
 			return
 		}
 
@@ -120,13 +121,13 @@ func UpdateTenantAPI() gin.HandlerFunc {
 		tenantID := c.Param("id")
 		member, err := isTenantAdmin(ctx.User, tenantID)
 		if err != nil || !member.IsAdmin() {
-			c.JSON(http.StatusOK, models.NewErrorResponse("仅管理员可修改租户信息"))
+			c.JSON(http.StatusOK, models.NewErrorResponse(i18n.T(c, "tenant.adminOnly")))
 			return
 		}
 
 		p := &models.UpdateTenantRequest{}
 		if err := c.ShouldBindJSON(p); err != nil {
-			c.JSON(http.StatusOK, models.NewErrorResponse("参数错误"))
+			c.JSON(http.StatusOK, models.NewErrorResponse(i18n.T(c, "common.invalidParameters")))
 			return
 		}
 
@@ -158,13 +159,13 @@ func AddDomainAPI() gin.HandlerFunc {
 		tenantID := c.Param("id")
 		member, err := isTenantAdmin(ctx.User, tenantID)
 		if err != nil || !member.IsAdmin() {
-			c.JSON(http.StatusOK, models.NewErrorResponse("你无权管理域名"))
+			c.JSON(http.StatusOK, models.NewErrorResponse(i18n.T(c, "tenant.noDomainPermission")))
 			return
 		}
 
 		p := &models.AddDomainRequest{}
 		if err := c.ShouldBindJSON(p); err != nil {
-			c.JSON(http.StatusOK, models.NewErrorResponse("参数错误"))
+			c.JSON(http.StatusOK, models.NewErrorResponse(i18n.T(c, "common.invalidParameters")))
 			return
 		}
 
@@ -196,13 +197,13 @@ func RemoveDomainAPI() gin.HandlerFunc {
 		tenantID := c.Param("id")
 		member, err := isTenantAdmin(ctx.User, tenantID)
 		if err != nil || !member.IsAdmin() {
-			c.JSON(http.StatusOK, models.NewErrorResponse("你无权管理域名"))
+			c.JSON(http.StatusOK, models.NewErrorResponse(i18n.T(c, "tenant.noDomainPermission")))
 			return
 		}
 
 		domain := c.Param("domain")
 		if domain == "" {
-			c.JSON(http.StatusOK, models.NewErrorResponse("domain 参数不能为空"))
+			c.JSON(http.StatusOK, models.NewErrorResponse(i18n.T(c, "tenant.domainParamRequired")))
 			return
 		}
 
@@ -232,7 +233,7 @@ func ListDomainsAPI() gin.HandlerFunc {
 	return Authenticator(func(c *gin.Context, ctx *AuthContext) {
 		tenantID := c.Param("id")
 		if getMemberOrNil(ctx.User, tenantID) == nil {
-			c.JSON(http.StatusOK, models.NewErrorResponse("你无权查看此租户域名"))
+			c.JSON(http.StatusOK, models.NewErrorResponse(i18n.T(c, "tenant.noDomainViewPermission")))
 			return
 		}
 
@@ -262,7 +263,7 @@ func GetTenantConfigAPI() gin.HandlerFunc {
 	return Authenticator(func(c *gin.Context, ctx *AuthContext) {
 		tenantID := c.Param("id")
 		if getMemberOrNil(ctx.User, tenantID) == nil {
-			c.JSON(http.StatusOK, models.NewErrorResponse("你无权查看此租户配置"))
+			c.JSON(http.StatusOK, models.NewErrorResponse(i18n.T(c, "tenant.noConfigViewPermission")))
 			return
 		}
 
@@ -289,13 +290,13 @@ func UpdateTenantConfigAPI() gin.HandlerFunc {
 		tenantID := c.Param("id")
 		member, err := isTenantAdmin(ctx.User, tenantID)
 		if err != nil || !member.IsAdmin() {
-			c.JSON(http.StatusOK, models.NewErrorResponse("你无权修改此租户配置"))
+			c.JSON(http.StatusOK, models.NewErrorResponse(i18n.T(c, "tenant.noConfigUpdatePermission")))
 			return
 		}
 
 		p := &models.UpdateTenantConfigRequest{}
 		if err := c.ShouldBindJSON(p); err != nil {
-			c.JSON(http.StatusOK, models.NewErrorResponse("参数错误"))
+			c.JSON(http.StatusOK, models.NewErrorResponse(i18n.T(c, "common.invalidParameters")))
 			return
 		}
 
@@ -308,7 +309,7 @@ func UpdateTenantConfigAPI() gin.HandlerFunc {
 					IdMaximumLength: *p.IdMaximumLength,
 				})
 			} else {
-				c.JSON(http.StatusOK, models.NewErrorResponse("最小长度 <= 默认长度 <= 最大长度，三个值均大于 0"))
+				c.JSON(http.StatusOK, models.NewErrorResponse(i18n.T(c, "tenant.invalidIdLengthConfig")))
 				return
 			}
 		}
@@ -321,7 +322,7 @@ func UpdateTenantConfigAPI() gin.HandlerFunc {
 					Value: *p.NotFoundValue,
 				})
 			} else {
-				c.JSON(http.StatusOK, models.NewErrorResponse("处理模式参数不正确"))
+				c.JSON(http.StatusOK, models.NewErrorResponse(i18n.T(c, "tenant.invalidNotFoundMode")))
 				return
 			}
 		}

--- a/internal/app/handlers/tenant_member.go
+++ b/internal/app/handlers/tenant_member.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/jwma/jump-jump/internal/app/db"
+	"github.com/jwma/jump-jump/internal/app/i18n"
 	"github.com/jwma/jump-jump/internal/app/models"
 	"github.com/jwma/jump-jump/internal/app/repository"
 )
@@ -47,14 +48,14 @@ func ListTenantMembersAPI() gin.HandlerFunc {
 		tenantID := c.Param("id")
 		member := getMemberOrNil(ctx.User, tenantID)
 		if member == nil {
-			c.JSON(http.StatusOK, models.NewErrorResponse("你不是该租户的成员"))
+			c.JSON(http.StatusOK, models.NewErrorResponse(i18n.T(c, "tenant.notMember")))
 			return
 		}
 
 		memberRepo := repository.GetTenantMemberRepo(db.GetPostgresPool())
 		members, err := memberRepo.ListByTenant(tenantID)
 		if err != nil {
-			c.JSON(http.StatusOK, models.NewErrorResponse("查询成员列表失败"))
+			c.JSON(http.StatusOK, models.NewErrorResponse(i18n.T(c, "tenant.memberListFailed")))
 			return
 		}
 
@@ -94,13 +95,13 @@ func InviteUserAPI() gin.HandlerFunc {
 		tenantID := c.Param("id")
 		member, err := isTenantAdmin(ctx.User, tenantID)
 		if err != nil || !member.IsAdmin() {
-			c.JSON(http.StatusOK, models.NewErrorResponse("仅租户管理员可邀请用户"))
+			c.JSON(http.StatusOK, models.NewErrorResponse(i18n.T(c, "member.adminOnlyInvite")))
 			return
 		}
 
 		req := &models.InviteUserRequest{}
 		if err := c.ShouldBindJSON(req); err != nil {
-			c.JSON(http.StatusOK, models.NewErrorResponse("参数错误"))
+			c.JSON(http.StatusOK, models.NewErrorResponse(i18n.T(c, "common.invalidParameters")))
 			return
 		}
 
@@ -114,19 +115,19 @@ func InviteUserAPI() gin.HandlerFunc {
 		memberRepo := repository.GetTenantMemberRepo(db.GetPostgresPool())
 		isMember, _ := memberRepo.IsMember(tenantID, invitee.ID)
 		if isMember {
-			c.JSON(http.StatusOK, models.NewErrorResponse("该用户已是租户成员"))
+			c.JSON(http.StatusOK, models.NewErrorResponse(i18n.T(c, "member.alreadyMember")))
 			return
 		}
 
 		if invitee.ID == ctx.User.ID {
-			c.JSON(http.StatusOK, models.NewErrorResponse("不能邀请自己"))
+			c.JSON(http.StatusOK, models.NewErrorResponse(i18n.T(c, "member.cannotInviteSelf")))
 			return
 		}
 
 		invRepo := repository.GetTenantInvitationRepo(db.GetPostgresPool())
 		hasPending, _ := invRepo.HasPendingInvitation(tenantID, invitee.ID)
 		if hasPending {
-			c.JSON(http.StatusOK, models.NewErrorResponse("该用户已有待处理的邀请"))
+			c.JSON(http.StatusOK, models.NewErrorResponse(i18n.T(c, "member.pendingInvitationExists")))
 			return
 		}
 
@@ -136,7 +137,7 @@ func InviteUserAPI() gin.HandlerFunc {
 			InviteeID: invitee.ID,
 		}
 		if err := invRepo.Create(inv); err != nil {
-			c.JSON(http.StatusOK, models.NewErrorResponse("创建邀请失败: "+err.Error()))
+			c.JSON(http.StatusOK, models.NewErrorResponse(i18n.T(c, "member.invitationCreationFailed")))
 			return
 		}
 
@@ -159,7 +160,7 @@ func ListMyInvitationsAPI() gin.HandlerFunc {
 		invRepo := repository.GetTenantInvitationRepo(db.GetPostgresPool())
 		invs, err := invRepo.FindPendingByInvitee(ctx.User.ID)
 		if err != nil {
-			c.JSON(http.StatusOK, models.NewErrorResponse("查询邀请列表失败"))
+			c.JSON(http.StatusOK, models.NewErrorResponse(i18n.T(c, "member.invitationListFailed")))
 			return
 		}
 
@@ -212,12 +213,12 @@ func AcceptInvitationAPI() gin.HandlerFunc {
 		}
 
 		if inv.InviteeID != ctx.User.ID {
-			c.JSON(http.StatusOK, models.NewErrorResponse("无权操作此邀请"))
+			c.JSON(http.StatusOK, models.NewErrorResponse(i18n.T(c, "invitation.noPermission")))
 			return
 		}
 
 		if inv.Status != models.InvitationStatusPending {
-			c.JSON(http.StatusOK, models.NewErrorResponse("邀请已处理"))
+			c.JSON(http.StatusOK, models.NewErrorResponse(i18n.T(c, "invitation.alreadyProcessed")))
 			return
 		}
 
@@ -227,12 +228,12 @@ func AcceptInvitationAPI() gin.HandlerFunc {
 			UserID:   ctx.User.ID,
 			Role:     models.RoleMember,
 		}); err != nil {
-			c.JSON(http.StatusOK, models.NewErrorResponse("加入租户失败"))
+			c.JSON(http.StatusOK, models.NewErrorResponse(i18n.T(c, "invitation.joinFailed")))
 			return
 		}
 
 		if err := invRepo.UpdateStatus(inv.ID, models.InvitationStatusAccepted); err != nil {
-			c.JSON(http.StatusOK, models.NewErrorResponse("操作失败"))
+			c.JSON(http.StatusOK, models.NewErrorResponse(i18n.T(c, "common.operationFailed")))
 			return
 		}
 
@@ -263,17 +264,17 @@ func RejectInvitationAPI() gin.HandlerFunc {
 		}
 
 		if inv.InviteeID != ctx.User.ID {
-			c.JSON(http.StatusOK, models.NewErrorResponse("无权操作此邀请"))
+			c.JSON(http.StatusOK, models.NewErrorResponse(i18n.T(c, "invitation.noPermission")))
 			return
 		}
 
 		if inv.Status != models.InvitationStatusPending {
-			c.JSON(http.StatusOK, models.NewErrorResponse("邀请已处理"))
+			c.JSON(http.StatusOK, models.NewErrorResponse(i18n.T(c, "invitation.alreadyProcessed")))
 			return
 		}
 
 		if err := invRepo.UpdateStatus(inv.ID, models.InvitationStatusRejected); err != nil {
-			c.JSON(http.StatusOK, models.NewErrorResponse("操作失败"))
+			c.JSON(http.StatusOK, models.NewErrorResponse(i18n.T(c, "common.operationFailed")))
 			return
 		}
 
@@ -301,35 +302,35 @@ func UpdateMemberRoleAPI() gin.HandlerFunc {
 
 		member, err := isTenantAdmin(ctx.User, tenantID)
 		if err != nil || !member.IsAdmin() {
-			c.JSON(http.StatusOK, models.NewErrorResponse("仅租户管理员可修改角色"))
+			c.JSON(http.StatusOK, models.NewErrorResponse(i18n.T(c, "member.adminOnlyChangeRole")))
 			return
 		}
 
 		if targetUserID == ctx.User.ID {
-			c.JSON(http.StatusOK, models.NewErrorResponse("不能修改自己的角色"))
+			c.JSON(http.StatusOK, models.NewErrorResponse(i18n.T(c, "member.cannotChangeOwnRole")))
 			return
 		}
 
 		req := &models.UpdateRoleRequest{}
 		if err := c.ShouldBindJSON(req); err != nil {
-			c.JSON(http.StatusOK, models.NewErrorResponse("参数错误"))
+			c.JSON(http.StatusOK, models.NewErrorResponse(i18n.T(c, "common.invalidParameters")))
 			return
 		}
 
 		if req.Role != models.RoleAdmin && req.Role != models.RoleMember {
-			c.JSON(http.StatusOK, models.NewErrorResponse("角色必须为 admin 或 member"))
+			c.JSON(http.StatusOK, models.NewErrorResponse(i18n.T(c, "member.invalidRole")))
 			return
 		}
 
 		memberRepo := repository.GetTenantMemberRepo(db.GetPostgresPool())
 		isMember, _ := memberRepo.IsMember(tenantID, targetUserID)
 		if !isMember {
-			c.JSON(http.StatusOK, models.NewErrorResponse("该用户不是租户成员"))
+			c.JSON(http.StatusOK, models.NewErrorResponse(i18n.T(c, "member.userNotMember")))
 			return
 		}
 
 		if err := memberRepo.UpdateRole(tenantID, targetUserID, req.Role); err != nil {
-			c.JSON(http.StatusOK, models.NewErrorResponse("修改角色失败"))
+			c.JSON(http.StatusOK, models.NewErrorResponse(i18n.T(c, "member.roleChangeFailed")))
 			return
 		}
 
@@ -356,24 +357,24 @@ func RemoveMemberAPI() gin.HandlerFunc {
 
 		member, err := isTenantAdmin(ctx.User, tenantID)
 		if err != nil || !member.IsAdmin() {
-			c.JSON(http.StatusOK, models.NewErrorResponse("仅租户管理员可移除成员"))
+			c.JSON(http.StatusOK, models.NewErrorResponse(i18n.T(c, "member.adminOnlyRemove")))
 			return
 		}
 
 		if targetUserID == ctx.User.ID {
-			c.JSON(http.StatusOK, models.NewErrorResponse("不能移除自己，如需离开请使用退出租户功能"))
+			c.JSON(http.StatusOK, models.NewErrorResponse(i18n.T(c, "member.cannotRemoveSelf")))
 			return
 		}
 
 		memberRepo := repository.GetTenantMemberRepo(db.GetPostgresPool())
 		isMember, _ := memberRepo.IsMember(tenantID, targetUserID)
 		if !isMember {
-			c.JSON(http.StatusOK, models.NewErrorResponse("该用户不是租户成员"))
+			c.JSON(http.StatusOK, models.NewErrorResponse(i18n.T(c, "member.userNotMember")))
 			return
 		}
 
 		if err := memberRepo.Delete(tenantID, targetUserID); err != nil {
-			c.JSON(http.StatusOK, models.NewErrorResponse("移除成员失败"))
+			c.JSON(http.StatusOK, models.NewErrorResponse(i18n.T(c, "member.removeFailed")))
 			return
 		}
 
@@ -397,13 +398,13 @@ func LeaveTenantAPI() gin.HandlerFunc {
 		tenantID := c.Param("id")
 		member := getMemberOrNil(ctx.User, tenantID)
 		if member == nil {
-			c.JSON(http.StatusOK, models.NewErrorResponse("你不是该租户的成员"))
+			c.JSON(http.StatusOK, models.NewErrorResponse(i18n.T(c, "tenant.notMember")))
 			return
 		}
 
 		memberRepo := repository.GetTenantMemberRepo(db.GetPostgresPool())
 		if err := memberRepo.Delete(tenantID, ctx.User.ID); err != nil {
-			c.JSON(http.StatusOK, models.NewErrorResponse("退出租户失败"))
+			c.JSON(http.StatusOK, models.NewErrorResponse(i18n.T(c, "member.leaveFailed")))
 			return
 		}
 

--- a/internal/app/handlers/user.go
+++ b/internal/app/handlers/user.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/jwma/jump-jump/internal/app/db"
+	"github.com/jwma/jump-jump/internal/app/i18n"
 	"github.com/jwma/jump-jump/internal/app/models"
 	"github.com/jwma/jump-jump/internal/app/repository"
 	"github.com/jwma/jump-jump/internal/app/utils"
@@ -23,25 +24,25 @@ import (
 func LoginAPI(c *gin.Context) {
 	f := &models.LoginAPIRequest{}
 	if err := c.BindJSON(f); err != nil {
-		c.JSON(http.StatusOK, models.NewErrorResponse("用户名或密码错误"))
+		c.JSON(http.StatusOK, models.NewErrorResponse(i18n.T(c, "auth.invalidCredentials")))
 		return
 	}
 
 	userRepo := repository.GetUserRepo(db.GetPostgresPool())
 	u, err := userRepo.FindByUsername(strings.TrimSpace(f.Username))
 	if err != nil {
-		c.JSON(http.StatusOK, models.NewErrorResponse("用户名或密码错误"))
+		c.JSON(http.StatusOK, models.NewErrorResponse(i18n.T(c, "auth.invalidCredentials")))
 		return
 	}
 
 	dk, _ := utils.EncodePassword([]byte(f.Password), u.Salt)
 	if string(u.Password) != string(dk) {
-		c.JSON(http.StatusOK, models.NewErrorResponse("用户名或密码错误"))
+		c.JSON(http.StatusOK, models.NewErrorResponse(i18n.T(c, "auth.invalidCredentials")))
 		return
 	}
 
 	if !u.IsActive {
-		c.JSON(http.StatusOK, models.NewErrorResponse("账号已被禁用"))
+		c.JSON(http.StatusOK, models.NewErrorResponse(i18n.T(c, "auth.accountDisabled")))
 		return
 	}
 
@@ -138,13 +139,13 @@ func ChangePasswordAPI() gin.HandlerFunc {
 	return Authenticator(func(c *gin.Context, ctx *AuthContext) {
 		p := &models.ChangePasswordAPIRequest{}
 		if err := c.ShouldBindJSON(p); err != nil {
-			c.JSON(http.StatusOK, models.NewErrorResponse("请填写原密码和新密码"))
+			c.JSON(http.StatusOK, models.NewErrorResponse(i18n.T(c, "auth.passwordRequired")))
 			return
 		}
 
 		dk, _ := utils.EncodePassword([]byte(p.Password), ctx.User.Salt)
 		if string(ctx.User.Password) != string(dk) {
-			c.JSON(http.StatusOK, models.NewErrorResponse("原密码错误"))
+			c.JSON(http.StatusOK, models.NewErrorResponse(i18n.T(c, "auth.wrongPassword")))
 			return
 		}
 

--- a/internal/app/i18n/i18n.go
+++ b/internal/app/i18n/i18n.go
@@ -1,0 +1,103 @@
+package i18n
+
+import (
+	"embed"
+	"errors"
+	"fmt"
+
+	"github.com/gin-gonic/gin"
+	"github.com/jwma/jump-jump/internal/app/models"
+	"github.com/nicksnyder/go-i18n/v2/i18n"
+	"github.com/pelletier/go-toml/v2"
+	"golang.org/x/text/language"
+)
+
+//go:embed locales/*.toml
+var localeFS embed.FS
+
+var bundle *i18n.Bundle
+
+func Init() error {
+	bundle = i18n.NewBundle(language.English)
+	bundle.RegisterUnmarshalFunc("toml", toml.Unmarshal)
+
+	for _, file := range []string{
+		"locales/active.en.toml",
+		"locales/active.zh.toml",
+	} {
+		buf, err := localeFS.ReadFile(file)
+		if err != nil {
+			return fmt.Errorf("reading locale %s: %w", file, err)
+		}
+		if _, err := bundle.ParseMessageFileBytes(buf, file); err != nil {
+			return fmt.Errorf("parsing locale %s: %w", file, err)
+		}
+	}
+	return nil
+}
+
+// T translates a message key using the locale from gin.Context.
+func T(c *gin.Context, key string) string {
+	return localize(c, key, nil)
+}
+
+// TWithData translates a message key with template data.
+func TWithData(c *gin.Context, key string, data map[string]interface{}) string {
+	return localize(c, key, data)
+}
+
+func localize(c *gin.Context, key string, data map[string]interface{}) string {
+	lang := "en"
+	if l, exists := c.Get("locale"); exists {
+		if s, ok := l.(string); ok {
+			lang = s
+		}
+	}
+	localizer := i18n.NewLocalizer(bundle, lang)
+	cfg := &i18n.LocalizeConfig{MessageID: key}
+	if data != nil {
+		cfg.TemplateData = data
+	}
+	msg, err := localizer.Localize(cfg)
+	if err != nil {
+		return key
+	}
+	return msg
+}
+
+// Error is a translatable error that carries an i18n key.
+type Error struct {
+	Key  string
+	Data map[string]interface{}
+}
+
+func (e *Error) Error() string {
+	return e.Key
+}
+
+// NewError creates a translatable error with the given i18n key.
+func NewError(key string) *Error {
+	return &Error{Key: key}
+}
+
+// TranslateError translates an error for user-facing display.
+func TranslateError(c *gin.Context, err error) string {
+	var te *Error
+	if errors.As(err, &te) {
+		if te.Data != nil {
+			return TWithData(c, te.Key, te.Data)
+		}
+		return T(c, te.Key)
+	}
+
+	var nf *models.NotFoundError
+	if errors.As(err, &nf) {
+		translated := T(c, nf.Msg)
+		if translated != nf.Msg {
+			return translated
+		}
+		return nf.Msg
+	}
+
+	return err.Error()
+}

--- a/internal/app/i18n/i18n.go
+++ b/internal/app/i18n/i18n.go
@@ -65,24 +65,9 @@ func localize(c *gin.Context, key string, data map[string]interface{}) string {
 	return msg
 }
 
-// Error is a translatable error that carries an i18n key.
-type Error struct {
-	Key  string
-	Data map[string]interface{}
-}
-
-func (e *Error) Error() string {
-	return e.Key
-}
-
-// NewError creates a translatable error with the given i18n key.
-func NewError(key string) *Error {
-	return &Error{Key: key}
-}
-
 // TranslateError translates an error for user-facing display.
 func TranslateError(c *gin.Context, err error) string {
-	var te *Error
+	var te *models.TranslatableError
 	if errors.As(err, &te) {
 		if te.Data != nil {
 			return TWithData(c, te.Key, te.Data)

--- a/internal/app/i18n/locales/active.en.toml
+++ b/internal/app/i18n/locales/active.en.toml
@@ -1,0 +1,174 @@
+# Common
+[common.invalidParameters]
+one = "Invalid parameters"
+
+[common.operationFailed]
+one = "Operation failed"
+
+[common.serverBusy]
+one = "Server is busy, please try again later"
+
+[common.notFound]
+one = "Not found"
+
+[common.resourceNotFound]
+one = "Requested resource does not exist"
+
+# Auth
+[auth.invalidCredentials]
+one = "Incorrect username or password"
+
+[auth.accountDisabled]
+one = "Account has been disabled"
+
+[auth.passwordRequired]
+one = "Please enter current and new password"
+
+[auth.wrongPassword]
+one = "Current password is incorrect"
+
+# User
+[user.notFound]
+one = "User not found"
+
+# Tenant
+[tenant.notFound]
+one = "Tenant not found"
+
+[tenant.memberCreationFailed]
+one = "Failed to create tenant membership"
+
+[tenant.noViewPermission]
+one = "You do not have permission to view this tenant"
+
+[tenant.adminOnly]
+one = "Only admins can modify tenant information"
+
+[tenant.noDomainPermission]
+one = "You do not have permission to manage domains"
+
+[tenant.domainParamRequired]
+one = "Domain parameter is required"
+
+[tenant.noDomainViewPermission]
+one = "You do not have permission to view this tenant's domains"
+
+[tenant.noConfigViewPermission]
+one = "You do not have permission to view this tenant's config"
+
+[tenant.noConfigUpdatePermission]
+one = "You do not have permission to modify this tenant's config"
+
+[tenant.invalidIdLengthConfig]
+one = "min length <= default length <= max length, all values must be greater than 0"
+
+[tenant.invalidNotFoundMode]
+one = "Invalid not-found mode"
+
+[tenant.notMember]
+one = "You are not a member of this tenant"
+
+[tenant.memberListFailed]
+one = "Failed to query member list"
+
+# Member
+[member.relationNotFound]
+one = "Membership relation not found"
+
+[member.notFound]
+one = "Member not found"
+
+[member.adminOnlyInvite]
+one = "Only tenant admins can invite users"
+
+[member.alreadyMember]
+one = "User is already a tenant member"
+
+[member.cannotInviteSelf]
+one = "You cannot invite yourself"
+
+[member.pendingInvitationExists]
+one = "This user already has a pending invitation"
+
+[member.invitationCreationFailed]
+one = "Failed to create invitation"
+
+[member.invitationListFailed]
+one = "Failed to query invitation list"
+
+[member.adminOnlyChangeRole]
+one = "Only tenant admins can change roles"
+
+[member.cannotChangeOwnRole]
+one = "You cannot change your own role"
+
+[member.invalidRole]
+one = "Role must be admin or member"
+
+[member.userNotMember]
+one = "User is not a tenant member"
+
+[member.roleChangeFailed]
+one = "Failed to change role"
+
+[member.adminOnlyRemove]
+one = "Only tenant admins can remove members"
+
+[member.cannotRemoveSelf]
+one = "You cannot remove yourself, use the leave tenant feature instead"
+
+[member.removeFailed]
+one = "Failed to remove member"
+
+[member.leaveFailed]
+one = "Failed to leave tenant"
+
+# Invitation
+[invitation.notFound]
+one = "Invitation not found"
+
+[invitation.noPermission]
+one = "You do not have permission to act on this invitation"
+
+[invitation.alreadyProcessed]
+one = "Invitation has already been processed"
+
+[invitation.joinFailed]
+one = "Failed to join tenant"
+
+# Short Link
+[shortLink.notFound]
+one = "Short link not found"
+
+[shortLink.idOccupied]
+one = "{{.id}} is already taken"
+
+[shortLink.invalidId]
+one = "Invalid ID"
+
+[shortLink.invalidDateParams]
+one = "Invalid date parameters"
+
+# Super Admin
+[superAdmin.usernamePasswordRequired]
+one = "Please enter username and password"
+
+[superAdmin.newPasswordRequired]
+one = "Please enter a new password"
+
+[superAdmin.userStatusRequired]
+one = "Please specify user status"
+
+[superAdmin.tenantStatusRequired]
+one = "Please specify tenant status"
+
+# Middleware
+[middleware.tenantIdRequired]
+one = "X-Tenant-ID header is required"
+
+[middleware.superAdminOnly]
+one = "Only super admins can perform this operation"
+
+# Landing
+[landing.pageNotFound]
+one = "The page you visited does not exist"

--- a/internal/app/i18n/locales/active.zh.toml
+++ b/internal/app/i18n/locales/active.zh.toml
@@ -1,0 +1,174 @@
+# Common
+[common.invalidParameters]
+one = "参数错误"
+
+[common.operationFailed]
+one = "操作失败"
+
+[common.serverBusy]
+one = "服务器繁忙，请稍后再试"
+
+[common.notFound]
+one = "未找到"
+
+[common.resourceNotFound]
+one = "请求资源不存在"
+
+# Auth
+[auth.invalidCredentials]
+one = "用户名或密码错误"
+
+[auth.accountDisabled]
+one = "账号已被禁用"
+
+[auth.passwordRequired]
+one = "请填写原密码和新密码"
+
+[auth.wrongPassword]
+one = "原密码错误"
+
+# User
+[user.notFound]
+one = "用户不存在"
+
+# Tenant
+[tenant.notFound]
+one = "租户不存在"
+
+[tenant.memberCreationFailed]
+one = "创建租户成员关系失败"
+
+[tenant.noViewPermission]
+one = "你无权查看此租户"
+
+[tenant.adminOnly]
+one = "仅管理员可修改租户信息"
+
+[tenant.noDomainPermission]
+one = "你无权管理域名"
+
+[tenant.domainParamRequired]
+one = "domain 参数不能为空"
+
+[tenant.noDomainViewPermission]
+one = "你无权查看此租户域名"
+
+[tenant.noConfigViewPermission]
+one = "你无权查看此租户配置"
+
+[tenant.noConfigUpdatePermission]
+one = "你无权修改此租户配置"
+
+[tenant.invalidIdLengthConfig]
+one = "最小长度 <= 默认长度 <= 最大长度，三个值均大于 0"
+
+[tenant.invalidNotFoundMode]
+one = "处理模式参数不正确"
+
+[tenant.notMember]
+one = "你不是该租户的成员"
+
+[tenant.memberListFailed]
+one = "查询成员列表失败"
+
+# Member
+[member.relationNotFound]
+one = "成员关系不存在"
+
+[member.notFound]
+one = "成员不存在"
+
+[member.adminOnlyInvite]
+one = "仅租户管理员可邀请用户"
+
+[member.alreadyMember]
+one = "该用户已是租户成员"
+
+[member.cannotInviteSelf]
+one = "不能邀请自己"
+
+[member.pendingInvitationExists]
+one = "该用户已有待处理的邀请"
+
+[member.invitationCreationFailed]
+one = "创建邀请失败"
+
+[member.invitationListFailed]
+one = "查询邀请列表失败"
+
+[member.adminOnlyChangeRole]
+one = "仅租户管理员可修改角色"
+
+[member.cannotChangeOwnRole]
+one = "不能修改自己的角色"
+
+[member.invalidRole]
+one = "角色必须为 admin 或 member"
+
+[member.userNotMember]
+one = "该用户不是租户成员"
+
+[member.roleChangeFailed]
+one = "修改角色失败"
+
+[member.adminOnlyRemove]
+one = "仅租户管理员可移除成员"
+
+[member.cannotRemoveSelf]
+one = "不能移除自己，如需离开请使用退出租户功能"
+
+[member.removeFailed]
+one = "移除成员失败"
+
+[member.leaveFailed]
+one = "退出租户失败"
+
+# Invitation
+[invitation.notFound]
+one = "邀请不存在"
+
+[invitation.noPermission]
+one = "无权操作此邀请"
+
+[invitation.alreadyProcessed]
+one = "邀请已处理"
+
+[invitation.joinFailed]
+one = "加入租户失败"
+
+# Short Link
+[shortLink.notFound]
+one = "短链接不存在"
+
+[shortLink.idOccupied]
+one = "{{.id}} 已被占用"
+
+[shortLink.invalidId]
+one = "ID 错误"
+
+[shortLink.invalidDateParams]
+one = "日期参数错误"
+
+# Super Admin
+[superAdmin.usernamePasswordRequired]
+one = "请填写用户名和密码"
+
+[superAdmin.newPasswordRequired]
+one = "请填写新密码"
+
+[superAdmin.userStatusRequired]
+one = "请指定用户状态"
+
+[superAdmin.tenantStatusRequired]
+one = "请指定租户状态"
+
+# Middleware
+[middleware.tenantIdRequired]
+one = "X-Tenant-ID header is required"
+
+[middleware.superAdminOnly]
+one = "仅超级管理员可执行此操作"
+
+# Landing
+[landing.pageNotFound]
+one = "你访问的页面不存在哦"

--- a/internal/app/i18n/locales/active.zh.toml
+++ b/internal/app/i18n/locales/active.zh.toml
@@ -164,7 +164,7 @@ one = "请指定租户状态"
 
 # Middleware
 [middleware.tenantIdRequired]
-one = "X-Tenant-ID header is required"
+one = "请提供 X-Tenant-ID 请求头"
 
 [middleware.superAdminOnly]
 one = "仅超级管理员可执行此操作"

--- a/internal/app/middleware/language.go
+++ b/internal/app/middleware/language.go
@@ -1,27 +1,41 @@
 package middleware
 
 import (
-	"strings"
-
 	"github.com/gin-gonic/gin"
+	"golang.org/x/text/language"
 )
+
+var matcher = language.NewMatcher([]language.Tag{
+	language.English,
+	language.Chinese,
+})
 
 func LanguageMiddleware() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		lang := c.Query("lang")
 
-		if lang == "" {
+		if lang != "" {
+			tag, _, _ := matcher.Match(language.Make(lang))
+			if tag == language.Chinese {
+				c.Set("locale", "zh")
+			} else {
+				c.Set("locale", "en")
+			}
+		} else {
 			accept := c.GetHeader("Accept-Language")
-			if strings.HasPrefix(accept, "zh") {
-				lang = "zh"
+			if accept != "" {
+				tags, _, _ := language.ParseAcceptLanguage(accept)
+				tag, _, _ := matcher.Match(tags...)
+				if tag == language.Chinese {
+					c.Set("locale", "zh")
+				} else {
+					c.Set("locale", "en")
+				}
+			} else {
+				c.Set("locale", "en")
 			}
 		}
 
-		if lang != "zh" {
-			lang = "en"
-		}
-
-		c.Set("locale", lang)
 		c.Next()
 	}
 }

--- a/internal/app/middleware/language.go
+++ b/internal/app/middleware/language.go
@@ -1,0 +1,27 @@
+package middleware
+
+import (
+	"strings"
+
+	"github.com/gin-gonic/gin"
+)
+
+func LanguageMiddleware() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		lang := c.Query("lang")
+
+		if lang == "" {
+			accept := c.GetHeader("Accept-Language")
+			if strings.HasPrefix(accept, "zh") {
+				lang = "zh"
+			}
+		}
+
+		if lang != "zh" {
+			lang = "en"
+		}
+
+		c.Set("locale", lang)
+		c.Next()
+	}
+}

--- a/internal/app/models/models.go
+++ b/internal/app/models/models.go
@@ -36,6 +36,20 @@ func (e *NotFoundError) Error() string {
 	return e.Msg
 }
 
+// TranslatableError carries an i18n key for deferred translation at the handler layer.
+type TranslatableError struct {
+	Key  string
+	Data map[string]interface{}
+}
+
+func (e *TranslatableError) Error() string {
+	return e.Key
+}
+
+func NewTranslatableError(key string) *TranslatableError {
+	return &TranslatableError{Key: key}
+}
+
 // --- Tenant ---
 
 type Tenant struct {

--- a/internal/app/repository/repository.go
+++ b/internal/app/repository/repository.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
-	"github.com/jwma/jump-jump/internal/app/i18n"
 	"github.com/jwma/jump-jump/internal/app/models"
 	"github.com/jwma/jump-jump/internal/app/utils"
 	"github.com/redis/go-redis/v9"
@@ -749,7 +748,7 @@ func (r *shortLinkRepository) Save(s *models.ShortLink) error {
 		s.Id, s.TenantID, s.Url, s.Description, s.IsEnable, s.CreatedBy, s.CreateTime)
 	if err != nil {
 		log.Printf("fail to save short link: %v", err)
-		return i18n.NewError("common.serverBusy")
+		return models.NewTranslatableError("common.serverBusy")
 	}
 	return nil
 }
@@ -764,7 +763,7 @@ func (r *shortLinkRepository) Update(s *models.ShortLink, params *models.UpdateS
 		`UPDATE short_links SET url = $1, description = $2, is_enabled = $3, updated_at = $4 WHERE id = $5`,
 		s.Url, s.Description, s.IsEnable, s.UpdateTime, s.Id)
 	if err != nil {
-		return i18n.NewError("common.serverBusy")
+		return models.NewTranslatableError("common.serverBusy")
 	}
 
 	r.rdb.Del(context.Background(), utils.GetShortLinkCacheKey(s.Id))
@@ -839,7 +838,7 @@ func (r *shortLinkRepository) ListByTenantID(tenantID string, start, pageSize in
 		 FROM short_links WHERE tenant_id = $1 ORDER BY created_at DESC LIMIT $2 OFFSET $3`,
 		tenantID, pageSize, start)
 	if err != nil {
-		return nil, i18n.NewError("common.serverBusy")
+		return nil, models.NewTranslatableError("common.serverBusy")
 	}
 	defer rows.Close()
 

--- a/internal/app/repository/repository.go
+++ b/internal/app/repository/repository.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/jwma/jump-jump/internal/app/i18n"
 	"github.com/jwma/jump-jump/internal/app/models"
 	"github.com/jwma/jump-jump/internal/app/utils"
 	"github.com/redis/go-redis/v9"
@@ -49,7 +50,7 @@ func (r *TenantRepository) GetByID(id string) (*models.Tenant, error) {
 		Scan(&t.ID, &t.Name, &t.Slug, &t.IsActive, &t.CreatedAt, &t.UpdatedAt)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, &models.NotFoundError{Msg: "租户不存在"}
+			return nil, &models.NotFoundError{Msg: "tenant.notFound"}
 		}
 		return nil, err
 	}
@@ -272,7 +273,7 @@ func (r *userRepository) FindByUsername(username string) (*models.User, error) {
 		username).Scan(&u.ID, &u.Username, &u.Password, &u.Salt, &u.IsActive, &u.IsSuper, &u.CreatedAt, &u.UpdatedAt)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, &models.NotFoundError{Msg: "用户不存在"}
+			return nil, &models.NotFoundError{Msg: "user.notFound"}
 		}
 		return nil, err
 	}
@@ -291,7 +292,7 @@ func (r *userRepository) FindByID(userID string) (*models.User, error) {
 		userID).Scan(&u.ID, &u.Username, &u.Password, &u.Salt, &u.IsActive, &u.IsSuper, &u.CreatedAt, &u.UpdatedAt)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, &models.NotFoundError{Msg: "用户不存在"}
+			return nil, &models.NotFoundError{Msg: "user.notFound"}
 		}
 		return nil, err
 	}
@@ -505,7 +506,7 @@ func (r *TenantMemberRepository) Get(tenantID, userID string) (*models.TenantMem
 		tenantID, userID).Scan(&m.TenantID, &m.UserID, &m.Role, &m.JoinedAt)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, &models.NotFoundError{Msg: "成员关系不存在"}
+			return nil, &models.NotFoundError{Msg: "member.relationNotFound"}
 		}
 		return nil, err
 	}
@@ -546,7 +547,7 @@ func (r *TenantMemberRepository) UpdateRole(tenantID, userID, role string) error
 		return err
 	}
 	if ct.RowsAffected() == 0 {
-		return &models.NotFoundError{Msg: "成员不存在"}
+		return &models.NotFoundError{Msg: "member.notFound"}
 	}
 	return nil
 }
@@ -615,7 +616,7 @@ func (r *TenantInvitationRepository) Get(id string) (*models.TenantInvitation, e
 		Scan(&inv.ID, &inv.TenantID, &inv.InviterID, &inv.InviteeID, &inv.Status, &inv.CreatedAt)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, &models.NotFoundError{Msg: "邀请不存在"}
+			return nil, &models.NotFoundError{Msg: "invitation.notFound"}
 		}
 		return nil, err
 	}
@@ -748,7 +749,7 @@ func (r *shortLinkRepository) Save(s *models.ShortLink) error {
 		s.Id, s.TenantID, s.Url, s.Description, s.IsEnable, s.CreatedBy, s.CreateTime)
 	if err != nil {
 		log.Printf("fail to save short link: %v", err)
-		return errors.New("服务器繁忙，请稍后再试")
+		return i18n.NewError("common.serverBusy")
 	}
 	return nil
 }
@@ -763,7 +764,7 @@ func (r *shortLinkRepository) Update(s *models.ShortLink, params *models.UpdateS
 		`UPDATE short_links SET url = $1, description = $2, is_enabled = $3, updated_at = $4 WHERE id = $5`,
 		s.Url, s.Description, s.IsEnable, s.UpdateTime, s.Id)
 	if err != nil {
-		return errors.New("服务器繁忙，请稍后再试")
+		return i18n.NewError("common.serverBusy")
 	}
 
 	r.rdb.Del(context.Background(), utils.GetShortLinkCacheKey(s.Id))
@@ -777,7 +778,7 @@ func (r *shortLinkRepository) Delete(s *models.ShortLink) {
 
 func (r *shortLinkRepository) Get(id string) (*models.ShortLink, error) {
 	if id == "" {
-		return nil, &models.NotFoundError{Msg: "短链接不存在"}
+		return nil, &models.NotFoundError{Msg: "shortLink.notFound"}
 	}
 
 	// Try cache
@@ -798,7 +799,7 @@ func (r *shortLinkRepository) Get(id string) (*models.ShortLink, error) {
 		&s.Id, &s.TenantID, &s.Url, &s.Description, &s.IsEnable, &s.CreatedBy, &s.CreateTime, &s.UpdateTime)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, &models.NotFoundError{Msg: "短链接不存在"}
+			return nil, &models.NotFoundError{Msg: "shortLink.notFound"}
 		}
 		return nil, err
 	}
@@ -838,7 +839,7 @@ func (r *shortLinkRepository) ListByTenantID(tenantID string, start, pageSize in
 		 FROM short_links WHERE tenant_id = $1 ORDER BY created_at DESC LIMIT $2 OFFSET $3`,
 		tenantID, pageSize, start)
 	if err != nil {
-		return nil, errors.New("系统繁忙请稍后再试")
+		return nil, i18n.NewError("common.serverBusy")
 	}
 	defer rows.Close()
 

--- a/internal/app/routers/router.go
+++ b/internal/app/routers/router.go
@@ -10,6 +10,7 @@ import (
 	"github.com/gin-gonic/gin"
 	docs "github.com/jwma/jump-jump/docs"
 	"github.com/jwma/jump-jump/internal/app/handlers"
+	appmw "github.com/jwma/jump-jump/internal/app/middleware"
 	swaggerFiles "github.com/swaggo/files"
 	ginSwagger "github.com/swaggo/gin-swagger"
 )
@@ -77,6 +78,7 @@ func SetupRouter() *gin.Engine {
 	}
 
 	r.Use(handlers.AllowedHostsMiddleware())
+	r.Use(appmw.LanguageMiddleware())
 	r.Use(gzip.Gzip(gzip.DefaultCompression, gzip.WithExcludedPaths([]string{"/v1/"})))
 
 	r.NoRoute(func(c *gin.Context) {
@@ -178,6 +180,7 @@ func SetupRouter() *gin.Engine {
 
 func SetupLandingRouter() *gin.Engine {
 	r := gin.Default()
+	r.Use(appmw.LanguageMiddleware())
 
 	r.GET("/", handlers.LandingHome)
 	r.GET("/:id", handlers.Redirect)


### PR DESCRIPTION
## Summary
- Introduce `github.com/nicksnyder/go-i18n/v2` with embedded TOML locale files (`active.en.toml`, `active.zh.toml`)
- Create `internal/app/middleware/language.go` — language detection: `?lang` query param > `Accept-Language` header > default `en`
- Create `internal/app/i18n/i18n.go` — initialization, `T()` / `TWithData()` helpers, `Error` type for translatable errors, `TranslateError()` for repository errors
- Extract all hardcoded Chinese messages from handlers, middleware, landing, and repository into semantic i18n keys
- Register language middleware on both API and landing routers; init i18n in both `Run()` and `RunLanding()`
- Update `config.go` default not-found message to English

## Verification
- `go build ./...` passes
- `go vet ./...` passes
- All handler `NewErrorResponse` calls now use `i18n.T()` — no hardcoded Chinese remains
- Swagger comments and internal repository `%w` log messages left untouched per spec

## Test plan
- [ ] API request with `Accept-Language: en` returns English error messages
- [ ] API request with `Accept-Language: zh` returns Chinese error messages
- [ ] API request without header defaults to English
- [ ] Landing page 404 supports both languages
- [ ] `?lang=en` / `?lang=zh` query param overrides Accept-Language

🤖 Generated with [Claude Code](https://claude.com/claude-code)