### PR TITLE
feat: frontend i18n phase 2 — upgrade, fix hardcoded text, language switcher

### DIFF
--- a/web-ui/package-lock.json
+++ b/web-ui/package-lock.json
@@ -21,7 +21,7 @@
         "tailwind-merge": "^3.5.0",
         "vue": "^3.5.32",
         "vue-echarts": "^8.0.1",
-        "vue-i18n": "^12.0.0-alpha.3",
+        "vue-i18n": "^11.4.2",
         "vue-router": "^4.6.4"
       },
       "devDependencies": {
@@ -399,13 +399,30 @@
       }
     },
     "node_modules/@intlify/core-base": {
-      "version": "12.0.0-alpha.3",
-      "resolved": "https://registry.npmjs.org/@intlify/core-base/-/core-base-12.0.0-alpha.3.tgz",
-      "integrity": "sha512-LEvBHBUbiOOtIBkp4IIQENVC5Fg2YHsvdXN1+WRIxQ8hzHbHSBiqZ2l68B/yg8sE1a4S7dqhkaAedunShWPH+Q==",
+      "version": "11.4.2",
+      "resolved": "https://registry.npmjs.org/@intlify/core-base/-/core-base-11.4.2.tgz",
+      "integrity": "sha512-7fpuCcVmeLv2T9qHsARqGvh8xt+sV2fH+Q+gMHFwB/rPXzo85DpbJFKn7dBH1L5p0c2cSh2DW+2h/64EKrISmA==",
       "license": "MIT",
       "dependencies": {
-        "@intlify/message-compiler": "12.0.0-alpha.3",
-        "@intlify/shared": "12.0.0-alpha.3"
+        "@intlify/devtools-types": "11.4.2",
+        "@intlify/message-compiler": "11.4.2",
+        "@intlify/shared": "11.4.2"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/kazupon"
+      }
+    },
+    "node_modules/@intlify/devtools-types": {
+      "version": "11.4.2",
+      "resolved": "https://registry.npmjs.org/@intlify/devtools-types/-/devtools-types-11.4.2.tgz",
+      "integrity": "sha512-3u8EN1kB6EMSi96KXs5k7a8y2X2g4+h3X6iwVZU47cP4n+mTuq//WMjG588BzSp/2XQ/dTXo2BLUXX+XS+PNfA==",
+      "license": "MIT",
+      "dependencies": {
+        "@intlify/core-base": "11.4.2",
+        "@intlify/shared": "11.4.2"
       },
       "engines": {
         "node": ">= 16"
@@ -415,12 +432,12 @@
       }
     },
     "node_modules/@intlify/message-compiler": {
-      "version": "12.0.0-alpha.3",
-      "resolved": "https://registry.npmjs.org/@intlify/message-compiler/-/message-compiler-12.0.0-alpha.3.tgz",
-      "integrity": "sha512-mDDTN3gfYOHhBnpnlby19UHyvMaOnzdlpsIrxUfs44R/vCATfn8pMOkE8PXD2t410xkocEj3FpDcC9XC/0v4Dg==",
+      "version": "11.4.2",
+      "resolved": "https://registry.npmjs.org/@intlify/message-compiler/-/message-compiler-11.4.2.tgz",
+      "integrity": "sha512-a6CDSGSMTGrg0BjD97x8TBYPf7qQMDlZipJ6UDfv/pd4OIym8TMlHu3MsH0bTNnRdAG2D6EFEykIgiQPqvtTkA==",
       "license": "MIT",
       "dependencies": {
-        "@intlify/shared": "12.0.0-alpha.3",
+        "@intlify/shared": "11.4.2",
         "source-map-js": "^1.0.2"
       },
       "engines": {
@@ -431,9 +448,9 @@
       }
     },
     "node_modules/@intlify/shared": {
-      "version": "12.0.0-alpha.3",
-      "resolved": "https://registry.npmjs.org/@intlify/shared/-/shared-12.0.0-alpha.3.tgz",
-      "integrity": "sha512-ryaNYBvxQjyJUmVuBBg+HHUsmGnfxcEUPR0NCeG4/K9N2qtyFE35C80S15IN6iYFE2MGWLN7HfOSyg0MXZIc9w==",
+      "version": "11.4.2",
+      "resolved": "https://registry.npmjs.org/@intlify/shared/-/shared-11.4.2.tgz",
+      "integrity": "sha512-NzpHbguRCsOHDwxmlBa9qu/imc+/QWgsYUaK6FZeNC0wK8QfAbhqrktEp/haVzxU1aikH8IX4ytD+mfFEMi/9A==",
       "license": "MIT",
       "engines": {
         "node": ">= 16"
@@ -441,29 +458,6 @@
       "funding": {
         "url": "https://github.com/sponsors/kazupon"
       }
-    },
-    "node_modules/@intlify/vue-i18n-core": {
-      "version": "12.0.0-alpha.3",
-      "resolved": "https://registry.npmjs.org/@intlify/vue-i18n-core/-/vue-i18n-core-12.0.0-alpha.3.tgz",
-      "integrity": "sha512-YwAfTQILHN+VoK0P/Yv47GbKnEf1lhfbliyVyW3knAL1EmT8m0m3rwffXJnwyQhYw8Jpx85CpL49WkSgyi6d/g==",
-      "license": "MIT",
-      "dependencies": {
-        "@intlify/core-base": "12.0.0-alpha.3",
-        "@intlify/shared": "12.0.0-alpha.3",
-        "@vue/devtools-api": "^6.5.0"
-      },
-      "engines": {
-        "node": ">= 16"
-      },
-      "peerDependencies": {
-        "vue": "^3.0.0"
-      }
-    },
-    "node_modules/@intlify/vue-i18n-core/node_modules/@vue/devtools-api": {
-      "version": "6.6.4",
-      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.6.4.tgz",
-      "integrity": "sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g==",
-      "license": "MIT"
     },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
@@ -4039,15 +4033,14 @@
       }
     },
     "node_modules/vue-i18n": {
-      "version": "12.0.0-alpha.3",
-      "resolved": "https://registry.npmjs.org/vue-i18n/-/vue-i18n-12.0.0-alpha.3.tgz",
-      "integrity": "sha512-+KQgD9LJoHfGCdJh3gaLdVS/Sps1n860+6wsjyeNLWJeEofjdVH7KPjz4rAeBlTAUaIDlIjHoXQY0Lk+8B6S9w==",
-      "deprecated": "This version is NOT deprecated. Previous deprecation was a mistake.",
+      "version": "11.4.2",
+      "resolved": "https://registry.npmjs.org/vue-i18n/-/vue-i18n-11.4.2.tgz",
+      "integrity": "sha512-sADDeKXqAGsPX6tK3t3y2ZiMpbVWN12tG+MhTiJ06rVoh58eGtM4wFyw3uWGbVkXByVp9Ne/AP+nSSzI+J9OAQ==",
       "license": "MIT",
       "dependencies": {
-        "@intlify/core-base": "12.0.0-alpha.3",
-        "@intlify/shared": "12.0.0-alpha.3",
-        "@intlify/vue-i18n-core": "12.0.0-alpha.3",
+        "@intlify/core-base": "11.4.2",
+        "@intlify/devtools-types": "11.4.2",
+        "@intlify/shared": "11.4.2",
         "@vue/devtools-api": "^6.5.0"
       },
       "engines": {

--- a/web-ui/package.json
+++ b/web-ui/package.json
@@ -25,7 +25,7 @@
     "tailwind-merge": "^3.5.0",
     "vue": "^3.5.32",
     "vue-echarts": "^8.0.1",
-    "vue-i18n": "^12.0.0-alpha.3",
+    "vue-i18n": "^11.4.2",
     "vue-router": "^4.6.4"
   },
   "devDependencies": {

--- a/web-ui/src/api/http.ts
+++ b/web-ui/src/api/http.ts
@@ -2,6 +2,7 @@ import axios from 'axios'
 import type { ApiResponse } from '@/types/api'
 import { useAuthStore } from '@/stores/auth'
 import router from '@/router'
+import i18n from '@/i18n'
 
 export class ApiError extends Error {
   status: number
@@ -28,6 +29,7 @@ http.interceptors.request.use((config) => {
   if (auth.currentTenantId && !config.url?.startsWith('/super/')) {
     config.headers['X-Tenant-ID'] = auth.currentTenantId
   }
+  config.headers['Accept-Language'] = i18n.global.locale.value
   return config
 })
 

--- a/web-ui/src/components/AppTopBar.vue
+++ b/web-ui/src/components/AppTopBar.vue
@@ -124,7 +124,7 @@ onBeforeUnmount(() => document.removeEventListener('click', closeDropdowns))
       <div class="topbar-dropdown relative">
         <button
           class="rounded p-1.5 text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-600 dark:hover:bg-gray-800 dark:hover:text-gray-300"
-          :aria-label="t('topbar.switchLanguage')"
+          :aria-label="t('topbar.toggleTheme')"
           @click.stop="themeDropdownOpen = !themeDropdownOpen"
         >
           <Sun v-if="theme === 'light'" class="h-5 w-5" />
@@ -191,7 +191,7 @@ onBeforeUnmount(() => document.removeEventListener('click', closeDropdowns))
             </h3>
             <button
               class="rounded p-1 text-gray-400 hover:bg-gray-100 hover:text-gray-600 dark:hover:bg-gray-800 dark:hover:text-gray-300"
-              :aria-label="t('topbar.notifications')"
+              :aria-label="t('topbar.closeNotifications')"
               @click="notifDropdownOpen = false"
             >
               <X class="h-4 w-4" />
@@ -244,7 +244,7 @@ onBeforeUnmount(() => document.removeEventListener('click', closeDropdowns))
       <div class="topbar-dropdown relative">
         <button
           class="flex items-center gap-2 rounded-lg px-2 py-1.5 transition-colors hover:bg-gray-100 dark:hover:bg-gray-800"
-          :aria-label="t('topbar.switchLanguage')"
+          :aria-label="t('topbar.userMenu')"
           aria-haspopup="menu"
           :aria-expanded="userDropdownOpen"
           @click.stop="userDropdownOpen = !userDropdownOpen"

--- a/web-ui/src/components/AppTopBar.vue
+++ b/web-ui/src/components/AppTopBar.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { ref, computed, onMounted, onBeforeUnmount } from 'vue'
 import { useRouter } from 'vue-router'
+import { useI18n } from 'vue-i18n'
 import { useAuthStore } from '@/stores/auth'
 import { useLayoutStore } from '@/stores/layout'
 import { useTheme } from '@/composables/useTheme'
@@ -16,8 +17,10 @@ import {
   Sun,
   Moon,
   Monitor,
+  Languages,
 } from 'lucide-vue-next'
 
+const { t, locale } = useI18n()
 const auth = useAuthStore()
 const layout = useLayoutStore()
 const router = useRouter()
@@ -26,6 +29,7 @@ const { theme } = useTheme()
 const userDropdownOpen = ref(false)
 const notifDropdownOpen = ref(false)
 const themeDropdownOpen = ref(false)
+const langDropdownOpen = ref(false)
 
 const pendingInvitations = computed(() => auth.invitations.filter((i) => i.status === 'pending'))
 
@@ -40,6 +44,12 @@ function setTheme(value: 'light' | 'dark' | 'system') {
   themeDropdownOpen.value = false
 }
 
+function setLocale(lang: string) {
+  locale.value = lang
+  localStorage.setItem('locale', lang)
+  langDropdownOpen.value = false
+}
+
 function navigateToChangePassword() {
   userDropdownOpen.value = false
   router.push({ name: 'change-password' })
@@ -51,6 +61,7 @@ function closeDropdowns(e: MouseEvent) {
     userDropdownOpen.value = false
     notifDropdownOpen.value = false
     themeDropdownOpen.value = false
+    langDropdownOpen.value = false
   }
 }
 
@@ -78,11 +89,42 @@ onBeforeUnmount(() => document.removeEventListener('click', closeDropdowns))
       <!-- Global Search -->
       <GlobalSearch />
 
+      <!-- Language switcher -->
+      <div class="topbar-dropdown relative">
+        <button
+          class="rounded p-1.5 text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-600 dark:hover:bg-gray-800 dark:hover:text-gray-300"
+          :aria-label="t('topbar.switchLanguage')"
+          @click.stop="langDropdownOpen = !langDropdownOpen"
+        >
+          <Languages class="h-5 w-5" />
+        </button>
+        <div
+          v-if="langDropdownOpen"
+          class="absolute right-0 top-full z-50 mt-2 w-32 overflow-hidden rounded-xl border border-gray-200 bg-white shadow-lg dark:border-gray-700 dark:bg-gray-900"
+          @click.stop
+        >
+          <button
+            class="flex w-full items-center gap-2 px-3 py-2 text-sm text-gray-600 hover:bg-gray-50 dark:text-gray-300 dark:hover:bg-gray-800"
+            :class="{ 'bg-gray-50 dark:bg-gray-800': locale === 'en' }"
+            @click="setLocale('en')"
+          >
+            EN
+          </button>
+          <button
+            class="flex w-full items-center gap-2 px-3 py-2 text-sm text-gray-600 hover:bg-gray-50 dark:text-gray-300 dark:hover:bg-gray-800"
+            :class="{ 'bg-gray-50 dark:bg-gray-800': locale === 'zh' }"
+            @click="setLocale('zh')"
+          >
+            中文
+          </button>
+        </div>
+      </div>
+
       <!-- Theme toggle -->
       <div class="topbar-dropdown relative">
         <button
           class="rounded p-1.5 text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-600 dark:hover:bg-gray-800 dark:hover:text-gray-300"
-          aria-label="Toggle theme"
+          :aria-label="t('topbar.switchLanguage')"
           @click.stop="themeDropdownOpen = !themeDropdownOpen"
         >
           <Sun v-if="theme === 'light'" class="h-5 w-5" />
@@ -99,21 +141,21 @@ onBeforeUnmount(() => document.removeEventListener('click', closeDropdowns))
             :class="{ 'bg-gray-50 dark:bg-gray-800': theme === 'light' }"
             @click="setTheme('light')"
           >
-            <Sun class="h-4 w-4" /> Light
+            <Sun class="h-4 w-4" /> {{ t('topbar.light') }}
           </button>
           <button
             class="flex w-full items-center gap-2 px-3 py-2 text-sm text-gray-600 hover:bg-gray-50 dark:text-gray-300 dark:hover:bg-gray-800"
             :class="{ 'bg-gray-50 dark:bg-gray-800': theme === 'dark' }"
             @click="setTheme('dark')"
           >
-            <Moon class="h-4 w-4" /> Dark
+            <Moon class="h-4 w-4" /> {{ t('topbar.dark') }}
           </button>
           <button
             class="flex w-full items-center gap-2 px-3 py-2 text-sm text-gray-600 hover:bg-gray-50 dark:text-gray-300 dark:hover:bg-gray-800"
             :class="{ 'bg-gray-50 dark:bg-gray-800': theme === 'system' }"
             @click="setTheme('system')"
           >
-            <Monitor class="h-4 w-4" /> System
+            <Monitor class="h-4 w-4" /> {{ t('topbar.system') }}
           </button>
         </div>
       </div>
@@ -122,7 +164,7 @@ onBeforeUnmount(() => document.removeEventListener('click', closeDropdowns))
       <div class="topbar-dropdown relative">
         <button
           class="relative rounded p-1.5 text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-600 dark:hover:bg-gray-800 dark:hover:text-gray-300"
-          aria-label="Open notifications"
+          :aria-label="t('topbar.notifications')"
           aria-haspopup="menu"
           :aria-expanded="notifDropdownOpen"
           @click.stop="notifDropdownOpen = !notifDropdownOpen"
@@ -144,10 +186,10 @@ onBeforeUnmount(() => document.removeEventListener('click', closeDropdowns))
           <div
             class="flex items-center justify-between border-b border-gray-200 dark:border-gray-700 px-4 py-3"
           >
-            <h3 class="text-sm font-semibold text-gray-900 dark:text-white">Notifications</h3>
+            <h3 class="text-sm font-semibold text-gray-900 dark:text-white">{{ t('topbar.notifications') }}</h3>
             <button
               class="rounded p-1 text-gray-400 hover:bg-gray-100 hover:text-gray-600 dark:hover:bg-gray-800 dark:hover:text-gray-300"
-              aria-label="Close notifications"
+              :aria-label="t('topbar.notifications')"
               @click="notifDropdownOpen = false"
             >
               <X class="h-4 w-4" />
@@ -168,18 +210,18 @@ onBeforeUnmount(() => document.removeEventListener('click', closeDropdowns))
                 </div>
                 <div class="min-w-0 flex-1">
                   <p class="text-sm text-gray-700 dark:text-gray-300">
-                    Invited to <span class="font-medium">{{ inv.tenantName }}</span>
+                    {{ t('topbar.invitedTo', { tenant: inv.tenantName }) }}
                   </p>
                   <p class="mt-0.5 text-xs text-gray-400 dark:text-gray-500">
                     <Clock class="mr-0.5 inline h-3 w-3" />
-                    Invited by {{ inv.inviterUsername }}
+                    {{ t('topbar.invitedBy', { inviter: inv.inviterUsername }) }}
                   </p>
                 </div>
               </div>
             </template>
             <div v-else class="px-4 py-8 text-center">
               <Bell class="mx-auto h-8 w-8 text-gray-200 dark:text-gray-700" />
-              <p class="mt-2 text-sm text-gray-400 dark:text-gray-500">No new notifications</p>
+              <p class="mt-2 text-sm text-gray-400 dark:text-gray-500">{{ t('topbar.noNotifications') }}</p>
             </div>
           </div>
 
@@ -189,7 +231,7 @@ onBeforeUnmount(() => document.removeEventListener('click', closeDropdowns))
             class="block border-t border-gray-200 dark:border-gray-700 px-4 py-2.5 text-center text-sm font-medium text-blue-600 transition-colors hover:bg-gray-50 dark:hover:bg-gray-800"
             @click="notifDropdownOpen = false"
           >
-            View all invitations
+            {{ t('topbar.viewAllInvitations') }}
           </router-link>
         </div>
       </div>
@@ -198,7 +240,7 @@ onBeforeUnmount(() => document.removeEventListener('click', closeDropdowns))
       <div class="topbar-dropdown relative">
         <button
           class="flex items-center gap-2 rounded-lg px-2 py-1.5 transition-colors hover:bg-gray-100 dark:hover:bg-gray-800"
-          aria-label="User menu"
+          :aria-label="t('topbar.switchLanguage')"
           aria-haspopup="menu"
           :aria-expanded="userDropdownOpen"
           @click.stop="userDropdownOpen = !userDropdownOpen"
@@ -234,14 +276,14 @@ onBeforeUnmount(() => document.removeEventListener('click', closeDropdowns))
               @click="navigateToChangePassword"
             >
               <KeyRound class="h-4 w-4 text-gray-400" />
-              Change Password
+              {{ t('topbar.changePassword') }}
             </button>
             <button
               class="flex w-full items-center gap-2.5 px-4 py-2 text-sm text-red-600 transition-colors hover:bg-red-50 dark:hover:bg-red-900/20"
               @click="handleLogout"
             >
               <LogOut class="h-4 w-4" />
-              Logout
+              {{ t('topbar.logout') }}
             </button>
           </div>
         </div>

--- a/web-ui/src/components/AppTopBar.vue
+++ b/web-ui/src/components/AppTopBar.vue
@@ -186,7 +186,9 @@ onBeforeUnmount(() => document.removeEventListener('click', closeDropdowns))
           <div
             class="flex items-center justify-between border-b border-gray-200 dark:border-gray-700 px-4 py-3"
           >
-            <h3 class="text-sm font-semibold text-gray-900 dark:text-white">{{ t('topbar.notifications') }}</h3>
+            <h3 class="text-sm font-semibold text-gray-900 dark:text-white">
+              {{ t('topbar.notifications') }}
+            </h3>
             <button
               class="rounded p-1 text-gray-400 hover:bg-gray-100 hover:text-gray-600 dark:hover:bg-gray-800 dark:hover:text-gray-300"
               :aria-label="t('topbar.notifications')"
@@ -221,7 +223,9 @@ onBeforeUnmount(() => document.removeEventListener('click', closeDropdowns))
             </template>
             <div v-else class="px-4 py-8 text-center">
               <Bell class="mx-auto h-8 w-8 text-gray-200 dark:text-gray-700" />
-              <p class="mt-2 text-sm text-gray-400 dark:text-gray-500">{{ t('topbar.noNotifications') }}</p>
+              <p class="mt-2 text-sm text-gray-400 dark:text-gray-500">
+                {{ t('topbar.noNotifications') }}
+              </p>
             </div>
           </div>
 

--- a/web-ui/src/components/ShortcutHelp.vue
+++ b/web-ui/src/components/ShortcutHelp.vue
@@ -41,7 +41,9 @@ function handleKeydown(e: KeyboardEvent) {
 
         <div class="space-y-1 px-5 py-4">
           <div class="flex items-center justify-between py-2">
-            <span class="text-sm text-gray-600 dark:text-gray-400">{{ t('shortcuts.openGlobalSearch') }}</span>
+            <span class="text-sm text-gray-600 dark:text-gray-400">{{
+              t('shortcuts.openGlobalSearch')
+            }}</span>
             <div class="flex items-center gap-1">
               <kbd
                 class="rounded border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 px-2 py-0.5 text-xs font-medium text-gray-500 dark:text-gray-400"
@@ -57,7 +59,9 @@ function handleKeydown(e: KeyboardEvent) {
           <div class="border-t border-gray-100 dark:border-gray-800" />
 
           <div class="flex items-center justify-between py-2">
-            <span class="text-sm text-gray-600 dark:text-gray-400">{{ t('shortcuts.showHelp') }}</span>
+            <span class="text-sm text-gray-600 dark:text-gray-400">{{
+              t('shortcuts.showHelp')
+            }}</span>
             <kbd
               class="rounded border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 px-2 py-0.5 text-xs font-medium text-gray-500 dark:text-gray-400"
               >?</kbd
@@ -71,7 +75,9 @@ function handleKeydown(e: KeyboardEvent) {
           </p>
 
           <div class="flex items-center justify-between py-2">
-            <span class="text-sm text-gray-600 dark:text-gray-400">{{ t('shortcuts.createNewLink') }}</span>
+            <span class="text-sm text-gray-600 dark:text-gray-400">{{
+              t('shortcuts.createNewLink')
+            }}</span>
             <kbd
               class="rounded border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 px-2 py-0.5 text-xs font-medium text-gray-500 dark:text-gray-400"
               >N</kbd
@@ -79,17 +85,21 @@ function handleKeydown(e: KeyboardEvent) {
           </div>
 
           <div class="flex items-center justify-between py-2">
-            <span class="text-sm text-gray-600 dark:text-gray-400">{{ t('shortcuts.focusSearch') }}</span>
+            <span class="text-sm text-gray-600 dark:text-gray-400">{{
+              t('shortcuts.focusSearch')
+            }}</span>
             <kbd
               class="rounded border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 px-2 py-0.5 text-xs font-medium text-gray-500 dark:text-gray-400"
               >/</kbd
-              >
+            >
           </div>
 
           <div class="border-t border-gray-100 dark:border-gray-800" />
 
           <div class="flex items-center justify-between py-2">
-            <span class="text-sm text-gray-600 dark:text-gray-400">{{ t('shortcuts.closePanels') }}</span>
+            <span class="text-sm text-gray-600 dark:text-gray-400">{{
+              t('shortcuts.closePanels')
+            }}</span>
             <kbd
               class="rounded border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 px-2 py-0.5 text-xs font-medium text-gray-500 dark:text-gray-400"
               >Esc</kbd

--- a/web-ui/src/components/ShortcutHelp.vue
+++ b/web-ui/src/components/ShortcutHelp.vue
@@ -1,6 +1,9 @@
 <script setup lang="ts">
+import { useI18n } from 'vue-i18n'
 import { showHelp } from '@/composables/useKeyboardShortcuts'
 import { X, Keyboard } from 'lucide-vue-next'
+
+const { t } = useI18n()
 
 function close() {
   showHelp.value = false
@@ -25,7 +28,7 @@ function handleKeydown(e: KeyboardEvent) {
           <div class="flex items-center gap-2">
             <Keyboard class="h-5 w-5 text-gray-500 dark:text-gray-400" />
             <h3 class="text-base font-semibold text-gray-900 dark:text-white">
-              Keyboard Shortcuts
+              {{ t('shortcuts.title') }}
             </h3>
           </div>
           <button
@@ -38,7 +41,7 @@ function handleKeydown(e: KeyboardEvent) {
 
         <div class="space-y-1 px-5 py-4">
           <div class="flex items-center justify-between py-2">
-            <span class="text-sm text-gray-600 dark:text-gray-400">Open global search</span>
+            <span class="text-sm text-gray-600 dark:text-gray-400">{{ t('shortcuts.openGlobalSearch') }}</span>
             <div class="flex items-center gap-1">
               <kbd
                 class="rounded border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 px-2 py-0.5 text-xs font-medium text-gray-500 dark:text-gray-400"
@@ -54,7 +57,7 @@ function handleKeydown(e: KeyboardEvent) {
           <div class="border-t border-gray-100 dark:border-gray-800" />
 
           <div class="flex items-center justify-between py-2">
-            <span class="text-sm text-gray-600 dark:text-gray-400">Show this help panel</span>
+            <span class="text-sm text-gray-600 dark:text-gray-400">{{ t('shortcuts.showHelp') }}</span>
             <kbd
               class="rounded border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 px-2 py-0.5 text-xs font-medium text-gray-500 dark:text-gray-400"
               >?</kbd
@@ -64,11 +67,11 @@ function handleKeydown(e: KeyboardEvent) {
           <div class="border-t border-gray-100 dark:border-gray-800" />
 
           <p class="pt-2 text-xs font-medium uppercase text-gray-400 dark:text-gray-500">
-            Short Links Page
+            {{ t('shortcuts.shortLinksPage') }}
           </p>
 
           <div class="flex items-center justify-between py-2">
-            <span class="text-sm text-gray-600 dark:text-gray-400">Create new short link</span>
+            <span class="text-sm text-gray-600 dark:text-gray-400">{{ t('shortcuts.createNewLink') }}</span>
             <kbd
               class="rounded border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 px-2 py-0.5 text-xs font-medium text-gray-500 dark:text-gray-400"
               >N</kbd
@@ -76,17 +79,17 @@ function handleKeydown(e: KeyboardEvent) {
           </div>
 
           <div class="flex items-center justify-between py-2">
-            <span class="text-sm text-gray-600 dark:text-gray-400">Focus search</span>
+            <span class="text-sm text-gray-600 dark:text-gray-400">{{ t('shortcuts.focusSearch') }}</span>
             <kbd
               class="rounded border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 px-2 py-0.5 text-xs font-medium text-gray-500 dark:text-gray-400"
               >/</kbd
-            >
+              >
           </div>
 
           <div class="border-t border-gray-100 dark:border-gray-800" />
 
           <div class="flex items-center justify-between py-2">
-            <span class="text-sm text-gray-600 dark:text-gray-400">Close panels / Cancel</span>
+            <span class="text-sm text-gray-600 dark:text-gray-400">{{ t('shortcuts.closePanels') }}</span>
             <kbd
               class="rounded border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 px-2 py-0.5 text-xs font-medium text-gray-500 dark:text-gray-400"
               >Esc</kbd

--- a/web-ui/src/i18n/locales/en.ts
+++ b/web-ui/src/i18n/locales/en.ts
@@ -88,6 +88,11 @@ export default {
     invitedBy: 'Invited by {inviter}',
     viewAllInvitations: 'View all invitations',
     changePassword: 'Change Password',
+    light: 'Light',
+    dark: 'Dark',
+    system: 'System',
+    switchLanguage: 'Switch language',
+    logout: 'Logout',
   },
   dashboard: {
     greeting: {
@@ -243,6 +248,8 @@ export default {
     referer: 'Referer',
     userAgent: 'User Agent',
     direct: 'Direct',
+    visitsWithCount: '{count} visits',
+    visitsWithPercent: '{count} visits ({percent}%)',
   },
   settings: {
     title: 'Settings',

--- a/web-ui/src/i18n/locales/en.ts
+++ b/web-ui/src/i18n/locales/en.ts
@@ -92,6 +92,9 @@ export default {
     dark: 'Dark',
     system: 'System',
     switchLanguage: 'Switch language',
+    toggleTheme: 'Toggle theme',
+    closeNotifications: 'Close notifications',
+    userMenu: 'User menu',
     logout: 'Logout',
   },
   dashboard: {
@@ -248,8 +251,8 @@ export default {
     referer: 'Referer',
     userAgent: 'User Agent',
     direct: 'Direct',
-    visitsWithCount: '{count} visits',
-    visitsWithPercent: '{count} visits ({percent}%)',
+    visitsWithCount: 'visits',
+    visitsWithPercent: 'visits ({percent}%)',
   },
   settings: {
     title: 'Settings',

--- a/web-ui/src/i18n/locales/zh.ts
+++ b/web-ui/src/i18n/locales/zh.ts
@@ -88,6 +88,11 @@ export default {
     invitedBy: '由 {inviter} 邀请',
     viewAllInvitations: '查看所有邀请',
     changePassword: '修改密码',
+    light: '浅色',
+    dark: '深色',
+    system: '跟随系统',
+    switchLanguage: '切换语言',
+    logout: '退出',
   },
   dashboard: {
     greeting: {
@@ -242,6 +247,8 @@ export default {
     referer: '来源',
     userAgent: '用户代理',
     direct: '直接访问',
+    visitsWithCount: '{count} 次访问',
+    visitsWithPercent: '{count} 次访问（{percent}%）',
   },
   settings: {
     title: '设置',

--- a/web-ui/src/i18n/locales/zh.ts
+++ b/web-ui/src/i18n/locales/zh.ts
@@ -92,6 +92,9 @@ export default {
     dark: '深色',
     system: '跟随系统',
     switchLanguage: '切换语言',
+    toggleTheme: '切换主题',
+    closeNotifications: '关闭通知',
+    userMenu: '用户菜单',
     logout: '退出',
   },
   dashboard: {
@@ -247,8 +250,8 @@ export default {
     referer: '来源',
     userAgent: '用户代理',
     direct: '直接访问',
-    visitsWithCount: '{count} 次访问',
-    visitsWithPercent: '{count} 次访问（{percent}%）',
+    visitsWithCount: '次访问',
+    visitsWithPercent: '次访问（{percent}%）',
   },
   settings: {
     title: '设置',

--- a/web-ui/src/pages/ShortLinkDetailPage.vue
+++ b/web-ui/src/pages/ShortLinkDetailPage.vue
@@ -460,7 +460,9 @@ watch([() => link.value, qrSelectedDomain], () => {
       </button>
     </div>
 
-    <div v-if="loading" class="mt-6 text-center text-gray-400 dark:text-gray-500">{{ t('shortLinkDetail.loading') }}</div>
+    <div v-if="loading" class="mt-6 text-center text-gray-400 dark:text-gray-500">
+      {{ t('shortLinkDetail.loading') }}
+    </div>
 
     <div v-else-if="notFound" class="mt-6 text-center text-gray-400 dark:text-gray-500">
       {{ t('shortLinkDetail.notFound') }}
@@ -930,7 +932,9 @@ watch([() => link.value, qrSelectedDomain], () => {
                       <td
                         class="max-w-[200px] truncate px-4 py-2.5 text-gray-600 dark:text-gray-400"
                       >
-                        {{ h.referer ? extractRefererSource(h.referer) : t('shortLinkDetail.direct') }}
+                        {{
+                          h.referer ? extractRefererSource(h.referer) : t('shortLinkDetail.direct')
+                        }}
                       </td>
                       <td
                         class="max-w-[300px] truncate px-4 py-2.5 text-xs text-gray-400 dark:text-gray-500"
@@ -943,7 +947,12 @@ watch([() => link.value, qrSelectedDomain], () => {
                 </table>
               </div>
               <div class="border-t px-4 py-3 text-xs text-gray-400 dark:text-gray-500">
-                {{ t('shortLinkDetail.recordCount', { count: histories.length, suffix: histories.length !== 1 ? 's' : '' }) }}
+                {{
+                  t('shortLinkDetail.recordCount', {
+                    count: histories.length,
+                    suffix: histories.length !== 1 ? 's' : '',
+                  })
+                }}
               </div>
             </template>
           </div>

--- a/web-ui/src/pages/ShortLinkDetailPage.vue
+++ b/web-ui/src/pages/ShortLinkDetailPage.vue
@@ -234,7 +234,7 @@ const visitChartOption = computed(() => ({
     trigger: 'axis' as const,
     formatter: (params: { name: string; value: number }[]) => {
       const p = params[0]
-      return `${p.name}<br/><b>${p.value}</b> 次访问`
+      return `${p.name}<br/><b>${p.value}</b> ${t('shortLinkDetail.visitsWithCount', { count: p.value })}`
     },
   },
   grid: { top: 16, right: 16, bottom: 32, left: 48 },
@@ -313,7 +313,7 @@ const osChartOption = computed(() =>
   makePieOption(
     osDistribution.value,
     (name, value, total) =>
-      `${name}<br/><b>${value}</b> 次访问 (${((value / total) * 100).toFixed(1)}%)`,
+      `${name}<br/><b>${value}</b> ${t('shortLinkDetail.visitsWithPercent', { count: value, percent: ((value / total) * 100).toFixed(1) })}`,
   ),
 )
 
@@ -321,7 +321,7 @@ const browserChartOption = computed(() =>
   makePieOption(
     browserDistribution.value,
     (name, value, total) =>
-      `${name}<br/><b>${value}</b> 次访问 (${((value / total) * 100).toFixed(1)}%)`,
+      `${name}<br/><b>${value}</b> ${t('shortLinkDetail.visitsWithPercent', { count: value, percent: ((value / total) * 100).toFixed(1) })}`,
   ),
 )
 
@@ -329,7 +329,7 @@ const refererChartOption = computed(() =>
   makePieOption(
     refererDistribution.value,
     (name, value, total) =>
-      `${name}<br/><b>${value}</b> 次访问 (${((value / total) * 100).toFixed(1)}%)`,
+      `${name}<br/><b>${value}</b> ${t('shortLinkDetail.visitsWithPercent', { count: value, percent: ((value / total) * 100).toFixed(1) })}`,
   ),
 )
 
@@ -456,19 +456,19 @@ watch([() => link.value, qrSelectedDomain], () => {
         @click="router.push({ name: 'short-link-edit', params: { id: link.id } })"
       >
         <Pencil class="h-3.5 w-3.5" />
-        Edit
+        {{ t('shortLinkDetail.edit') }}
       </button>
     </div>
 
-    <div v-if="loading" class="mt-6 text-center text-gray-400 dark:text-gray-500">Loading...</div>
+    <div v-if="loading" class="mt-6 text-center text-gray-400 dark:text-gray-500">{{ t('shortLinkDetail.loading') }}</div>
 
     <div v-else-if="notFound" class="mt-6 text-center text-gray-400 dark:text-gray-500">
-      Short link not found.
+      {{ t('shortLinkDetail.notFound') }}
       <button
         class="ml-2 text-blue-600 hover:underline"
         @click="router.push({ name: 'short-links' })"
       >
-        Back to list
+        {{ t('common.backToList') }}
       </button>
     </div>
 
@@ -711,7 +711,7 @@ watch([() => link.value, qrSelectedDomain], () => {
             @click="activeTab = 'trend'"
           >
             <LayoutGrid class="h-3.5 w-3.5" />
-            Charts
+            {{ t('shortLinkDetail.charts') }}
           </button>
           <button
             class="inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 text-xs font-medium transition-colors"
@@ -723,7 +723,7 @@ watch([() => link.value, qrSelectedDomain], () => {
             @click="activeTab = 'records'"
           >
             <FileText class="h-3.5 w-3.5" />
-            Access Records
+            {{ t('shortLinkDetail.accessRecords') }}
           </button>
         </div>
 
@@ -741,7 +741,7 @@ watch([() => link.value, qrSelectedDomain], () => {
               v-else-if="totalVisits === 0"
               class="flex h-56 items-center justify-center text-sm text-gray-400 dark:text-gray-500"
             >
-              No data for this period.
+              {{ t('shortLinkDetail.noData') }}
             </div>
             <div v-else class="h-56">
               <VChart
@@ -767,7 +767,7 @@ watch([() => link.value, qrSelectedDomain], () => {
                 v-else-if="osDistribution.length === 0"
                 class="flex h-56 items-center justify-center text-sm text-gray-400 dark:text-gray-500"
               >
-                No data for this period.
+                {{ t('shortLinkDetail.noData') }}
               </div>
               <div v-else class="h-56">
                 <VChart
@@ -791,7 +791,7 @@ watch([() => link.value, qrSelectedDomain], () => {
                 v-else-if="browserDistribution.length === 0"
                 class="flex h-56 items-center justify-center text-sm text-gray-400 dark:text-gray-500"
               >
-                No data for this period.
+                {{ t('shortLinkDetail.noData') }}
               </div>
               <div v-else class="h-56">
                 <VChart
@@ -817,7 +817,7 @@ watch([() => link.value, qrSelectedDomain], () => {
               v-else-if="refererDistribution.length === 0"
               class="flex h-56 items-center justify-center text-sm text-gray-400 dark:text-gray-500"
             >
-              No data for this period.
+              {{ t('shortLinkDetail.noData') }}
             </div>
             <div v-else class="h-64">
               <VChart
@@ -839,7 +839,7 @@ watch([() => link.value, qrSelectedDomain], () => {
               v-if="ipDistribution.length === 0"
               class="py-8 text-center text-sm text-gray-400 dark:text-gray-500"
             >
-              No data for this period.
+              {{ t('shortLinkDetail.noData') }}
             </div>
             <table v-else class="w-full text-left text-sm">
               <thead>
@@ -890,7 +890,7 @@ watch([() => link.value, qrSelectedDomain], () => {
               v-else-if="histories.length === 0"
               class="flex h-40 items-center justify-center text-sm text-gray-400 dark:text-gray-500"
             >
-              No access records for this period.
+              {{ t('shortLinkDetail.noRecords') }}
             </div>
             <template v-else>
               <div class="overflow-x-auto">
@@ -930,7 +930,7 @@ watch([() => link.value, qrSelectedDomain], () => {
                       <td
                         class="max-w-[200px] truncate px-4 py-2.5 text-gray-600 dark:text-gray-400"
                       >
-                        {{ h.referer ? extractRefererSource(h.referer) : 'Direct' }}
+                        {{ h.referer ? extractRefererSource(h.referer) : t('shortLinkDetail.direct') }}
                       </td>
                       <td
                         class="max-w-[300px] truncate px-4 py-2.5 text-xs text-gray-400 dark:text-gray-500"
@@ -943,7 +943,7 @@ watch([() => link.value, qrSelectedDomain], () => {
                 </table>
               </div>
               <div class="border-t px-4 py-3 text-xs text-gray-400 dark:text-gray-500">
-                {{ histories.length }} record{{ histories.length !== 1 ? 's' : '' }}
+                {{ t('shortLinkDetail.recordCount', { count: histories.length, suffix: histories.length !== 1 ? 's' : '' }) }}
               </div>
             </template>
           </div>

--- a/web-ui/src/pages/ShortLinkDetailPage.vue
+++ b/web-ui/src/pages/ShortLinkDetailPage.vue
@@ -234,7 +234,7 @@ const visitChartOption = computed(() => ({
     trigger: 'axis' as const,
     formatter: (params: { name: string; value: number }[]) => {
       const p = params[0]
-      return `${p.name}<br/><b>${p.value}</b> ${t('shortLinkDetail.visitsWithCount', { count: p.value })}`
+      return `${p.name}<br/><b>${p.value}</b> ${t('shortLinkDetail.visitsWithCount')}`
     },
   },
   grid: { top: 16, right: 16, bottom: 32, left: 48 },
@@ -313,7 +313,7 @@ const osChartOption = computed(() =>
   makePieOption(
     osDistribution.value,
     (name, value, total) =>
-      `${name}<br/><b>${value}</b> ${t('shortLinkDetail.visitsWithPercent', { count: value, percent: ((value / total) * 100).toFixed(1) })}`,
+      `${name}<br/><b>${value}</b> ${t('shortLinkDetail.visitsWithPercent', { percent: ((value / total) * 100).toFixed(1) })}`,
   ),
 )
 
@@ -321,7 +321,7 @@ const browserChartOption = computed(() =>
   makePieOption(
     browserDistribution.value,
     (name, value, total) =>
-      `${name}<br/><b>${value}</b> ${t('shortLinkDetail.visitsWithPercent', { count: value, percent: ((value / total) * 100).toFixed(1) })}`,
+      `${name}<br/><b>${value}</b> ${t('shortLinkDetail.visitsWithPercent', { percent: ((value / total) * 100).toFixed(1) })}`,
   ),
 )
 
@@ -329,7 +329,7 @@ const refererChartOption = computed(() =>
   makePieOption(
     refererDistribution.value,
     (name, value, total) =>
-      `${name}<br/><b>${value}</b> ${t('shortLinkDetail.visitsWithPercent', { count: value, percent: ((value / total) * 100).toFixed(1) })}`,
+      `${name}<br/><b>${value}</b> ${t('shortLinkDetail.visitsWithPercent', { percent: ((value / total) * 100).toFixed(1) })}`,
   ),
 )
 


### PR DESCRIPTION
## Summary
- Upgrade vue-i18n from `12.0.0-alpha.3` to stable `11.4.2`
- Fix all hardcoded Chinese/English text in `ShortLinkDetailPage.vue`, `AppTopBar.vue`, and `ShortcutHelp.vue` — replaced with `t()` calls
- Add language switcher dropdown to TopBar (Languages icon, EN/中文)
- Add `Accept-Language` header to all API requests via axios interceptor

## Test plan
- [ ] `npm run build` passes with no errors
- [ ] Switch to English: all page text, buttons, placeholders, tooltips are in English
- [ ] Switch to Chinese: all page text is in Chinese
- [ ] Language switch takes effect immediately and persists after refresh
- [ ] All API requests carry the current language's `Accept-Language` header
- [ ] Chart tooltips show localized "X visits" text in both languages

🤖 Generated with [Claude Code](https://claude.com/claude-code)