### PR TITLE
feat(web-ui): add SaaS landing page

### DIFF
--- a/web-ui/src/i18n/locales/en.ts
+++ b/web-ui/src/i18n/locales/en.ts
@@ -589,6 +589,85 @@ export default {
     focusSearch: 'Focus search',
     closePanels: 'Close panels / Cancel',
   },
+  landing: {
+    nav: {
+      dashboard: 'Dashboard',
+      login: 'Log in',
+      getStarted: 'Get Started Free',
+    },
+    hero: {
+      title: 'Simple & Powerful URL Shortener',
+      subtitle:
+        'Create short links, track visits, manage team collaboration — all in one platform.',
+      cta: 'Get Started Free',
+      secondary: 'Learn More',
+    },
+    features: {
+      title: 'Everything You Need',
+      subtitle: 'Powerful features to manage and track your short links.',
+      items: [
+        {
+          icon: 'Link',
+          title: 'Short Link Management',
+          description: 'Create, edit, enable, or disable short links with one click.',
+        },
+        {
+          icon: 'BarChart3',
+          title: 'Visit Analytics',
+          description: 'Track PV/UV, visit trends, device and IP distribution.',
+        },
+        {
+          icon: 'QrCode',
+          title: 'QR Code Generation',
+          description: 'Auto-generate QR codes for every short link for easy sharing.',
+        },
+        {
+          icon: 'Globe',
+          title: 'Custom Domains',
+          description: 'Bind your own domain to build your brand identity.',
+        },
+        {
+          icon: 'Users',
+          title: 'Team Collaboration',
+          description: 'Multi-tenant architecture with role-based access control.',
+        },
+        {
+          icon: 'Code2',
+          title: 'Open Source',
+          description: 'MIT licensed. Self-host and keep full control of your data.',
+        },
+      ],
+    },
+    howItWorks: {
+      title: 'How It Works',
+      subtitle: 'Get started in three simple steps.',
+      steps: [
+        { number: '1', title: 'Create a Short Link', description: 'Paste your long URL and generate a short link instantly.' },
+        { number: '2', title: 'Share & Distribute', description: 'Share via link or QR code to reach your audience.' },
+        { number: '3', title: 'Track & Analyze', description: 'Monitor visits, sources, devices, and more in real time.' },
+      ],
+    },
+    openSource: {
+      title: 'Open Source & Free',
+      subtitle:
+        'Jump Jump is MIT licensed and fully open source. Self-host on your own infrastructure and keep complete control of your data.',
+      starGithub: 'Star on GitHub',
+      selfHost: 'Self-Host Now',
+      githubUrl: 'https://github.com/jwma/jump-jump',
+    },
+    cta: {
+      title: 'Ready to Get Started?',
+      subtitle: 'No credit card required. Start shortening URLs in seconds.',
+      button: 'Get Started Free',
+    },
+    footer: {
+      description: 'A simple and powerful URL shortener.',
+      github: 'GitHub',
+      githubUrl: 'https://github.com/jwma/jump-jump',
+      license: 'MIT License',
+      copyright: '© 2026 Jump Jump. MIT License.',
+    },
+  },
   qrCode: {
     title: 'QR Code',
     imageAlt: 'QR code for short link',

--- a/web-ui/src/i18n/locales/en.ts
+++ b/web-ui/src/i18n/locales/en.ts
@@ -604,58 +604,67 @@ export default {
     },
     features: {
       title: 'Everything You Need',
-      subtitle: 'Powerful features to manage and track your short links.',
+      subtitle: 'From creation to analytics — the full short link management workflow.',
       items: [
         {
           icon: 'Link',
           title: 'Short Link Management',
-          description: 'Create, edit, enable, or disable short links with one click.',
+          description:
+            'Custom IDs, batch enable/disable/delete, search by ID or URL — manage all your links with ease.',
         },
         {
           icon: 'BarChart3',
           title: 'Visit Analytics',
-          description: 'Track PV/UV, visit trends, device and IP distribution.',
+          description:
+            'Visit trends, OS & browser breakdowns, referer sources, top IPs — filter by custom date range.',
         },
         {
           icon: 'QrCode',
           title: 'QR Code Generation',
-          description: 'Auto-generate QR codes for every short link for easy sharing.',
+          description:
+            'Auto-generated QR codes for every short link, with PNG download for offline sharing.',
         },
         {
           icon: 'Globe',
           title: 'Custom Domains',
-          description: 'Bind your own domain to build your brand identity.',
+          description:
+            'Bind your own domains per tenant, configure multiple domains with a default — build your brand.',
         },
         {
           icon: 'Users',
-          title: 'Team Collaboration',
-          description: 'Multi-tenant architecture with role-based access control.',
+          title: 'Multi-Tenant Collaboration',
+          description:
+            'Create multiple tenants (teams), assign admin & member roles, and invite members to collaborate.',
         },
         {
           icon: 'Code2',
-          title: 'Open Source',
-          description: 'MIT licensed. Self-host and keep full control of your data.',
+          title: 'Open Source & Self-Hostable',
+          description:
+            'MIT licensed, fully open source. Self-host on your own server, configure ID length and 404 handling.',
         },
       ],
     },
     howItWorks: {
       title: 'How It Works',
-      subtitle: 'Get started in three simple steps.',
+      subtitle: 'Get started in three steps.',
       steps: [
         {
           number: '1',
           title: 'Create a Short Link',
-          description: 'Paste your long URL and generate a short link instantly.',
+          description:
+            'Paste your target URL, optionally set a custom ID and description, and generate instantly.',
         },
         {
           number: '2',
           title: 'Share & Distribute',
-          description: 'Share via link or QR code to reach your audience.',
+          description:
+            'Copy the short link or download the QR code — share via social media, print, or any channel.',
         },
         {
           number: '3',
-          title: 'Track & Analyze',
-          description: 'Monitor visits, sources, devices, and more in real time.',
+          title: 'View Visit Analytics',
+          description:
+            'Track visit trends, OS/browser breakdowns, referer sources, and top IPs with detailed charts.',
         },
       ],
     },

--- a/web-ui/src/i18n/locales/en.ts
+++ b/web-ui/src/i18n/locales/en.ts
@@ -642,9 +642,21 @@ export default {
       title: 'How It Works',
       subtitle: 'Get started in three simple steps.',
       steps: [
-        { number: '1', title: 'Create a Short Link', description: 'Paste your long URL and generate a short link instantly.' },
-        { number: '2', title: 'Share & Distribute', description: 'Share via link or QR code to reach your audience.' },
-        { number: '3', title: 'Track & Analyze', description: 'Monitor visits, sources, devices, and more in real time.' },
+        {
+          number: '1',
+          title: 'Create a Short Link',
+          description: 'Paste your long URL and generate a short link instantly.',
+        },
+        {
+          number: '2',
+          title: 'Share & Distribute',
+          description: 'Share via link or QR code to reach your audience.',
+        },
+        {
+          number: '3',
+          title: 'Track & Analyze',
+          description: 'Monitor visits, sources, devices, and more in real time.',
+        },
       ],
     },
     openSource: {

--- a/web-ui/src/i18n/locales/zh.ts
+++ b/web-ui/src/i18n/locales/zh.ts
@@ -587,6 +587,84 @@ export default {
     focusSearch: '聚焦搜索',
     closePanels: '关闭面板 / 取消',
   },
+  landing: {
+    nav: {
+      dashboard: '进入控制台',
+      login: '登录',
+      getStarted: '免费开始',
+    },
+    hero: {
+      title: '简单好用的短链接管理平台',
+      subtitle: '创建短链接、追踪访问数据、管理团队协作，一个平台搞定。',
+      cta: '免费开始使用',
+      secondary: '了解更多',
+    },
+    features: {
+      title: '核心功能',
+      subtitle: '强大功能，管理和追踪您的短链接。',
+      items: [
+        {
+          icon: 'Link',
+          title: '短链接管理',
+          description: '一键创建、编辑、启用或禁用短链接。',
+        },
+        {
+          icon: 'BarChart3',
+          title: '访问统计',
+          description: '追踪 PV/UV、访问趋势、设备和 IP 分布。',
+        },
+        {
+          icon: 'QrCode',
+          title: '二维码生成',
+          description: '每个短链接自动生成二维码，方便分享。',
+        },
+        {
+          icon: 'Globe',
+          title: '自定义域名',
+          description: '绑定自己的域名，打造品牌形象。',
+        },
+        {
+          icon: 'Users',
+          title: '团队协作',
+          description: '多租户架构，支持角色权限管理。',
+        },
+        {
+          icon: 'Code2',
+          title: '开源免费',
+          description: 'MIT 协议，可自行部署，数据自主掌控。',
+        },
+      ],
+    },
+    howItWorks: {
+      title: '使用流程',
+      subtitle: '三个简单步骤，快速上手。',
+      steps: [
+        { number: '1', title: '创建短链接', description: '粘贴长链接，一键生成短链接。' },
+        { number: '2', title: '分享传播', description: '通过链接或二维码分享给目标用户。' },
+        { number: '3', title: '追踪数据', description: '实时查看访问量、来源、设备等数据。' },
+      ],
+    },
+    openSource: {
+      title: '开源免费',
+      subtitle:
+        'Jump Jump 采用 MIT 协议，完全开源。可以在自己的服务器上部署，完全掌控您的数据。',
+      starGithub: 'Star on GitHub',
+      selfHost: '自行部署',
+      githubUrl: 'https://github.com/jwma/jump-jump',
+    },
+    cta: {
+      title: '准备好开始了吗？',
+      subtitle: '无需信用卡，几秒钟即可开始使用。',
+      button: '免费开始使用',
+    },
+    footer: {
+      description: '简单好用的短链接管理平台。',
+      github: 'GitHub',
+      githubUrl: 'https://github.com/jwma/jump-jump',
+      license: 'MIT License',
+      copyright: '© 2026 Jump Jump. MIT License.',
+    },
+  },
   qrCode: {
     title: '二维码',
     imageAlt: '短链接二维码',

--- a/web-ui/src/i18n/locales/zh.ts
+++ b/web-ui/src/i18n/locales/zh.ts
@@ -601,47 +601,61 @@ export default {
     },
     features: {
       title: '核心功能',
-      subtitle: '强大功能，管理和追踪您的短链接。',
+      subtitle: '从创建到分析，满足短链接管理全流程需求。',
       items: [
         {
           icon: 'Link',
           title: '短链接管理',
-          description: '一键创建、编辑、启用或禁用短链接。',
+          description:
+            '支持自定义 ID、批量启用/禁用/删除，按 ID 或 URL 搜索筛选，灵活管理所有链接。',
         },
         {
           icon: 'BarChart3',
-          title: '访问统计',
-          description: '追踪 PV/UV、访问趋势、设备和 IP 分布。',
+          title: '访问分析',
+          description: '追踪访问趋势、操作系统与浏览器分布、来源分析、热门 IP，支持按时间段查看。',
         },
         {
           icon: 'QrCode',
           title: '二维码生成',
-          description: '每个短链接自动生成二维码，方便分享。',
+          description: '每个短链接自动生成二维码，支持下载 PNG，方便线下分享和推广。',
         },
         {
           icon: 'Globe',
           title: '自定义域名',
-          description: '绑定自己的域名，打造品牌形象。',
+          description: '为租户绑定自有域名，支持多域名配置和默认域名设置，打造品牌形象。',
         },
         {
           icon: 'Users',
-          title: '团队协作',
-          description: '多租户架构，支持角色权限管理。',
+          title: '多租户协作',
+          description: '支持创建多个租户（团队），管理员与成员角色分离，邀请成员加入协作。',
         },
         {
           icon: 'Code2',
-          title: '开源免费',
-          description: 'MIT 协议，可自行部署，数据自主掌控。',
+          title: '开源可自部署',
+          description:
+            'MIT 协议开源，可自行部署到私有服务器，完全掌控数据，也可配置 ID 长度和 404 处理。',
         },
       ],
     },
     howItWorks: {
       title: '使用流程',
-      subtitle: '三个简单步骤，快速上手。',
+      subtitle: '三步即可开始使用。',
       steps: [
-        { number: '1', title: '创建短链接', description: '粘贴长链接，一键生成短链接。' },
-        { number: '2', title: '分享传播', description: '通过链接或二维码分享给目标用户。' },
-        { number: '3', title: '追踪数据', description: '实时查看访问量、来源、设备等数据。' },
+        {
+          number: '1',
+          title: '创建短链接',
+          description: '粘贴目标 URL，可选填自定义 ID 和描述，一键生成短链接和二维码。',
+        },
+        {
+          number: '2',
+          title: '分享与分发',
+          description: '复制短链接或下载二维码，通过社交媒体、线下物料等渠道分发。',
+        },
+        {
+          number: '3',
+          title: '查看访问分析',
+          description: '实时查看访问趋势、操作系统/浏览器分布、来源统计和热门 IP 等详细数据。',
+        },
       ],
     },
     openSource: {

--- a/web-ui/src/i18n/locales/zh.ts
+++ b/web-ui/src/i18n/locales/zh.ts
@@ -646,8 +646,7 @@ export default {
     },
     openSource: {
       title: '开源免费',
-      subtitle:
-        'Jump Jump 采用 MIT 协议，完全开源。可以在自己的服务器上部署，完全掌控您的数据。',
+      subtitle: 'Jump Jump 采用 MIT 协议，完全开源。可以在自己的服务器上部署，完全掌控您的数据。',
       starGithub: 'Star on GitHub',
       selfHost: '自行部署',
       githubUrl: 'https://github.com/jwma/jump-jump',

--- a/web-ui/src/layouts/LandingLayout.vue
+++ b/web-ui/src/layouts/LandingLayout.vue
@@ -2,21 +2,36 @@
 import { ref, onMounted, onUnmounted } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useAuthStore } from '@/stores/auth'
-import { Link2 } from 'lucide-vue-next'
+import { Link2, Languages } from 'lucide-vue-next'
 
-const { t } = useI18n()
+const { t, locale } = useI18n()
 const auth = useAuthStore()
 const scrolled = ref(false)
+const langDropdownOpen = ref(false)
+
+function setLocale(lang: string) {
+  locale.value = lang
+  localStorage.setItem('locale', lang)
+  langDropdownOpen.value = false
+}
 
 function onScroll() {
   scrolled.value = window.scrollY > 16
 }
 
+function closeDropdowns() {
+  langDropdownOpen.value = false
+}
+
 onMounted(() => {
   onScroll()
   window.addEventListener('scroll', onScroll, { passive: true })
+  document.addEventListener('click', closeDropdowns)
 })
-onUnmounted(() => window.removeEventListener('scroll', onScroll))
+onUnmounted(() => {
+  window.removeEventListener('scroll', onScroll)
+  document.removeEventListener('click', closeDropdowns)
+})
 </script>
 
 <template>
@@ -39,6 +54,37 @@ onUnmounted(() => window.removeEventListener('scroll', onScroll))
         </router-link>
 
         <div class="flex items-center gap-3">
+          <!-- Language switcher -->
+          <div class="relative">
+            <button
+              class="rounded p-1.5 text-gray-500 transition-colors hover:bg-gray-100 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-300"
+              :aria-label="t('topbar.switchLanguage')"
+              @click.stop="langDropdownOpen = !langDropdownOpen"
+            >
+              <Languages class="h-5 w-5" />
+            </button>
+            <div
+              v-if="langDropdownOpen"
+              class="absolute right-0 top-full z-50 mt-2 w-28 overflow-hidden rounded-xl border border-gray-200 bg-white shadow-lg dark:border-gray-700 dark:bg-gray-900"
+              @click.stop
+            >
+              <button
+                class="flex w-full items-center gap-2 px-3 py-2 text-sm text-gray-600 transition-colors hover:bg-gray-50 dark:text-gray-300 dark:hover:bg-gray-800"
+                :class="{ 'bg-gray-50 font-medium dark:bg-gray-800': locale === 'en' }"
+                @click="setLocale('en')"
+              >
+                English
+              </button>
+              <button
+                class="flex w-full items-center gap-2 px-3 py-2 text-sm text-gray-600 transition-colors hover:bg-gray-50 dark:text-gray-300 dark:hover:bg-gray-800"
+                :class="{ 'bg-gray-50 font-medium dark:bg-gray-800': locale === 'zh' }"
+                @click="setLocale('zh')"
+              >
+                中文
+              </button>
+            </div>
+          </div>
+
           <router-link
             v-if="auth.isLoggedIn"
             :to="{ name: 'dashboard' }"

--- a/web-ui/src/layouts/LandingLayout.vue
+++ b/web-ui/src/layouts/LandingLayout.vue
@@ -1,0 +1,114 @@
+<script setup lang="ts">
+import { ref, onMounted, onUnmounted } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useAuthStore } from '@/stores/auth'
+import { Link2 } from 'lucide-vue-next'
+
+const { t } = useI18n()
+const auth = useAuthStore()
+const scrolled = ref(false)
+
+function onScroll() {
+  scrolled.value = window.scrollY > 16
+}
+
+onMounted(() => window.addEventListener('scroll', onScroll, { passive: true }))
+onUnmounted(() => window.removeEventListener('scroll', onScroll))
+</script>
+
+<template>
+  <div class="min-h-screen bg-white dark:bg-gray-950">
+    <!-- Navbar -->
+    <nav
+      class="fixed inset-x-0 top-0 z-50 transition-all duration-300"
+      :class="
+        scrolled
+          ? 'border-b border-gray-200 dark:border-gray-800 bg-white/80 dark:bg-gray-950/80 backdrop-blur-md shadow-sm'
+          : 'bg-transparent'
+      "
+    >
+      <div class="mx-auto flex h-16 max-w-6xl items-center justify-between px-4 sm:px-6 lg:px-8">
+        <router-link :to="{ name: 'landing' }" class="flex items-center gap-2">
+          <div class="flex h-8 w-8 items-center justify-center rounded-lg bg-blue-600">
+            <Link2 class="h-5 w-5 text-white" />
+          </div>
+          <span class="text-lg font-bold text-gray-900 dark:text-white">Jump Jump</span>
+        </router-link>
+
+        <div class="flex items-center gap-3">
+          <router-link
+            v-if="auth.isLoggedIn"
+            :to="{ name: 'dashboard' }"
+            class="rounded-lg px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 transition-colors hover:bg-gray-100 dark:hover:bg-gray-800"
+          >
+            {{ t('landing.nav.dashboard') }}
+          </router-link>
+          <template v-else>
+            <router-link
+              :to="{ name: 'login' }"
+              class="rounded-lg px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 transition-colors hover:bg-gray-100 dark:hover:bg-gray-800"
+            >
+              {{ t('landing.nav.login') }}
+            </router-link>
+            <router-link
+              :to="{ name: 'login' }"
+              class="rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-blue-700"
+            >
+              {{ t('landing.nav.getStarted') }}
+            </router-link>
+          </template>
+        </div>
+      </div>
+    </nav>
+
+    <!-- Main -->
+    <main>
+      <router-view v-slot="{ Component }">
+        <transition name="fade" mode="out-in">
+          <component :is="Component" />
+        </transition>
+      </router-view>
+    </main>
+
+    <!-- Footer -->
+    <footer class="border-t border-gray-200 dark:border-gray-800 bg-gray-50 dark:bg-gray-900">
+      <div class="mx-auto max-w-6xl px-4 py-12 sm:px-6 lg:px-8">
+        <div class="flex flex-col items-center gap-4 sm:flex-row sm:justify-between">
+          <div class="flex items-center gap-2">
+            <div class="flex h-7 w-7 items-center justify-center rounded-md bg-blue-600">
+              <Link2 class="h-4 w-4 text-white" />
+            </div>
+            <span class="text-sm text-gray-600 dark:text-gray-400">
+              {{ t('landing.footer.description') }}
+            </span>
+          </div>
+          <div class="flex items-center gap-6">
+            <a
+              :href="t('landing.footer.githubUrl')"
+              target="_blank"
+              rel="noopener noreferrer"
+              class="text-sm text-gray-500 dark:text-gray-400 transition-colors hover:text-gray-700 dark:hover:text-gray-300"
+            >
+              {{ t('landing.footer.github') }}
+            </a>
+            <span class="text-sm text-gray-400 dark:text-gray-500">
+              {{ t('landing.footer.copyright') }}
+            </span>
+          </div>
+        </div>
+      </div>
+    </footer>
+  </div>
+</template>
+
+<style scoped>
+.fade-enter-active,
+.fade-leave-active {
+  transition: opacity 0.15s ease;
+}
+
+.fade-enter-from,
+.fade-leave-to {
+  opacity: 0;
+}
+</style>

--- a/web-ui/src/layouts/LandingLayout.vue
+++ b/web-ui/src/layouts/LandingLayout.vue
@@ -187,7 +187,7 @@ onUnmounted(() => {
           </span>
           <div class="flex items-center gap-1">
             <button
-              v-for="opt in (['light', 'dark', 'system'] as const)"
+              v-for="opt in ['light', 'dark', 'system'] as const"
               :key="opt"
               class="rounded-lg px-3 py-1.5 text-sm transition-colors"
               :class="

--- a/web-ui/src/layouts/LandingLayout.vue
+++ b/web-ui/src/layouts/LandingLayout.vue
@@ -12,7 +12,10 @@ function onScroll() {
   scrolled.value = window.scrollY > 16
 }
 
-onMounted(() => window.addEventListener('scroll', onScroll, { passive: true }))
+onMounted(() => {
+  onScroll()
+  window.addEventListener('scroll', onScroll, { passive: true })
+})
 onUnmounted(() => window.removeEventListener('scroll', onScroll))
 </script>
 

--- a/web-ui/src/layouts/LandingLayout.vue
+++ b/web-ui/src/layouts/LandingLayout.vue
@@ -2,17 +2,25 @@
 import { ref, onMounted, onUnmounted } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useAuthStore } from '@/stores/auth'
-import { Link2, Languages } from 'lucide-vue-next'
+import { useTheme } from '@/composables/useTheme'
+import { Link2, Languages, Sun, Moon, Monitor } from 'lucide-vue-next'
 
 const { t, locale } = useI18n()
 const auth = useAuthStore()
+const { theme } = useTheme()
 const scrolled = ref(false)
 const langDropdownOpen = ref(false)
+const themeDropdownOpen = ref(false)
 
 function setLocale(lang: string) {
   locale.value = lang
   localStorage.setItem('locale', lang)
   langDropdownOpen.value = false
+}
+
+function setTheme(value: 'light' | 'dark' | 'system') {
+  theme.value = value
+  themeDropdownOpen.value = false
 }
 
 function onScroll() {
@@ -21,6 +29,7 @@ function onScroll() {
 
 function closeDropdowns() {
   langDropdownOpen.value = false
+  themeDropdownOpen.value = false
 }
 
 onMounted(() => {
@@ -54,6 +63,46 @@ onUnmounted(() => {
         </router-link>
 
         <div class="flex items-center gap-3">
+          <!-- Theme toggle -->
+          <div class="relative">
+            <button
+              class="rounded p-1.5 text-gray-500 transition-colors hover:bg-gray-100 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-300"
+              :aria-label="t('topbar.toggleTheme')"
+              @click.stop="themeDropdownOpen = !themeDropdownOpen"
+            >
+              <Sun v-if="theme === 'light'" class="h-5 w-5" />
+              <Moon v-else-if="theme === 'dark'" class="h-5 w-5" />
+              <Monitor v-else class="h-5 w-5" />
+            </button>
+            <div
+              v-if="themeDropdownOpen"
+              class="absolute right-0 top-full z-50 mt-2 w-36 overflow-hidden rounded-xl border border-gray-200 bg-white shadow-lg dark:border-gray-700 dark:bg-gray-900"
+              @click.stop
+            >
+              <button
+                class="flex w-full items-center gap-2 px-3 py-2 text-sm text-gray-600 transition-colors hover:bg-gray-50 dark:text-gray-300 dark:hover:bg-gray-800"
+                :class="{ 'bg-gray-50 font-medium dark:bg-gray-800': theme === 'light' }"
+                @click="setTheme('light')"
+              >
+                <Sun class="h-4 w-4" /> {{ t('topbar.light') }}
+              </button>
+              <button
+                class="flex w-full items-center gap-2 px-3 py-2 text-sm text-gray-600 transition-colors hover:bg-gray-50 dark:text-gray-300 dark:hover:bg-gray-800"
+                :class="{ 'bg-gray-50 font-medium dark:bg-gray-800': theme === 'dark' }"
+                @click="setTheme('dark')"
+              >
+                <Moon class="h-4 w-4" /> {{ t('topbar.dark') }}
+              </button>
+              <button
+                class="flex w-full items-center gap-2 px-3 py-2 text-sm text-gray-600 transition-colors hover:bg-gray-50 dark:text-gray-300 dark:hover:bg-gray-800"
+                :class="{ 'bg-gray-50 font-medium dark:bg-gray-800': theme === 'system' }"
+                @click="setTheme('system')"
+              >
+                <Monitor class="h-4 w-4" /> {{ t('topbar.system') }}
+              </button>
+            </div>
+          </div>
+
           <!-- Language switcher -->
           <div class="relative">
             <button

--- a/web-ui/src/layouts/LandingLayout.vue
+++ b/web-ui/src/layouts/LandingLayout.vue
@@ -3,7 +3,7 @@ import { ref, onMounted, onUnmounted } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useAuthStore } from '@/stores/auth'
 import { useTheme } from '@/composables/useTheme'
-import { Link2, Languages, Sun, Moon, Monitor } from 'lucide-vue-next'
+import { Link2, Languages, Sun, Moon, Monitor, Menu, X } from 'lucide-vue-next'
 
 const { t, locale } = useI18n()
 const auth = useAuthStore()
@@ -11,6 +11,7 @@ const { theme } = useTheme()
 const scrolled = ref(false)
 const langDropdownOpen = ref(false)
 const themeDropdownOpen = ref(false)
+const mobileMenuOpen = ref(false)
 
 function setLocale(lang: string) {
   locale.value = lang
@@ -30,6 +31,11 @@ function onScroll() {
 function closeDropdowns() {
   langDropdownOpen.value = false
   themeDropdownOpen.value = false
+}
+
+function closeMobileMenu() {
+  mobileMenuOpen.value = false
+  closeDropdowns()
 }
 
 onMounted(() => {
@@ -62,7 +68,8 @@ onUnmounted(() => {
           <span class="text-lg font-bold text-gray-900 dark:text-white">Jump Jump</span>
         </router-link>
 
-        <div class="flex items-center gap-3">
+        <!-- Desktop nav (sm+) -->
+        <div class="hidden items-center gap-3 sm:flex">
           <!-- Theme toggle -->
           <div class="relative">
             <button
@@ -151,6 +158,93 @@ onUnmounted(() => {
             <router-link
               :to="{ name: 'login' }"
               class="cursor-pointer rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-blue-700"
+            >
+              {{ t('landing.nav.getStarted') }}
+            </router-link>
+          </template>
+        </div>
+
+        <!-- Mobile hamburger button -->
+        <button
+          class="rounded-lg p-2 text-gray-500 transition-colors hover:bg-gray-100 dark:text-gray-400 dark:hover:bg-gray-800 sm:hidden"
+          :aria-label="mobileMenuOpen ? 'Close menu' : 'Open menu'"
+          @click="mobileMenuOpen = !mobileMenuOpen"
+        >
+          <X v-if="mobileMenuOpen" class="h-6 w-6" />
+          <Menu v-else class="h-6 w-6" />
+        </button>
+      </div>
+
+      <!-- Mobile menu dropdown -->
+      <div
+        v-if="mobileMenuOpen"
+        class="border-t border-gray-200 bg-white px-4 pb-4 pt-2 dark:border-gray-800 dark:bg-gray-950 sm:hidden"
+      >
+        <div class="flex items-center justify-between">
+          <!-- Theme toggle -->
+          <span class="text-sm text-gray-500 dark:text-gray-400">
+            {{ t('topbar.toggleTheme') }}
+          </span>
+          <div class="flex items-center gap-1">
+            <button
+              v-for="opt in (['light', 'dark', 'system'] as const)"
+              :key="opt"
+              class="rounded-lg px-3 py-1.5 text-sm transition-colors"
+              :class="
+                theme === opt
+                  ? 'bg-blue-50 font-medium text-blue-600 dark:bg-blue-950 dark:text-blue-400'
+                  : 'text-gray-500 hover:bg-gray-100 dark:text-gray-400 dark:hover:bg-gray-800'
+              "
+              @click="setTheme(opt)"
+            >
+              {{ t(`topbar.${opt}`) }}
+            </button>
+          </div>
+        </div>
+
+        <div class="mt-3 flex items-center justify-between">
+          <!-- Language switcher -->
+          <span class="text-sm text-gray-500 dark:text-gray-400">
+            {{ t('topbar.switchLanguage') }}
+          </span>
+          <div class="flex items-center gap-1">
+            <button
+              v-for="loc in ['en', 'zh']"
+              :key="loc"
+              class="rounded-lg px-3 py-1.5 text-sm transition-colors"
+              :class="
+                locale === loc
+                  ? 'bg-blue-50 font-medium text-blue-600 dark:bg-blue-950 dark:text-blue-400'
+                  : 'text-gray-500 hover:bg-gray-100 dark:text-gray-400 dark:hover:bg-gray-800'
+              "
+              @click="setLocale(loc)"
+            >
+              {{ loc === 'en' ? 'English' : '中文' }}
+            </button>
+          </div>
+        </div>
+
+        <div class="mt-4 flex flex-col gap-2 border-t border-gray-200 pt-4 dark:border-gray-800">
+          <router-link
+            v-if="auth.isLoggedIn"
+            :to="{ name: 'dashboard' }"
+            class="cursor-pointer rounded-lg px-4 py-2.5 text-center text-sm font-medium text-gray-700 transition-colors hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-800"
+            @click="closeMobileMenu"
+          >
+            {{ t('landing.nav.dashboard') }}
+          </router-link>
+          <template v-else>
+            <router-link
+              :to="{ name: 'login' }"
+              class="cursor-pointer rounded-lg px-4 py-2.5 text-center text-sm font-medium text-blue-600 transition-colors hover:bg-blue-50 dark:text-blue-400 dark:hover:bg-blue-950"
+              @click="closeMobileMenu"
+            >
+              {{ t('landing.nav.login') }}
+            </router-link>
+            <router-link
+              :to="{ name: 'login' }"
+              class="cursor-pointer rounded-lg bg-blue-600 px-4 py-2.5 text-center text-sm font-medium text-white transition-colors hover:bg-blue-700"
+              @click="closeMobileMenu"
             >
               {{ t('landing.nav.getStarted') }}
             </router-link>

--- a/web-ui/src/layouts/LandingLayout.vue
+++ b/web-ui/src/layouts/LandingLayout.vue
@@ -20,15 +20,15 @@ onUnmounted(() => window.removeEventListener('scroll', onScroll))
   <div class="min-h-screen bg-white dark:bg-gray-950">
     <!-- Navbar -->
     <nav
-      class="fixed inset-x-0 top-0 z-50 transition-all duration-300"
+      class="fixed inset-x-0 top-0 z-50 transition-all duration-200"
       :class="
         scrolled
-          ? 'border-b border-gray-200 dark:border-gray-800 bg-white/80 dark:bg-gray-950/80 backdrop-blur-md shadow-sm'
+          ? 'border-b border-gray-200 bg-white/80 shadow-sm backdrop-blur-md dark:border-gray-800 dark:bg-gray-950/80'
           : 'bg-transparent'
       "
     >
       <div class="mx-auto flex h-16 max-w-6xl items-center justify-between px-4 sm:px-6 lg:px-8">
-        <router-link :to="{ name: 'landing' }" class="flex items-center gap-2">
+        <router-link :to="{ name: 'landing' }" class="flex cursor-pointer items-center gap-2">
           <div class="flex h-8 w-8 items-center justify-center rounded-lg bg-blue-600">
             <Link2 class="h-5 w-5 text-white" />
           </div>
@@ -39,20 +39,20 @@ onUnmounted(() => window.removeEventListener('scroll', onScroll))
           <router-link
             v-if="auth.isLoggedIn"
             :to="{ name: 'dashboard' }"
-            class="rounded-lg px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 transition-colors hover:bg-gray-100 dark:hover:bg-gray-800"
+            class="cursor-pointer rounded-lg px-4 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-800"
           >
             {{ t('landing.nav.dashboard') }}
           </router-link>
           <template v-else>
             <router-link
               :to="{ name: 'login' }"
-              class="rounded-lg px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 transition-colors hover:bg-gray-100 dark:hover:bg-gray-800"
+              class="cursor-pointer rounded-lg px-4 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-800"
             >
               {{ t('landing.nav.login') }}
             </router-link>
             <router-link
               :to="{ name: 'login' }"
-              class="rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-blue-700"
+              class="cursor-pointer rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-blue-700"
             >
               {{ t('landing.nav.getStarted') }}
             </router-link>
@@ -71,7 +71,7 @@ onUnmounted(() => window.removeEventListener('scroll', onScroll))
     </main>
 
     <!-- Footer -->
-    <footer class="border-t border-gray-200 dark:border-gray-800 bg-gray-50 dark:bg-gray-900">
+    <footer class="border-t border-gray-200 bg-gray-50 dark:border-gray-800 dark:bg-gray-900">
       <div class="mx-auto max-w-6xl px-4 py-12 sm:px-6 lg:px-8">
         <div class="flex flex-col items-center gap-4 sm:flex-row sm:justify-between">
           <div class="flex items-center gap-2">
@@ -87,7 +87,7 @@ onUnmounted(() => window.removeEventListener('scroll', onScroll))
               :href="t('landing.footer.githubUrl')"
               target="_blank"
               rel="noopener noreferrer"
-              class="text-sm text-gray-500 dark:text-gray-400 transition-colors hover:text-gray-700 dark:hover:text-gray-300"
+              class="cursor-pointer text-sm text-gray-500 transition-colors hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-300"
             >
               {{ t('landing.footer.github') }}
             </a>

--- a/web-ui/src/pages/LandingPage.vue
+++ b/web-ui/src/pages/LandingPage.vue
@@ -13,7 +13,7 @@ import {
   Server,
 } from 'lucide-vue-next'
 
-const { t } = useI18n()
+const { t, tm } = useI18n()
 const router = useRouter()
 
 const iconMap: Record<string, typeof Link> = { Link, BarChart3, QrCode, Globe, Users, Code2 }
@@ -82,7 +82,7 @@ function goToLogin() {
 
         <div class="mt-16 grid gap-8 sm:grid-cols-2 lg:grid-cols-3">
           <div
-            v-for="(item, i) in t('landing.features.items') as unknown as any[]"
+            v-for="(item, i) in tm('landing.features.items') as unknown as any[]"
             :key="i"
             class="group rounded-2xl border border-gray-200 bg-white p-6 transition-colors hover:border-blue-300 hover:shadow-lg hover:shadow-blue-500/5 dark:border-gray-800 dark:bg-gray-900 dark:hover:border-blue-700"
           >
@@ -118,7 +118,7 @@ function goToLogin() {
 
         <div class="mt-16 grid gap-8 sm:grid-cols-3">
           <div
-            v-for="(step, i) in t('landing.howItWorks.steps') as unknown as any[]"
+            v-for="(step, i) in tm('landing.howItWorks.steps') as unknown as any[]"
             :key="i"
             class="relative text-center"
           >

--- a/web-ui/src/pages/LandingPage.vue
+++ b/web-ui/src/pages/LandingPage.vue
@@ -1,0 +1,189 @@
+<script setup lang="ts">
+import { useI18n } from 'vue-i18n'
+import { useRouter } from 'vue-router'
+import {
+  Link,
+  BarChart3,
+  QrCode,
+  Globe,
+  Users,
+  Code2,
+  ArrowRight,
+  Github,
+  Server,
+} from 'lucide-vue-next'
+
+const { t } = useI18n()
+const router = useRouter()
+
+const iconMap: Record<string, typeof Link> = { Link, BarChart3, QrCode, Globe, Users, Code2 }
+
+function scrollToFeatures() {
+  document.getElementById('features')?.scrollIntoView({ behavior: 'smooth' })
+}
+
+function goToLogin() {
+  router.push({ name: 'login' })
+}
+</script>
+
+<template>
+  <div>
+    <!-- Hero -->
+    <section class="relative overflow-hidden pt-32 pb-20 sm:pt-40 sm:pb-28">
+      <div
+        class="pointer-events-none absolute inset-0 bg-gradient-to-br from-blue-50 via-white to-indigo-50 dark:from-blue-950/30 dark:via-gray-950 dark:to-indigo-950/20"
+      />
+      <div class="pointer-events-none absolute top-20 left-1/4 h-72 w-72 rounded-full bg-blue-400/10 blur-3xl dark:bg-blue-500/5" />
+      <div class="pointer-events-none absolute bottom-10 right-1/4 h-72 w-72 rounded-full bg-indigo-400/10 blur-3xl dark:bg-indigo-500/5" />
+
+      <div class="relative mx-auto max-w-6xl px-4 text-center sm:px-6 lg:px-8">
+        <h1
+          class="text-4xl font-extrabold tracking-tight text-gray-900 dark:text-white sm:text-5xl lg:text-6xl"
+        >
+          {{ t('landing.hero.title') }}
+        </h1>
+        <p class="mx-auto mt-6 max-w-2xl text-lg text-gray-600 dark:text-gray-400">
+          {{ t('landing.hero.subtitle') }}
+        </p>
+        <div class="mt-10 flex flex-col items-center justify-center gap-4 sm:flex-row">
+          <button
+            class="inline-flex items-center gap-2 rounded-xl bg-blue-600 px-8 py-3.5 text-base font-semibold text-white shadow-lg shadow-blue-500/25 transition-all hover:bg-blue-700 hover:shadow-blue-500/40"
+            @click="goToLogin"
+          >
+            {{ t('landing.hero.cta') }}
+            <ArrowRight class="h-5 w-5" />
+          </button>
+          <button
+            class="inline-flex items-center gap-2 rounded-xl border border-gray-300 px-8 py-3.5 text-base font-semibold text-gray-700 dark:border-gray-700 dark:text-gray-300 transition-colors hover:bg-gray-50 dark:hover:bg-gray-800"
+            @click="scrollToFeatures"
+          >
+            {{ t('landing.hero.secondary') }}
+          </button>
+        </div>
+      </div>
+    </section>
+
+    <!-- Features -->
+    <section id="features" class="py-20 sm:py-28">
+      <div class="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
+        <div class="text-center">
+          <h2 class="text-3xl font-bold text-gray-900 dark:text-white sm:text-4xl">
+            {{ t('landing.features.title') }}
+          </h2>
+          <p class="mt-4 text-lg text-gray-600 dark:text-gray-400">
+            {{ t('landing.features.subtitle') }}
+          </p>
+        </div>
+
+        <div class="mt-16 grid gap-8 sm:grid-cols-2 lg:grid-cols-3">
+          <div
+            v-for="(item, i) in (t('landing.features.items') as unknown as any[])"
+            :key="i"
+            class="group rounded-2xl border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900 p-6 transition-all hover:border-blue-300 hover:shadow-lg hover:shadow-blue-500/5 dark:hover:border-blue-700"
+          >
+            <div
+              class="mb-4 flex h-12 w-12 items-center justify-center rounded-xl bg-blue-50 text-blue-600 transition-colors group-hover:bg-blue-100 dark:bg-blue-950 dark:text-blue-400 dark:group-hover:bg-blue-900"
+            >
+              <component :is="iconMap[item.icon]" class="h-6 w-6" />
+            </div>
+            <h3 class="text-lg font-semibold text-gray-900 dark:text-white">{{ item.title }}</h3>
+            <p class="mt-2 text-sm leading-relaxed text-gray-600 dark:text-gray-400">
+              {{ item.description }}
+            </p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- How It Works -->
+    <section class="border-y border-gray-200 bg-gray-50 py-20 dark:border-gray-800 dark:bg-gray-900 sm:py-28">
+      <div class="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
+        <div class="text-center">
+          <h2 class="text-3xl font-bold text-gray-900 dark:text-white sm:text-4xl">
+            {{ t('landing.howItWorks.title') }}
+          </h2>
+          <p class="mt-4 text-lg text-gray-600 dark:text-gray-400">
+            {{ t('landing.howItWorks.subtitle') }}
+          </p>
+        </div>
+
+        <div class="mt-16 grid gap-8 sm:grid-cols-3">
+          <div
+            v-for="(step, i) in (t('landing.howItWorks.steps') as unknown as any[])"
+            :key="i"
+            class="relative text-center"
+          >
+            <div
+              class="mx-auto mb-6 flex h-14 w-14 items-center justify-center rounded-2xl bg-blue-600 text-xl font-bold text-white"
+            >
+              {{ step.number }}
+            </div>
+            <h3 class="text-lg font-semibold text-gray-900 dark:text-white">{{ step.title }}</h3>
+            <p class="mt-2 text-sm leading-relaxed text-gray-600 dark:text-gray-400">
+              {{ step.description }}
+            </p>
+            <!-- Connector line (hidden on last item and mobile) -->
+            <div
+              v-if="i < 2"
+              class="absolute top-7 left-[calc(50%+40px)] hidden h-px w-[calc(100%-80px)] bg-gray-300 dark:bg-gray-700 sm:block"
+            />
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- Open Source -->
+    <section class="py-20 sm:py-28">
+      <div class="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
+        <div class="rounded-3xl border border-gray-200 dark:border-gray-800 bg-gradient-to-br from-blue-50 to-indigo-50 p-10 text-center dark:from-blue-950/30 dark:to-indigo-950/20 sm:p-16">
+          <h2 class="text-3xl font-bold text-gray-900 dark:text-white sm:text-4xl">
+            {{ t('landing.openSource.title') }}
+          </h2>
+          <p class="mx-auto mt-4 max-w-2xl text-lg text-gray-600 dark:text-gray-400">
+            {{ t('landing.openSource.subtitle') }}
+          </p>
+          <div class="mt-8 flex flex-col items-center justify-center gap-4 sm:flex-row">
+            <a
+              :href="t('landing.openSource.githubUrl')"
+              target="_blank"
+              rel="noopener noreferrer"
+              class="inline-flex items-center gap-2 rounded-xl border border-gray-300 bg-white px-6 py-3 text-sm font-semibold text-gray-700 shadow-sm transition-colors hover:bg-gray-50 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-300 dark:hover:bg-gray-800"
+            >
+              <Github class="h-5 w-5" />
+              {{ t('landing.openSource.starGithub') }}
+            </a>
+            <a
+              :href="t('landing.openSource.githubUrl')"
+              target="_blank"
+              rel="noopener noreferrer"
+              class="inline-flex items-center gap-2 rounded-xl border border-gray-300 bg-white px-6 py-3 text-sm font-semibold text-gray-700 shadow-sm transition-colors hover:bg-gray-50 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-300 dark:hover:bg-gray-800"
+            >
+              <Server class="h-5 w-5" />
+              {{ t('landing.openSource.selfHost') }}
+            </a>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- CTA -->
+    <section class="border-t border-gray-200 bg-gray-50 py-20 dark:border-gray-800 dark:bg-gray-900 sm:py-28">
+      <div class="mx-auto max-w-6xl px-4 text-center sm:px-6 lg:px-8">
+        <h2 class="text-3xl font-bold text-gray-900 dark:text-white sm:text-4xl">
+          {{ t('landing.cta.title') }}
+        </h2>
+        <p class="mx-auto mt-4 max-w-xl text-lg text-gray-600 dark:text-gray-400">
+          {{ t('landing.cta.subtitle') }}
+        </p>
+        <button
+          class="mt-8 inline-flex items-center gap-2 rounded-xl bg-blue-600 px-8 py-3.5 text-base font-semibold text-white shadow-lg shadow-blue-500/25 transition-all hover:bg-blue-700 hover:shadow-blue-500/40"
+          @click="goToLogin"
+        >
+          {{ t('landing.cta.button') }}
+          <ArrowRight class="h-5 w-5" />
+        </button>
+      </div>
+    </section>
+  </div>
+</template>

--- a/web-ui/src/pages/LandingPage.vue
+++ b/web-ui/src/pages/LandingPage.vue
@@ -34,8 +34,12 @@ function goToLogin() {
       <div
         class="pointer-events-none absolute inset-0 bg-gradient-to-br from-blue-50 via-white to-indigo-50 dark:from-blue-950/30 dark:via-gray-950 dark:to-indigo-950/20"
       />
-      <div class="pointer-events-none absolute top-20 left-1/4 h-72 w-72 rounded-full bg-blue-400/10 blur-3xl dark:bg-blue-500/5" />
-      <div class="pointer-events-none absolute bottom-10 right-1/4 h-72 w-72 rounded-full bg-indigo-400/10 blur-3xl dark:bg-indigo-500/5" />
+      <div
+        class="pointer-events-none absolute top-20 left-1/4 h-72 w-72 rounded-full bg-blue-400/10 blur-3xl dark:bg-blue-500/5"
+      />
+      <div
+        class="pointer-events-none absolute bottom-10 right-1/4 h-72 w-72 rounded-full bg-indigo-400/10 blur-3xl dark:bg-indigo-500/5"
+      />
 
       <div class="relative mx-auto max-w-6xl px-4 text-center sm:px-6 lg:px-8">
         <h1
@@ -48,14 +52,14 @@ function goToLogin() {
         </p>
         <div class="mt-10 flex flex-col items-center justify-center gap-4 sm:flex-row">
           <button
-            class="inline-flex items-center gap-2 rounded-xl bg-blue-600 px-8 py-3.5 text-base font-semibold text-white shadow-lg shadow-blue-500/25 transition-all hover:bg-blue-700 hover:shadow-blue-500/40"
+            class="inline-flex cursor-pointer items-center gap-2 rounded-xl bg-blue-600 px-8 py-3.5 text-base font-semibold text-white shadow-lg shadow-blue-500/25 transition-colors hover:bg-blue-700 hover:shadow-blue-500/40"
             @click="goToLogin"
           >
             {{ t('landing.hero.cta') }}
             <ArrowRight class="h-5 w-5" />
           </button>
           <button
-            class="inline-flex items-center gap-2 rounded-xl border border-gray-300 px-8 py-3.5 text-base font-semibold text-gray-700 dark:border-gray-700 dark:text-gray-300 transition-colors hover:bg-gray-50 dark:hover:bg-gray-800"
+            class="inline-flex cursor-pointer items-center gap-2 rounded-xl border border-gray-300 px-8 py-3.5 text-base font-semibold text-gray-700 transition-colors hover:bg-gray-50 dark:border-gray-700 dark:text-gray-300 dark:hover:bg-gray-800"
             @click="scrollToFeatures"
           >
             {{ t('landing.hero.secondary') }}
@@ -78,16 +82,18 @@ function goToLogin() {
 
         <div class="mt-16 grid gap-8 sm:grid-cols-2 lg:grid-cols-3">
           <div
-            v-for="(item, i) in (t('landing.features.items') as unknown as any[])"
+            v-for="(item, i) in t('landing.features.items') as unknown as any[]"
             :key="i"
-            class="group rounded-2xl border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900 p-6 transition-all hover:border-blue-300 hover:shadow-lg hover:shadow-blue-500/5 dark:hover:border-blue-700"
+            class="group rounded-2xl border border-gray-200 bg-white p-6 transition-colors hover:border-blue-300 hover:shadow-lg hover:shadow-blue-500/5 dark:border-gray-800 dark:bg-gray-900 dark:hover:border-blue-700"
           >
             <div
               class="mb-4 flex h-12 w-12 items-center justify-center rounded-xl bg-blue-50 text-blue-600 transition-colors group-hover:bg-blue-100 dark:bg-blue-950 dark:text-blue-400 dark:group-hover:bg-blue-900"
             >
               <component :is="iconMap[item.icon]" class="h-6 w-6" />
             </div>
-            <h3 class="text-lg font-semibold text-gray-900 dark:text-white">{{ item.title }}</h3>
+            <h3 class="text-lg font-semibold text-gray-900 dark:text-white">
+              {{ item.title }}
+            </h3>
             <p class="mt-2 text-sm leading-relaxed text-gray-600 dark:text-gray-400">
               {{ item.description }}
             </p>
@@ -97,7 +103,9 @@ function goToLogin() {
     </section>
 
     <!-- How It Works -->
-    <section class="border-y border-gray-200 bg-gray-50 py-20 dark:border-gray-800 dark:bg-gray-900 sm:py-28">
+    <section
+      class="border-y border-gray-200 bg-gray-50 py-20 dark:border-gray-800 dark:bg-gray-900 sm:py-28"
+    >
       <div class="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
         <div class="text-center">
           <h2 class="text-3xl font-bold text-gray-900 dark:text-white sm:text-4xl">
@@ -110,7 +118,7 @@ function goToLogin() {
 
         <div class="mt-16 grid gap-8 sm:grid-cols-3">
           <div
-            v-for="(step, i) in (t('landing.howItWorks.steps') as unknown as any[])"
+            v-for="(step, i) in t('landing.howItWorks.steps') as unknown as any[]"
             :key="i"
             class="relative text-center"
           >
@@ -119,7 +127,9 @@ function goToLogin() {
             >
               {{ step.number }}
             </div>
-            <h3 class="text-lg font-semibold text-gray-900 dark:text-white">{{ step.title }}</h3>
+            <h3 class="text-lg font-semibold text-gray-900 dark:text-white">
+              {{ step.title }}
+            </h3>
             <p class="mt-2 text-sm leading-relaxed text-gray-600 dark:text-gray-400">
               {{ step.description }}
             </p>
@@ -136,7 +146,9 @@ function goToLogin() {
     <!-- Open Source -->
     <section class="py-20 sm:py-28">
       <div class="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
-        <div class="rounded-3xl border border-gray-200 dark:border-gray-800 bg-gradient-to-br from-blue-50 to-indigo-50 p-10 text-center dark:from-blue-950/30 dark:to-indigo-950/20 sm:p-16">
+        <div
+          class="rounded-3xl border border-gray-200 bg-gradient-to-br from-blue-50 to-indigo-50 p-10 text-center dark:border-gray-800 dark:from-blue-950/30 dark:to-indigo-950/20 sm:p-16"
+        >
           <h2 class="text-3xl font-bold text-gray-900 dark:text-white sm:text-4xl">
             {{ t('landing.openSource.title') }}
           </h2>
@@ -148,7 +160,7 @@ function goToLogin() {
               :href="t('landing.openSource.githubUrl')"
               target="_blank"
               rel="noopener noreferrer"
-              class="inline-flex items-center gap-2 rounded-xl border border-gray-300 bg-white px-6 py-3 text-sm font-semibold text-gray-700 shadow-sm transition-colors hover:bg-gray-50 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-300 dark:hover:bg-gray-800"
+              class="inline-flex cursor-pointer items-center gap-2 rounded-xl border border-gray-300 bg-white px-6 py-3 text-sm font-semibold text-gray-700 shadow-sm transition-colors hover:bg-gray-50 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-300 dark:hover:bg-gray-800"
             >
               <Github class="h-5 w-5" />
               {{ t('landing.openSource.starGithub') }}
@@ -157,7 +169,7 @@ function goToLogin() {
               :href="t('landing.openSource.githubUrl')"
               target="_blank"
               rel="noopener noreferrer"
-              class="inline-flex items-center gap-2 rounded-xl border border-gray-300 bg-white px-6 py-3 text-sm font-semibold text-gray-700 shadow-sm transition-colors hover:bg-gray-50 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-300 dark:hover:bg-gray-800"
+              class="inline-flex cursor-pointer items-center gap-2 rounded-xl border border-gray-300 bg-white px-6 py-3 text-sm font-semibold text-gray-700 shadow-sm transition-colors hover:bg-gray-50 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-300 dark:hover:bg-gray-800"
             >
               <Server class="h-5 w-5" />
               {{ t('landing.openSource.selfHost') }}
@@ -168,7 +180,9 @@ function goToLogin() {
     </section>
 
     <!-- CTA -->
-    <section class="border-t border-gray-200 bg-gray-50 py-20 dark:border-gray-800 dark:bg-gray-900 sm:py-28">
+    <section
+      class="border-t border-gray-200 bg-gray-50 py-20 dark:border-gray-800 dark:bg-gray-900 sm:py-28"
+    >
       <div class="mx-auto max-w-6xl px-4 text-center sm:px-6 lg:px-8">
         <h2 class="text-3xl font-bold text-gray-900 dark:text-white sm:text-4xl">
           {{ t('landing.cta.title') }}
@@ -177,7 +191,7 @@ function goToLogin() {
           {{ t('landing.cta.subtitle') }}
         </p>
         <button
-          class="mt-8 inline-flex items-center gap-2 rounded-xl bg-blue-600 px-8 py-3.5 text-base font-semibold text-white shadow-lg shadow-blue-500/25 transition-all hover:bg-blue-700 hover:shadow-blue-500/40"
+          class="mt-8 inline-flex cursor-pointer items-center gap-2 rounded-xl bg-blue-600 px-8 py-3.5 text-base font-semibold text-white shadow-lg shadow-blue-500/25 transition-colors hover:bg-blue-700 hover:shadow-blue-500/40"
           @click="goToLogin"
         >
           {{ t('landing.cta.button') }}

--- a/web-ui/src/pages/SelectTenantPage.vue
+++ b/web-ui/src/pages/SelectTenantPage.vue
@@ -51,13 +51,13 @@ onMounted(async () => {
 
 function selectTenant(tenantId: string) {
   auth.selectTenant(tenantId)
-  const redirect = (route.query.redirect as string) || '/'
+  const redirect = (route.query.redirect as string) || '/dashboard'
   router.push(redirect)
 }
 
 function enterSuperAdmin() {
   auth.clearTenant()
-  const redirect = (route.query.redirect as string) || '/'
+  const redirect = (route.query.redirect as string) || '/dashboard'
   router.push(redirect)
 }
 

--- a/web-ui/src/router/index.ts
+++ b/web-ui/src/router/index.ts
@@ -54,6 +54,19 @@ const router = createRouter({
     },
     {
       path: '/',
+      component: () => import('@/layouts/LandingLayout.vue'),
+      meta: { requiresAuth: false },
+      children: [
+        {
+          path: '',
+          name: 'landing',
+          component: () => import('@/pages/LandingPage.vue'),
+          meta: { requiresAuth: false },
+        },
+      ],
+    },
+    {
+      path: '/dashboard',
       component: () => import('@/layouts/DefaultLayout.vue'),
       meta: { requiresAuth: true },
       children: [


### PR DESCRIPTION
## Summary

- Add public-facing SaaS landing page at `/` route for Jump Jump
- Move dashboard from `/` to `/dashboard` (requires auth)
- New `LandingLayout.vue` with transparent navbar that gains glassmorphism effect on scroll
- New `LandingPage.vue` with Hero, Features, How It Works, Open Source, CTA sections, and Footer
- Full i18n support (English & Chinese)
- Dark mode support throughout
- Responsive design (mobile-first, supports sm/md/lg breakpoints)
- Uses Lucide icons (no images/screenshots per spec)

## Files Changed

| File | Change |
|------|--------|
| `src/layouts/LandingLayout.vue` | New — landing page layout with navbar and footer |
| `src/pages/LandingPage.vue` | New — landing page with all content sections |
| `src/router/index.ts` | Modified — `/` is public landing, dashboard at `/dashboard` |
| `src/i18n/locales/en.ts` | Modified — added landing page English translations |
| `src/i18n/locales/zh.ts` | Modified — added landing page Chinese translations |

## Test Plan

- [ ] Access `/` shows landing page regardless of auth state
- [ ] Landing page navbar shows "Dashboard" link when logged in, "Log in" + "Get Started" when not
- [ ] All text supports en/zh (i18n)
- [ ] Dark mode renders correctly
- [ ] Mobile responsive layout works
- [ ] No images/screenshots included
- [ ] "Get Started" / CTA buttons navigate to `/login`
- [ ] "Dashboard" button navigates to `/dashboard`
- [ ] Existing dashboard routes work under `/dashboard`

Closes #103

🤖 Generated with [Claude Code](https://claude.com/claude-code)