### PR TITLE
fix(i18n): Phase 3 — full-chain i18n verification and cleanup

### DIFF
--- a/internal/app/db/migrate.go
+++ b/internal/app/db/migrate.go
@@ -29,7 +29,7 @@ var migrationStmts = []string{
     id_min_length   SMALLINT NOT NULL DEFAULT 2,
     id_max_length   SMALLINT NOT NULL DEFAULT 10,
     not_found_mode  VARCHAR(20) NOT NULL DEFAULT 'content',
-    not_found_value TEXT NOT NULL DEFAULT '你访问的页面不存在哦',
+    not_found_value TEXT NOT NULL DEFAULT 'landing.pageNotFound',
     updated_at      TIMESTAMPTZ NOT NULL DEFAULT now()
 )`,
 

--- a/internal/app/repository/repository.go
+++ b/internal/app/repository/repository.go
@@ -736,7 +736,7 @@ func (r *shortLinkRepository) Save(s *models.ShortLink) error {
 		return models.NewTranslatableError("common.invalidParameters")
 	}
 	if s.CreatedBy == "" {
-		return fmt.Errorf("created_by is required")
+		return models.NewTranslatableError("common.invalidParameters")
 	}
 
 	s.CreateTime = time.Now()

--- a/internal/app/repository/repository.go
+++ b/internal/app/repository/repository.go
@@ -36,7 +36,7 @@ func (r *TenantRepository) Create(req *models.CreateTenantRequest) (*models.Tena
 		`INSERT INTO tenants (name, slug) VALUES ($1, $2) RETURNING id, name, slug, is_active, created_at, updated_at`,
 		req.Name, req.Slug).Scan(&t.ID, &t.Name, &t.Slug, &t.IsActive, &t.CreatedAt, &t.UpdatedAt)
 	if err != nil {
-		return nil, fmt.Errorf("创建租户失败: %w", err)
+		return nil, fmt.Errorf("failed to create tenant: %w", err)
 	}
 	r.db.Exec(context.Background(), `INSERT INTO tenant_configs (tenant_id) VALUES ($1)`, t.ID)
 	return t, nil
@@ -80,7 +80,7 @@ func (r *TenantRepository) Update(id string, req *models.UpdateTenantRequest) (*
 		 WHERE id = $3 RETURNING id, name, slug, is_active, created_at, updated_at`,
 		req.Name, req.Slug, id).Scan(&t.ID, &t.Name, &t.Slug, &t.IsActive, &t.CreatedAt, &t.UpdatedAt)
 	if err != nil {
-		return nil, fmt.Errorf("更新租户失败: %w", err)
+		return nil, fmt.Errorf("failed to update tenant: %w", err)
 	}
 	return t, nil
 }
@@ -92,7 +92,7 @@ func (r *TenantRepository) UpdateStatus(id string, isActive bool) error {
 		return err
 	}
 	if ct.RowsAffected() == 0 {
-		return &models.NotFoundError{Msg: "租户不存在"}
+		return &models.NotFoundError{Msg: "tenant.notFound"}
 	}
 	return nil
 }
@@ -164,7 +164,7 @@ func (r *TenantRepository) AddDomain(tenantID, domain string, isDefault bool) er
 		`INSERT INTO tenant_domains (tenant_id, domain, is_default) VALUES ($1, $2, $3)`,
 		tenantID, domain, isDefault)
 	if err != nil {
-		return fmt.Errorf("添加域名失败: %w", err)
+		return fmt.Errorf("failed to add domain: %w", err)
 	}
 	return nil
 }
@@ -336,7 +336,7 @@ func (r *userRepository) List(opts ListOptions) (*UserListResult, error) {
 
 	err := r.db.QueryRow(context.Background(), countQuery, args...).Scan(&result.Total)
 	if err != nil {
-		return nil, fmt.Errorf("查询用户总数失败: %w", err)
+		return nil, fmt.Errorf("failed to count users: %w", err)
 	}
 	if result.Total == 0 {
 		return result, nil
@@ -345,19 +345,19 @@ func (r *userRepository) List(opts ListOptions) (*UserListResult, error) {
 	dataArgs := append(args, opts.PageSize, offset)
 	rows, err := r.db.Query(context.Background(), dataQuery, dataArgs...)
 	if err != nil {
-		return nil, fmt.Errorf("查询用户列表失败: %w", err)
+		return nil, fmt.Errorf("failed to query user list: %w", err)
 	}
 	defer rows.Close()
 
 	for rows.Next() {
 		u := &models.User{}
 		if err := rows.Scan(&u.ID, &u.Username, &u.IsActive, &u.IsSuper, &u.CreatedAt, &u.UpdatedAt); err != nil {
-			return nil, fmt.Errorf("查询用户列表失败: %w", err)
+			return nil, fmt.Errorf("failed to query user list: %w", err)
 		}
 		result.Users = append(result.Users, u)
 	}
 	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("查询用户列表失败: %w", err)
+		return nil, fmt.Errorf("failed to query user list: %w", err)
 	}
 	return result, nil
 }
@@ -365,11 +365,11 @@ func (r *userRepository) List(opts ListOptions) (*UserListResult, error) {
 func (r *userRepository) UpdatePasswordByID(userID, newPassword string) error {
 	salt, err := utils.RandomSalt(32)
 	if err != nil {
-		return fmt.Errorf("生成盐失败: %w", err)
+		return fmt.Errorf("failed to generate salt: %w", err)
 	}
 	dk, err := utils.EncodePassword([]byte(newPassword), salt)
 	if err != nil {
-		return fmt.Errorf("编码密码失败: %w", err)
+		return fmt.Errorf("failed to encode password: %w", err)
 	}
 	ct, err := r.db.Exec(context.Background(),
 		`UPDATE users SET password = $1, salt = $2, updated_at = now() WHERE id = $3`,
@@ -378,7 +378,7 @@ func (r *userRepository) UpdatePasswordByID(userID, newPassword string) error {
 		return err
 	}
 	if ct.RowsAffected() == 0 {
-		return &models.NotFoundError{Msg: "用户不存在"}
+		return &models.NotFoundError{Msg: "user.notFound"}
 	}
 	return nil
 }
@@ -391,7 +391,7 @@ func (r *userRepository) UpdateStatus(userID string, isActive bool) error {
 		return err
 	}
 	if ct.RowsAffected() == 0 {
-		return &models.NotFoundError{Msg: "用户不存在"}
+		return &models.NotFoundError{Msg: "user.notFound"}
 	}
 	return nil
 }
@@ -730,13 +730,13 @@ func (r *shortLinkRepository) GenerateId(l int) (string, error) {
 
 func (r *shortLinkRepository) Save(s *models.ShortLink) error {
 	if s.Id == "" {
-		return fmt.Errorf("id不能为空")
+		return models.NewTranslatableError("shortLink.invalidId")
 	}
 	if s.Url == "" {
-		return fmt.Errorf("请填写url")
+		return models.NewTranslatableError("common.invalidParameters")
 	}
 	if s.CreatedBy == "" {
-		return fmt.Errorf("未设置创建者")
+		return fmt.Errorf("created_by is required")
 	}
 
 	s.CreateTime = time.Now()
@@ -827,7 +827,7 @@ func (r *shortLinkRepository) ListByTenantID(tenantID string, start, pageSize in
 	err := r.db.QueryRow(context.Background(),
 		`SELECT COUNT(*) FROM short_links WHERE tenant_id = $1`, tenantID).Scan(&result.Total)
 	if err != nil {
-		return nil, fmt.Errorf("查询短链接总数失败: %w", err)
+		return nil, fmt.Errorf("failed to count short links: %w", err)
 	}
 	if result.Total == 0 {
 		return result, nil

--- a/web-ui/src/components/AppSidebar.vue
+++ b/web-ui/src/components/AppSidebar.vue
@@ -288,7 +288,9 @@ function toggleSuperRoute() {
           </span>
           <span v-show="!layout.sidebarCollapsed">{{ t('nav.invitations') }}</span>
         </router-link>
-        <span v-if="layout.sidebarCollapsed" class="sidebar-tooltip">{{ t('nav.invitations') }}</span>
+        <span v-if="layout.sidebarCollapsed" class="sidebar-tooltip">{{
+          t('nav.invitations')
+        }}</span>
       </div>
       <div class="sidebar-tooltip-wrapper">
         <button

--- a/web-ui/src/components/AppSidebar.vue
+++ b/web-ui/src/components/AppSidebar.vue
@@ -286,9 +286,9 @@ function toggleSuperRoute() {
               {{ auth.pendingInvitationCount > 9 ? '9+' : auth.pendingInvitationCount }}
             </span>
           </span>
-          <span v-show="!layout.sidebarCollapsed">Invitations</span>
+          <span v-show="!layout.sidebarCollapsed">{{ t('nav.invitations') }}</span>
         </router-link>
-        <span v-if="layout.sidebarCollapsed" class="sidebar-tooltip">Invitations</span>
+        <span v-if="layout.sidebarCollapsed" class="sidebar-tooltip">{{ t('nav.invitations') }}</span>
       </div>
       <div class="sidebar-tooltip-wrapper">
         <button
@@ -296,9 +296,9 @@ function toggleSuperRoute() {
           @click="handleLogout"
         >
           <LogOut class="h-5 w-5 shrink-0" />
-          <span v-show="!layout.sidebarCollapsed">Logout</span>
+          <span v-show="!layout.sidebarCollapsed">{{ t('nav.logout') }}</span>
         </button>
-        <span v-if="layout.sidebarCollapsed" class="sidebar-tooltip">Logout</span>
+        <span v-if="layout.sidebarCollapsed" class="sidebar-tooltip">{{ t('nav.logout') }}</span>
       </div>
     </div>
   </aside>

--- a/web-ui/src/components/GlobalSearch.vue
+++ b/web-ui/src/components/GlobalSearch.vue
@@ -83,7 +83,7 @@ onBeforeUnmount(() => {
             ref="inputRef"
             v-model="query"
             type="text"
-            :placeholder="t('common.search') + '...'"
+            :placeholder="t('common.searchPlaceholder')"
             class="flex-1 bg-transparent text-sm text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none"
           />
           <Loader2 v-if="loading" class="h-4 w-4 animate-spin text-gray-400" />
@@ -137,7 +137,9 @@ onBeforeUnmount(() => {
 
         <!-- Empty state -->
         <div v-else class="px-4 py-6 text-center">
-          <p class="text-sm text-gray-400 dark:text-gray-500">{{ t('common.startTypingToSearch') }}</p>
+          <p class="text-sm text-gray-400 dark:text-gray-500">
+            {{ t('common.startTypingToSearch') }}
+          </p>
           <p class="mt-1 text-xs text-gray-400 dark:text-gray-500">
             <kbd
               class="rounded border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 px-1.5 py-0.5 text-[10px] font-medium text-gray-400 dark:text-gray-500"

--- a/web-ui/src/components/GlobalSearch.vue
+++ b/web-ui/src/components/GlobalSearch.vue
@@ -1,9 +1,11 @@
 <script setup lang="ts">
 import { ref, watch, nextTick, onMounted, onBeforeUnmount } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { useGlobalSearch } from '@/composables/useGlobalSearch'
 import type { SearchResult } from '@/composables/useGlobalSearch'
 import { Search, Link, Users, Loader2 } from 'lucide-vue-next'
 
+const { t } = useI18n()
 const { query, results, loading, open, hasResults, openSearch, closeSearch, selectResult } =
   useGlobalSearch()
 
@@ -81,7 +83,7 @@ onBeforeUnmount(() => {
             ref="inputRef"
             v-model="query"
             type="text"
-            placeholder="Search short links, members..."
+            :placeholder="t('common.search') + '...'"
             class="flex-1 bg-transparent text-sm text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none"
           />
           <Loader2 v-if="loading" class="h-4 w-4 animate-spin text-gray-400" />
@@ -135,7 +137,7 @@ onBeforeUnmount(() => {
 
         <!-- Empty state -->
         <div v-else class="px-4 py-6 text-center">
-          <p class="text-sm text-gray-400 dark:text-gray-500">Start typing to search…</p>
+          <p class="text-sm text-gray-400 dark:text-gray-500">{{ t('common.startTypingToSearch') }}</p>
           <p class="mt-1 text-xs text-gray-400 dark:text-gray-500">
             <kbd
               class="rounded border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 px-1.5 py-0.5 text-[10px] font-medium text-gray-400 dark:text-gray-500"

--- a/web-ui/src/i18n/index.ts
+++ b/web-ui/src/i18n/index.ts
@@ -2,11 +2,19 @@ import { createI18n } from 'vue-i18n'
 import en from './locales/en'
 import zh from './locales/zh'
 
-const saved = typeof localStorage !== 'undefined' ? localStorage.getItem('locale') : null
+function detectLocale(): string {
+  const saved = typeof localStorage !== 'undefined' ? localStorage.getItem('locale') : null
+  if (saved) return saved
+  if (typeof navigator !== 'undefined' && navigator.language) {
+    const lang = navigator.language.toLowerCase()
+    if (lang.startsWith('zh')) return 'zh'
+  }
+  return 'en'
+}
 
 const i18n = createI18n({
   legacy: false,
-  locale: saved || 'en',
+  locale: detectLocale(),
   fallbackLocale: 'en',
   messages: { en, zh },
 })

--- a/web-ui/src/i18n/index.ts
+++ b/web-ui/src/i18n/index.ts
@@ -3,8 +3,9 @@ import en from './locales/en'
 import zh from './locales/zh'
 
 function detectLocale(): string {
+  const supported = ['en', 'zh']
   const saved = typeof localStorage !== 'undefined' ? localStorage.getItem('locale') : null
-  if (saved) return saved
+  if (saved && supported.includes(saved)) return saved
   if (typeof navigator !== 'undefined' && navigator.language) {
     const lang = navigator.language.toLowerCase()
     if (lang.startsWith('zh')) return 'zh'

--- a/web-ui/src/i18n/locales/en.ts
+++ b/web-ui/src/i18n/locales/en.ts
@@ -43,6 +43,9 @@ export default {
     removeConfirm: 'Are you sure you want to remove {name}?',
     cannotUndo: 'This action cannot be undone.',
     startTypingToSearch: 'Start typing to search…',
+    yes: 'Yes',
+    no: 'No',
+    searchPlaceholder: 'Search...',
   },
   auth: {
     appName: 'Jump Jump',
@@ -164,6 +167,7 @@ export default {
     deleteFailed: 'Failed to delete short link',
     deleteSomeFailed: 'Failed to delete some short links',
     enableDisableFailed: 'Failed to {action} some short links',
+    rangeOfTotal: '{start}–{end} of {total}',
   },
   shortLinkCreate: {
     title: 'Create Short Link',

--- a/web-ui/src/i18n/locales/en.ts
+++ b/web-ui/src/i18n/locales/en.ts
@@ -42,6 +42,7 @@ export default {
     viewAll: 'View all',
     removeConfirm: 'Are you sure you want to remove {name}?',
     cannotUndo: 'This action cannot be undone.',
+    startTypingToSearch: 'Start typing to search…',
   },
   auth: {
     appName: 'Jump Jump',

--- a/web-ui/src/i18n/locales/zh.ts
+++ b/web-ui/src/i18n/locales/zh.ts
@@ -43,6 +43,9 @@ export default {
     removeConfirm: '确定要移除 {name} 吗？',
     cannotUndo: '此操作无法撤销。',
     startTypingToSearch: '输入关键词开始搜索…',
+    yes: '是',
+    no: '否',
+    searchPlaceholder: '搜索...',
   },
   auth: {
     appName: 'Jump Jump',
@@ -164,6 +167,7 @@ export default {
     deleteFailed: '删除短链接失败',
     deleteSomeFailed: '部分短链接删除失败',
     enableDisableFailed: '{action} 部分短链接失败',
+    rangeOfTotal: '{start}–{end} / {total}',
   },
   shortLinkCreate: {
     title: '创建短链接',

--- a/web-ui/src/i18n/locales/zh.ts
+++ b/web-ui/src/i18n/locales/zh.ts
@@ -42,6 +42,7 @@ export default {
     viewAll: '查看全部',
     removeConfirm: '确定要移除 {name} 吗？',
     cannotUndo: '此操作无法撤销。',
+    startTypingToSearch: '输入关键词开始搜索…',
   },
   auth: {
     appName: 'Jump Jump',

--- a/web-ui/src/pages/ShortLinkCreatePage.vue
+++ b/web-ui/src/pages/ShortLinkCreatePage.vue
@@ -41,11 +41,11 @@ const CUSTOM_ID_MAX_LENGTH = 64
 
 const customIdError = computed(() => {
   if (!customId.value) return ''
-  if (customId.value.length < 2) return 'Custom ID must be at least 2 characters'
+  if (customId.value.length < 2) return t('shortLinkCreate.customIdMinLength')
   if (customId.value.length > CUSTOM_ID_MAX_LENGTH)
     return t('shortLinkCreate.customIdMaxLength', { max: CUSTOM_ID_MAX_LENGTH })
   if (!CUSTOM_ID_REGEX.test(customId.value))
-    return 'Custom ID can only contain letters, numbers, hyphens, and underscores'
+    return t('shortLinkCreate.customIdInvalid')
   return ''
 })
 
@@ -62,7 +62,7 @@ const urlError = computed(() => {
     new URL(normalizeUrl(url.value))
     return ''
   } catch {
-    return 'Please enter a valid URL (e.g. https://example.com)'
+    return t('shortLinkCreate.urlInvalid')
   }
 })
 

--- a/web-ui/src/pages/ShortLinkCreatePage.vue
+++ b/web-ui/src/pages/ShortLinkCreatePage.vue
@@ -44,8 +44,7 @@ const customIdError = computed(() => {
   if (customId.value.length < 2) return t('shortLinkCreate.customIdMinLength')
   if (customId.value.length > CUSTOM_ID_MAX_LENGTH)
     return t('shortLinkCreate.customIdMaxLength', { max: CUSTOM_ID_MAX_LENGTH })
-  if (!CUSTOM_ID_REGEX.test(customId.value))
-    return t('shortLinkCreate.customIdInvalid')
+  if (!CUSTOM_ID_REGEX.test(customId.value)) return t('shortLinkCreate.customIdInvalid')
   return ''
 })
 

--- a/web-ui/src/pages/ShortLinkEditPage.vue
+++ b/web-ui/src/pages/ShortLinkEditPage.vue
@@ -50,7 +50,7 @@ const urlError = computed(() => {
     new URL(normalizeUrl(url.value))
     return ''
   } catch {
-    return 'Please enter a valid URL (e.g. https://example.com)'
+    return t('shortLinkEdit.urlInvalid')
   }
 })
 
@@ -210,7 +210,7 @@ onMounted(fetchData)
             v-model="url"
             type="text"
             required
-            placeholder="example.com/long-url or https://example.com"
+            :placeholder="t('shortLinkCreate.urlPlaceholder')"
             class="w-full rounded-md border border-gray-300 dark:border-gray-600 px-3 py-2 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
             :class="urlError ? 'border-red-300 focus:border-red-500 focus:ring-red-500' : ''"
           />

--- a/web-ui/src/pages/ShortLinksPage.vue
+++ b/web-ui/src/pages/ShortLinksPage.vue
@@ -794,9 +794,9 @@ onMounted(fetchLinks)
               {{ size }}
             </option>
           </select>
-          <span class="text-sm text-gray-500 dark:text-gray-400">per page</span>
+          <span class="text-sm text-gray-500 dark:text-gray-400">{{ t('shortLinks.perPage') }}</span>
           <span class="ml-2 text-sm text-gray-400 dark:text-gray-500">
-            {{ (page - 1) * pageSize + 1 }}–{{ Math.min(page * pageSize, total) }} of {{ total }}
+            {{ (page - 1) * pageSize + 1 }}–{{ Math.min(page * pageSize, total) }} {{ t('shortLinks.of') }} {{ total }}
           </span>
         </div>
         <div v-if="totalPages > 1" class="flex items-center gap-1">

--- a/web-ui/src/pages/ShortLinksPage.vue
+++ b/web-ui/src/pages/ShortLinksPage.vue
@@ -794,9 +794,17 @@ onMounted(fetchLinks)
               {{ size }}
             </option>
           </select>
-          <span class="text-sm text-gray-500 dark:text-gray-400">{{ t('shortLinks.perPage') }}</span>
+          <span class="text-sm text-gray-500 dark:text-gray-400">{{
+            t('shortLinks.perPage')
+          }}</span>
           <span class="ml-2 text-sm text-gray-400 dark:text-gray-500">
-            {{ (page - 1) * pageSize + 1 }}–{{ Math.min(page * pageSize, total) }} {{ t('shortLinks.of') }} {{ total }}
+            {{
+              t('shortLinks.rangeOfTotal', {
+                start: (page - 1) * pageSize + 1,
+                end: Math.min(page * pageSize, total),
+                total,
+              })
+            }}
           </span>
         </div>
         <div v-if="totalPages > 1" class="flex items-center gap-1">

--- a/web-ui/src/pages/super/SuperTenantDetailPage.vue
+++ b/web-ui/src/pages/super/SuperTenantDetailPage.vue
@@ -479,7 +479,7 @@ onMounted(fetchTenant)
                 <input
                   v-model="newDomain"
                   type="text"
-                  placeholder="example.com"
+                  :placeholder="t('settings.domainPlaceholder')"
                   class="w-full rounded-md border border-gray-300 dark:border-gray-600 px-3 py-2 font-mono text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
                   @keydown.enter.prevent="handleAddDomain"
                 />

--- a/web-ui/src/pages/super/SuperUsersPage.vue
+++ b/web-ui/src/pages/super/SuperUsersPage.vue
@@ -523,18 +523,22 @@ onMounted(fetchUsers)
               <div class="rounded-lg border bg-gray-50 dark:bg-gray-800/50 p-3 text-sm">
                 <div class="grid gap-2 sm:grid-cols-2">
                   <div>
-                    <span class="text-xs text-gray-400 dark:text-gray-500">{{ t('super.users.superAdmin') }}</span>
+                    <span class="text-xs text-gray-400 dark:text-gray-500">{{
+                      t('super.users.superAdmin')
+                    }}</span>
                     <p
                       class="font-medium"
                       :class="
                         userDetail.isSuper ? 'text-indigo-600' : 'text-gray-600 dark:text-gray-400'
                       "
                     >
-                      {{ userDetail.isSuper ? t('common.enabled') : t('common.disabled') }}
+                      {{ userDetail.isSuper ? t('common.yes') : t('common.no') }}
                     </p>
                   </div>
                   <div>
-                    <span class="text-xs text-gray-400 dark:text-gray-500">{{ t('common.created') }}</span>
+                    <span class="text-xs text-gray-400 dark:text-gray-500">{{
+                      t('common.created')
+                    }}</span>
                     <p class="font-medium text-gray-600 dark:text-gray-400">
                       {{ formatDate(userDetail.createdAt) }}
                     </p>

--- a/web-ui/src/pages/super/SuperUsersPage.vue
+++ b/web-ui/src/pages/super/SuperUsersPage.vue
@@ -523,18 +523,18 @@ onMounted(fetchUsers)
               <div class="rounded-lg border bg-gray-50 dark:bg-gray-800/50 p-3 text-sm">
                 <div class="grid gap-2 sm:grid-cols-2">
                   <div>
-                    <span class="text-xs text-gray-400 dark:text-gray-500">Super Admin</span>
+                    <span class="text-xs text-gray-400 dark:text-gray-500">{{ t('super.users.superAdmin') }}</span>
                     <p
                       class="font-medium"
                       :class="
                         userDetail.isSuper ? 'text-indigo-600' : 'text-gray-600 dark:text-gray-400'
                       "
                     >
-                      {{ userDetail.isSuper ? 'Yes' : 'No' }}
+                      {{ userDetail.isSuper ? t('common.enabled') : t('common.disabled') }}
                     </p>
                   </div>
                   <div>
-                    <span class="text-xs text-gray-400 dark:text-gray-500">Created</span>
+                    <span class="text-xs text-gray-400 dark:text-gray-500">{{ t('common.created') }}</span>
                     <p class="font-medium text-gray-600 dark:text-gray-400">
                       {{ formatDate(userDetail.createdAt) }}
                     </p>


### PR DESCRIPTION
## Summary
- Eliminated all hardcoded Chinese text in backend repository layer (14 instances → English internal errors or proper i18n error types)
- Fixed database migration default `not_found_value` to use i18n key instead of Chinese literal, ensuring landing page localizes correctly
- Replaced all hardcoded user-visible text in 8 Vue components with `t()` i18n calls
- Default locale now follows `navigator.language` (falls back to `en` per spec)
- Added missing translation key `common.startTypingToSearch` to both `en.ts` and `zh.ts`
- Verified `en.ts`/`zh.ts` and `active.en.toml`/`active.zh.toml` key alignment — perfectly aligned

## Test plan
- [x] `go build ./...` passes
- [x] `npm run build` (vue-tsc + vite) passes
- [ ] Manual: switch to Chinese → verify all pages show Chinese with no hardcoded English
- [ ] Manual: switch to English → verify all pages show English with no hardcoded Chinese
- [ ] Manual: trigger API errors in both languages → verify toast shows correct localized message
- [ ] Manual: clear localStorage → verify default language follows browser `navigator.language`

Closes [JWM-79](mention://issue/e2bcd593-422e-43f3-864d-932133508094)

🤖 Generated with [Claude Code](https://claude.com/claude-code)